### PR TITLE
Fixed connection timeout for the SiteCheck web scans

### DIFF
--- a/sucuri.php
+++ b/sucuri.php
@@ -5223,6 +5223,10 @@ class SucuriScanAPI extends SucuriScanOption
             $url = self::apiUrlProtocol($url);
             $timeout = self::requestTimeout();
 
+            if (is_array($args) && isset($args['timeout'])) {
+                $timeout = $args['timeout'];
+            }
+
             // Add random request parameter to avoid request reset.
             if (!empty($params) && !array_key_exists('time', $params)) {
                 $params['time'] = time();


### PR DESCRIPTION
Most of the HTTP requests executed through out the entire code base to communicate with the Sucuri API service and the 3rd-party services provided by WordPress have a low connection timeout, the plugin assumes that the service is not available after five seconds that can be configured by the user from the settings page. However, the connection with the SiteCheck API service takes around ~20 secs when a fresh scan is requested, because of this the plugin needs to force a different connection timeout of around ~30 secs that can also be configured from the settings page.