### PR TITLE
Fixed get_option method when the value is in the database

### DIFF
--- a/sucuri.php
+++ b/sucuri.php
@@ -3145,8 +3145,10 @@ class SucuriScanOption extends SucuriScanRequest
             $value = get_option($option);
 
             if ($value !== false) {
-                delete_option($option);
-                self::update_option($option, $value);
+                if (strpos($option, 'sucuriscan_') === 0) {
+                    delete_option($option);
+                    self::update_option($option, $value);
+                }
 
                 return $value;
             }


### PR DESCRIPTION
When the plugin is retrieving one or more settings it tries to read them from a plain text file located _(by default)_ at _"/wp-content/uploads/sucuri/sucuri-settings.php"_, this is a JSON encoded file with an array where the keys are the names of the options. If the option is found in the file then it immediately returns its value, otherwise it continues with the search in the database, if it finds it then deletes the option from there and writes its value in the JSON file for future usage. If at the end the option is not found in the JSON file nor in the database then it returns a default value hardcoded in the code.

This pull-request fixes a bug that was going to cause a deletion of the non-plugin options if they were not in the JSON file, the deletion was intended to be executed only with the options associated with the plugin which are all prefixed with _"sucuriscan_"_.