### PR TITLE
Fixed minor issues with the data storage getter

### DIFF
--- a/sucuri.php
+++ b/sucuri.php
@@ -2536,7 +2536,7 @@ class SucuriScanCache extends SucuriScan
     {
         if (!is_null($this->datastore)) {
             $folder_path = $this->datastore_folder_path();
-            $file_path = $folder_path . 'sucuri-' . $this->datastore . '.php';
+            $file_path = $folder_path . '/sucuri-' . $this->datastore . '.php';
 
             // Create the datastore parent directory.
             if (!file_exists($folder_path)) {
@@ -3266,10 +3266,11 @@ class SucuriScanOption extends SucuriScanRequest
 
         // Merge with the default options to ensure full cleanup.
         $default = self::get_default_option_names();
-        $options = array_merge($options, $default);
 
-        foreach ($options as $option) {
-            self::delete_option($option);
+        foreach ($default as $option) {
+            if (is_string($option)) {
+                self::delete_option($option);
+            }
         }
     }
 

--- a/sucuri.php
+++ b/sucuri.php
@@ -75,7 +75,7 @@ define('SUCURISCAN_PLUGIN_FILE', 'sucuri.php');
 /**
  * The name of the folder where the plugin's files will be located.
  */
-define('SUCURISCAN_PLUGIN_FOLDER', 'sucuri-scanner');
+define('SUCURISCAN_PLUGIN_FOLDER', basename(__DIR__));
 
 /**
  * The fullpath where the plugin's files will be located.


### PR DESCRIPTION
There is a button in the general settings page that allows users to reset the configuration of the plugin, this basically deletes all the options prefixed with _"sucuriscan"_ from the database and the JSON file. However, since the data returned from the database is actually an object and the one returned from the plain text file is a string the function that is supposed to delete the data gets confused and throws a warning about the different data types. This PR fixes this minor issue.

Additionally, in the cache library used to read and parse the content of the security logs was missing a forward slash to separate the directory path where the user decided to store the logs and the file name for the cache.