### PR TITLE
Backward compatibility for HTTP requests and granular unit-tests

### DIFF
--- a/sucuri.php
+++ b/sucuri.php
@@ -7776,6 +7776,15 @@ class SucuriScanInterface
 
         // Display the HTML notice to the current user.
         if ($display_notice === true && !empty($message)) {
+            if (defined('SUCURISCAN_THROW_EXCEPTIONS')
+                && SUCURISCAN_THROW_EXCEPTIONS === true
+            ) {
+                $number = (string) crc32($type);
+                $code = (int) substr($number, 0, 3);
+
+                throw new Exception($message, $code);
+            }
+
             echo SucuriScanTemplate::getSection(
                 'notification-admin',
                 array(

--- a/sucuri.php
+++ b/sucuri.php
@@ -5550,6 +5550,12 @@ class SucuriScanAPI extends SucuriScanOption
                 . 'd to reduce the noise during the execution of the HTTP req'
                 . 'uests.';
             }
+
+            // Check if the MX records as missing for API registration.
+            if (strpos($raw, 'Invalid email') !== false) {
+                $msg = 'Email has an invalid format, or the host '
+                . 'associated to the email has no MX records.';
+            }
         }
 
         if (!empty($msg) && $enqueue) {
@@ -5578,7 +5584,8 @@ class SucuriScanAPI extends SucuriScanOption
         ), false);
 
         if (self::handleResponse($response)) {
-            self::setPluginKey($response['body']->output->api_key);
+            self::setPluginKey($response['output']['api_key']);
+
             SucuriScanEvent::schedule_task();
             SucuriScanEvent::notify_event('plugin_change', 'Site registered and API key generated');
             SucuriScanInterface::info('The API key for your site was successfully generated and saved.');

--- a/sucuri.php
+++ b/sucuri.php
@@ -7767,6 +7767,11 @@ class SucuriScanInterface
             ) {
                 $number = (string) crc32($type);
                 $code = (int) substr($number, 0, 3);
+                $message = str_replace(
+                    '<b>Sucuri:</b>',
+                    ($type === 'error' ? 'Error:' : 'Info:'),
+                    $message
+                );
 
                 throw new Exception($message, $code);
             }


### PR DESCRIPTION
Before the release of WordPress 4.6 the core developers decided to introduce a new object _"WP_HTTP_Requests_Response"_ to hold the relevant information after a HTTP request. There are multiple blocks of code in the plugin that rely in the format old object, this pull-request drops the dependencies of the built-in functions _"wp_remote_get"_ and _"wp_remote_head"_ to be able to control the backward compatibility with old WordPress installations.

Additionally, to simplify the automated tests we have modified the admin notices to throw a generic exception when a constant _"SUCURISCAN_THROW_EXCEPTION"_ is defined as a boolean _True_, with this we can expand the coverage of the unit-tests to all the functions that were generating admin notices with errors and info messages after the modifications of the settings or the execution of specific actions.

Tested against: WordPress 4.1.0, 4.4.4, 4.5.3, and _(soon to be released)_ 4.6.beta