### PR TITLE
Fixed issues with URLs and broken API requests

### DIFF
--- a/sucuri.php
+++ b/sucuri.php
@@ -5290,7 +5290,12 @@ class SucuriScanAPI extends SucuriScanOption
         }
 
         // Special response for connection timeouts.
-        if ($enqueue && @preg_match('/time(d\s)?out/', $raw_message)) {
+        if ($enqueue === true
+            && array_key_exists('params', $response)
+            && array_key_exists('m', $response['params'])
+            && array_key_exists('time', $response['params'])
+            && @preg_match('/time(d\s)?out/', $raw_message)
+        ) {
             $action_message = ''; /* Empty the error message. */
             $cache = new SucuriScanCache('auditqueue');
             $cache_key = md5($response['params']['time']);
@@ -9707,7 +9712,8 @@ function sucuriscan_auditlogs()
         $iterator_start = ($page_number - 1) * $max_per_page;
         $iterator_end = $total_items;
 
-        if ($audit_logs->total_entries >= $max_per_page
+        if (property_exists($audit_logs, 'total_entries')
+            && $audit_logs->total_entries >= $max_per_page
             && SucuriScanOption::is_disabled(':audit_report')
         ) {
             $params['AuditLogs.EnableAuditReportVisibility'] = 'visible';

--- a/sucuri.php
+++ b/sucuri.php
@@ -562,23 +562,23 @@ class SucuriScan
                 $upload_dir = wp_upload_dir();
 
                 if (isset($upload_dir['basedir'])) {
-                    $uploads_path = rtrim($upload_dir['basedir'], '/');
+                    $uploads_path = rtrim($upload_dir['basedir'], DIRECTORY_SEPARATOR);
                 }
             }
 
             if ($uploads_path === false) {
                 if (defined('WP_CONTENT_DIR')) {
-                    $uploads_path = WP_CONTENT_DIR . '/uploads';
+                    $uploads_path = implode(DIRECTORY_SEPARATOR, array(WP_CONTENT_DIR, 'uploads'));
                 } else {
-                    $uploads_path = ABSPATH . '/wp-content/uploads';
+                    $uploads_path = implode(DIRECTORY_SEPARATOR, array(ABSPATH, 'wp-content', 'uploads'));
                 }
             }
 
-            $datastore = $uploads_path . '/' . $default_dir;
+            $datastore = $uploads_path . DIRECTORY_SEPARATOR . $default_dir;
             SucuriScanOption::update_option(':datastore_path', $datastore);
         }
 
-        return $datastore . '/' . $path;
+        return $datastore . DIRECTORY_SEPARATOR . $path;
     }
 
     /**

--- a/sucuri.php
+++ b/sucuri.php
@@ -6514,6 +6514,14 @@ class SucuriScanTemplate extends SucuriScanRequest
             $url_path .= '_' . strtolower($page);
         }
 
+        if (SucuriScan::is_multisite()) {
+            $url_path = str_replace(
+                'wp-admin/network/admin-ajax.php',
+                'wp-admin/admin-ajax.php',
+                $url_path
+            );
+        }
+
         return $url_path;
     }
 

--- a/sucuri.php
+++ b/sucuri.php
@@ -3793,6 +3793,7 @@ class SucuriScanEvent extends SucuriScan
             } elseif ($event == 'scan_checksums') {
                 $event = 'core_integrity_checks';
                 $email_params['Force'] = true;
+                $email_params['ForceHTML'] = true;
             }
 
             $title = str_replace('_', "\x20", $event);
@@ -6206,9 +6207,10 @@ class SucuriScanMail extends SucuriScanOption
         }
 
         // Check whether the email notifications will be sent in HTML or Plain/Text.
-        if (self::prettify_mails()) {
+        if (self::prettify_mails() || (isset($data_set['ForceHTML']) && $data_set['ForceHTML'])) {
             $headers = array( 'content-type: text/html' );
             $data_set['PrettifyType'] = 'pretty';
+            unset($data_set['ForceHTML']);
         } else {
             $message = strip_tags($message);
         }
@@ -13235,10 +13237,6 @@ function sucuriscan_settings_alert_events($nonce)
         // Update the notification settings.
         if (SucuriScanRequest::post(':save_alert_events') !== false) {
             $ucounter = 0;
-
-            if (SucuriScanRequest::post(':notify_scan_checksums') == 1) {
-                $_POST['sucuriscan_prettify_mails'] = '1';
-            }
 
             foreach ($sucuriscan_notify_options as $alert_type => $alert_label) {
                 $option_value = SucuriScanRequest::post($alert_type, '(1|0)');


### PR DESCRIPTION
When a HTTP request fails the plugin tries to store the data for future retries, unfortunately the current code had a dependency in one of the data entries containing the timestamp of the initial execution used to keep the audit logs in chronological order, some API endpoints do not provide this data and were making the code throw some warnings; [this commit](https://github.com/Sucuri/sucuri-wordpress-plugin/commit/c8eda72) fixes the issue.

The directory separator for the main folder where the plugin stores the security logs and some temporary data was using a hardcoded version of the forward slash character which was not compatible with the Windows server configuration; [this commit](https://github.com/Sucuri/sucuri-wordpress-plugin/commit/44a8720) fixes that issue.

The URL for the Ajax requests that returns the content of the table in the core integrity tool was pointing to the wrong directory when the website was configured as a network, this issue was also affecting the error logs scanner and probably other Ajax requests making use of the _"admin-ajax.php"_ file.

The email notifications for the core integrity checks requires to be in HTML for design purposes, the current code forces the setting to prettify the email notifications using HTML code when the core integrity alerts were enabled, the new code changes this and uses a new approach which is to force the setting temporarily to leave the other email notifications in plain text if the admin desires. 