### PR TITLE
Added automatic log exporter file creation

### DIFF
--- a/sucuri.php
+++ b/sucuri.php
@@ -13172,11 +13172,12 @@ function sucuriscan_settings_selfhosting_monitor($nonce)
                 SucuriScanInterface::info($message);
             } elseif (strpos($monitor_fpath, $_SERVER['DOCUMENT_ROOT']) !== false) {
                 SucuriScanInterface::error('File should not be publicly accessible.');
-            } elseif (!file_exists($monitor_fpath)) {
-                SucuriScanInterface::error('File path does not exists.');
-            } elseif (!is_writable($monitor_fpath)) {
-                SucuriScanInterface::error('File path is not writable.');
+            } elseif (file_exists($monitor_fpath)) {
+                SucuriScanInterface::error('File already exists and will not be overwritten.');
+            } elseif (!is_writable(dirname($monitor_fpath))) {
+                SucuriScanInterface::error('File parent directory is not writable.');
             } else {
+                @file_put_contents($monitor_fpath, '', LOCK_EX);
                 $message = 'Log exporter file path was set correctly.';
 
                 SucuriScanEvent::report_info_event($message);


### PR DESCRIPTION
The log exporter allows admin users to force the plugin to send a copy of the data generated when WordPress triggers an event that is being monitored by the plugin, the file path should not be publicly accessible, and the file must not exists to prevent unwanted modifications to the current files in the server as a malicious admin could reset the content of arbitrary files at will. This pull-request adds validations to check if the specified file path exists, if the parent directory is writable, and then creates the file per user requests and set two entries in the options table to track the status of the tool _(enabled or disabled)_.