### PR TITLE
Added error message when storage is not writable

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: dd@sucuri.net
 Donate Link: https://sucuri.net/
 Tags: malware, security, firewall, scan, spam, virus, sucuri, protection,WordPress Security, Login Security,Security Auditing,File Integrity,htaccess,phishing,backdoors,SQL Injection, RFI, LFI, XSS, CSRF, website firewall, Website Security, Performance Optimization, Zero Day, Software Vulnerability, Exploits, Hacks, Attackers, Bad Actors, Reverse Proxy, Two Factor Security, Two Factor Authentication, Security Logs, HeatBleed Vulnerability, Website Protection, Bash Vulnerability, RevSlider Vulnerability, MailPoet Vulnerability, Malware Prevention, Website Firewall, Website AntiVirus, Security Response, Security Detection, Security Prevention
 Requires at least:3.2
-Stable tag: 1.7.19
+Stable tag: 1.8.0
 Tested up to: 4.5.3
 
 The Sucuri WordPress Security plugin is a security toolset for security integrity monitoring, malware detection and security hardening.
@@ -353,6 +353,13 @@ service from the WordPress dashboard.
 
 
 == Changelog ==
+
+= 1.8.0 =
+* Added error message when storage is not writable
+* Fixed option getter to migrate plugin settings if possible
+* Fixed base directory name without PHP __DIR__ constant
+* Fixed user authentication denial when no blocked users
+* Fixed htaccess standard rules checker with no WP_Rewrite
 
 = 1.7.19 =
 * Added function to rescue HTTP requests using sockets

--- a/sucuri.php
+++ b/sucuri.php
@@ -3157,14 +3157,21 @@ class SucuriScanOption extends SucuriScanRequest
          * If the option is not in the external file nor in the database, and
          * the name starts with the same prefix used by the plugin then we must
          * return the default value defined by the author.
+         *
+         * Note that if the plain text file is not writable the function should
+         * not delete the option from the database to keep backward compatibility
+         * with previous installations of the plugin.
          */
         if (function_exists('get_option')) {
             $value = get_option($option);
 
             if ($value !== false) {
                 if (strpos($option, 'sucuriscan_') === 0) {
-                    delete_option($option);
-                    self::update_option($option, $value);
+                    $written = self::update_option($option, $value);
+
+                    if ($written === true) {
+                        delete_option($option);
+                    }
                 }
 
                 return $value;

--- a/sucuri.php
+++ b/sucuri.php
@@ -4,7 +4,7 @@ Plugin Name: Sucuri Security - Auditing, Malware Scanner and Hardening
 Plugin URI: https://wordpress.sucuri.net/
 Description: The <a href="https://sucuri.net/" target="_blank">Sucuri</a> plugin provides the website owner the best Activity Auditing, SiteCheck Remote Malware Scanning, Effective Security Hardening and Post-Hack features. SiteCheck will check for malware, spam, blacklisting and other security issues like .htaccess redirects, hidden eval code, etc. The best thing about it is it's completely free.
 Author: Sucuri, INC
-Version: 1.7.19
+Version: 1.8.0
 Author URI: https://sucuri.net
 */
 
@@ -65,7 +65,7 @@ define('SUCURISCAN', 'sucuriscan');
 /**
  * Current version of the plugin's code.
  */
-define('SUCURISCAN_VERSION', '1.7.19');
+define('SUCURISCAN_VERSION', '1.8.0');
 
 /**
  * The name of the Sucuri plugin main file.

--- a/sucuri.php
+++ b/sucuri.php
@@ -12568,7 +12568,10 @@ class SucuriScanBlockedUsers extends SucuriScanLastLogins
                 $blocked = $cache->getAll();
                 $cache_key = md5($username);
 
-                if (array_key_exists($cache_key, $blocked)) {
+                if (is_array($blocked)
+                    && is_string($cache_key)
+                    && array_key_exists($cache_key, $blocked)
+                ) {
                     $blocked[$cache_key]->last_attempt = time();
                     $cache->set($cache_key, $blocked[$cache_key]);
 

--- a/sucuri.php
+++ b/sucuri.php
@@ -14791,11 +14791,16 @@ function sucuriscan_htaccess_is_standard($rules = false)
         }
     }
 
-    if (is_string($rules) && !empty($rules)) {
+    if (class_exists('WP_Rewrite')
+        && is_string($rules)
+        && !empty($rules)
+    ) {
         $rewrite = new WP_Rewrite();
         $standard = $rewrite->mod_rewrite_rules();
 
-        return (bool) (strpos($rules, $standard) !== false);
+        if (!empty($standard)) {
+            return (bool) (strpos($rules, $standard) !== false);
+        }
     }
 
     return false;

--- a/sucuri.php
+++ b/sucuri.php
@@ -74,8 +74,14 @@ define('SUCURISCAN_PLUGIN_FILE', 'sucuri.php');
 
 /**
  * The name of the folder where the plugin's files will be located.
+ *
+ * Note that we are using the constant FILE instead of DIR because some
+ * installations of PHP are either outdated or are not supporting the access to
+ * that definition, to keep things simple we will select the name of the
+ * directory name of the current file, then select the base name of that
+ * directory.
  */
-define('SUCURISCAN_PLUGIN_FOLDER', basename(__DIR__));
+define('SUCURISCAN_PLUGIN_FOLDER', basename(dirname(__FILE__)));
 
 /**
  * The fullpath where the plugin's files will be located.


### PR DESCRIPTION
The current code is failing silently when the user tries to generate, recover, or manually set an API key to fully activate the plugin when the data storage folder is not writable. This pull-request adds a warning message on `_POST` requests associated with the management of the key _(specifically in the general settings page)_ advising the user to grant write privileges in the directory set as the data storage, or the to the settings file.

Apparently the WordPress class _"WP_Rewrite"_ is not available all the time as it used to be in previous versions, this provokes a warning in the _"Site Info"_ page when the panel used to check the integrity of the access control file is rendered, this is because the class is being used to retrieve the default rules that Wordpress inserts in the main `.htaccess` file when the permalinks are enabled.

When the blocked users mechanism was implemented I missed a conditional to check if the variable that holds the list of blocked accounts is actually an array in order to check if the user that is trying to authenticate is in the list via `array_key_exists`; right now this piece of code is throwing a warning and this pull-request fixes that issue.

Some users are still hosting their websites in servers with a very old PHP installation, with the latest update we started using the constant `__DIR__` that was introduced with PHP 5.3 but a user complained because he is using PHP 5.2; this pull-request changes that constant and uses `dirname(__FILE__)` instead which is available in older versions.

With the release of version 1.7.18 the plugin stopped using the database to store the settings, now it stores them in a plain text file located _(by default)_ in the uploads folder. When the plugin tries to get a setting and it is not in the plain text file it continues searching in the database, if the option is found there it writes the data in the file and deletes it from the database. However, if the file is not writable the plugin is deleting all the settings even if the custom `update_option` fails. This pull-request fixes this problem by checking if the write action suceeded before it tries to delete the setting from the database.