### PR TITLE
Fixed Curl redirection follower with safe_mode enabled

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: dd@sucuri.net
 Donate Link: https://sucuri.net/
 Tags: malware, security, firewall, scan, spam, virus, sucuri, protection,WordPress Security, Login Security,Security Auditing,File Integrity,htaccess,phishing,backdoors,SQL Injection, RFI, LFI, XSS, CSRF, website firewall, Website Security, Performance Optimization, Zero Day, Software Vulnerability, Exploits, Hacks, Attackers, Bad Actors, Reverse Proxy, Two Factor Security, Two Factor Authentication, Security Logs, HeatBleed Vulnerability, Website Protection, Bash Vulnerability, RevSlider Vulnerability, MailPoet Vulnerability, Malware Prevention, Website Firewall, Website AntiVirus, Security Response, Security Detection, Security Prevention
 Requires at least:3.2
-Stable tag: 1.7.17
-Tested up to: 4.4.1
+Stable tag: 1.7.19
+Tested up to: 4.5.3
 
 The Sucuri WordPress Security plugin is a security toolset for security integrity monitoring, malware detection and security hardening.
 
@@ -353,6 +353,31 @@ service from the WordPress dashboard.
 
 
 == Changelog ==
+
+= 1.7.19 =
+* Added function to rescue HTTP requests using sockets
+* Fixed mishandled JSON data in audit logs Ajax request
+* Modified list of CloudProxy features and promo video
+
+= 1.7.18 =
+* Added options library using external file instead of the database
+* Modified API calls using custom HTTP request using Curl
+* Fixed core files marked as broken in a Windows server
+* Fixed pagination links in last and failed logins page
+* Fixed password with ampersands in email notification
+* Fixed whitelist hardening using the authz_core module
+* Removed unnecessary emails to reduce spam
+* Added constant to stop execution of admin init hooks
+* Added explanation for invalid emails and no MX records
+* Added link to open the form to insert the API key manually
+* Added more options in the IP discoverer setting
+* Added option to configure malware scanner timeout
+* Added option to configure the API communication protocol
+* Added option to reset the malware scanner cache
+* Added scheduled task and email alert for available updates
+* Added tool to block user accounts from attempting a login
+* Added tool to debug HTTP requests to the API services
+* Various minor adjustments and fixes
 
 = 1.7.17 =
 * Added API service failback mechanism

--- a/sucuri.php
+++ b/sucuri.php
@@ -5081,6 +5081,22 @@ class SucuriScanAPI extends SucuriScanOption
         return substr($trail, 1);
     }
 
+    private static function canCurlFollowRedirection()
+    {
+        $safe_mode = ini_get('safe_mode');
+        $open_basedir = ini_get('open_basedir');
+
+        if ($safe_mode === '1' || $safe_mode === 'On') {
+            return false;
+        }
+
+        if (!empty($open_basedir)) {
+            return false;
+        }
+
+        return true;
+    }
+
     /**
      * Assign the communication protocol.
      *
@@ -5303,8 +5319,11 @@ class SucuriScanAPI extends SucuriScanOption
             curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
             curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, $timeout);
             curl_setopt($curl, CURLOPT_TIMEOUT, $timeout * 2);
-            curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
-            curl_setopt($curl, CURLOPT_MAXREDIRS, 2);
+
+            if (self::canCurlFollowRedirection()) {
+                curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+                curl_setopt($curl, CURLOPT_MAXREDIRS, 2);
+            }
 
             if ($method === 'POST') {
                 curl_setopt($curl, CURLOPT_POST, true);

--- a/sucuri.php
+++ b/sucuri.php
@@ -1847,6 +1847,8 @@ class SucuriScanFileInfo extends SucuriScan
             }
 
             if (is_array($tree) && !empty($tree)) {
+                sort($tree); /* Sort in alphabetic order */
+
                 return array_map(array('SucuriScan', 'fixPath'), $tree);
             }
         }
@@ -2165,12 +2167,15 @@ class SucuriScanFileInfo extends SucuriScan
             foreach ($dir_tree as $filepath) {
                 $dir_path = dirname($filepath);
 
-                if (is_array($dirs)
-                    && !in_array($dir_path, $dirs)
-                    && array_key_exists('directories', $this->ignored_directories)
-                    && is_array($this->ignored_directories['directories'])
-                    && !in_array($dir_path, $this->ignored_directories['directories'])
-                ) {
+                if (!in_array($dir_path, $dirs)) {
+                    if (is_array($this->ignored_directories)
+                        && array_key_exists('directories', $this->ignored_directories)
+                        && is_array($this->ignored_directories['directories'])
+                        && in_array($dir_path, $this->ignored_directories['directories'])
+                    ) {
+                        continue;
+                    }
+
                     $dirs[] = $dir_path;
                 }
             }

--- a/sucuri.php
+++ b/sucuri.php
@@ -4,7 +4,7 @@ Plugin Name: Sucuri Security - Auditing, Malware Scanner and Hardening
 Plugin URI: https://wordpress.sucuri.net/
 Description: The <a href="https://sucuri.net/" target="_blank">Sucuri</a> plugin provides the website owner the best Activity Auditing, SiteCheck Remote Malware Scanning, Effective Security Hardening and Post-Hack features. SiteCheck will check for malware, spam, blacklisting and other security issues like .htaccess redirects, hidden eval code, etc. The best thing about it is it's completely free.
 Author: Sucuri, INC
-Version: 1.7.17
+Version: 1.7.19
 Author URI: https://sucuri.net
 */
 
@@ -65,7 +65,7 @@ define('SUCURISCAN', 'sucuriscan');
 /**
  * Current version of the plugin's code.
  */
-define('SUCURISCAN_VERSION', '1.7.17');
+define('SUCURISCAN_VERSION', '1.7.19');
 
 /**
  * The name of the Sucuri plugin main file.


### PR DESCRIPTION
`CURLOPT_FOLLOWLOCATION` cannot be activated when _"safe_mode"_ is enabled or an _"open_basedir"_ is set. This pull-request adds a condition around this option to prevent this failure in the execution of the HTTP requests, alternative the user can go to the _"API Service"_ panel located in the plugin' settings page and change the _"API Request Handler"_ to force the plugin to use the alternate interfaces instead of Curl.