### PR TITLE
Added function to rescue HTTP requests using sockets

### DIFF
--- a/inc/tpl/bsidebar.html.tpl
+++ b/inc/tpl/bsidebar.html.tpl
@@ -16,13 +16,12 @@
 
         <div class="sucuriscan-ad-footer">
             <ul>
-                <li>Sucuri CloudProxy Firewall</li>
-                <li class="featured">Stopping 33M+ attacks a month</li>
-                <li>Web Application Firewall Protection</li>
+                <li>Sucuri Firewall</li>
+                <li>Protection . Performance . Security</li>
+                <li class="featured">Cloud-based WAF + DDoS Protection</li>
                 <li>Virtual Website Patching</li>
-                <li>Cloud Intrusion Prevention System</li>
-                <li>High Security Website Monitoring</li>
-                <li>Malicious Traffic Filtering</li>
+                <li>Anycast CDN + Website Accelerator</li>
+                <li>All in one security for your site.</li>
             </ul>
         </div>
     </div>
@@ -52,8 +51,6 @@
             <img src="%%SUCURI.SucuriURL%%/inc/images/sucuri-website.png" alt="Sucuri Website" />
         </a>
     </div>
-
-    <iframe src="https://www.youtube-nocookie.com/embed/EVa9FY3nKuQ" height="250" class="sucuriscan-scanner-video" allowfullscreen></iframe>
 
     <a href="https://wordpress.org/support/plugin/sucuri-scanner" target="_blank"
     class="button button-primary sucuriscan-supportbtn">Visit Support Forum</a>

--- a/inc/tpl/settings-apiservice-handler.html.tpl
+++ b/inc/tpl/settings-apiservice-handler.html.tpl
@@ -1,0 +1,25 @@
+
+<div class="postbox">
+    <h3>API Request Handler</h3>
+
+    <div class="inside">
+        <p>
+            Select which interface will be used to send the HTTP requests to the
+            external API services, the plugin will try to use the best option
+            automatically and rescue the requests when any of the options is not
+            available. Be sure to understand the purpose of this option before
+            you try to modify it.
+        </p>
+
+        <form action="%%SUCURI.URL.Settings%%#apiservice" method="post">
+            <input type="hidden" name="sucuriscan_page_nonce" value="%%SUCURI.PageNonce%%" />
+            <span class="sucuriscan-input-group">
+                <label>HTTP Request Handler:</label>
+                <select name="sucuriscan_api_handler">
+                    %%%SUCURI.ApiHandlerOptions%%%
+                </select>
+            </span>
+            <button type="submit" class="button-primary">Proceed</button>
+        </form>
+    </div>
+</div>

--- a/inc/tpl/settings-apiservice.html.tpl
+++ b/inc/tpl/settings-apiservice.html.tpl
@@ -6,6 +6,8 @@
 
     %%%SUCURI.SettingsSection.ApiSSL%%%
 
+    %%%SUCURI.SettingsSection.ApiHandler%%%
+
     %%%SUCURI.SettingsSection.ApiTimeout%%%
 
     %%%SUCURI.SettingsSection.ApiProtocol%%%

--- a/uninstall.php
+++ b/uninstall.php
@@ -20,6 +20,7 @@ $sucuriscan_option_names = array(
     'account',
     'addr_header',
     'ads_visibility',
+    'api_handler',
     'api_key',
     'api_protocol',
     'api_service',


### PR DESCRIPTION
This pull-request adds a secondary mechanism to rescue the HTTP requests sent by the plugin to external API services using raw sockets via the built-in PHP function _"fsockopen"_. This is necessary for websites without _"libcurl"_.