### PR TITLE
Added new version 1.8.2

### DIFF
--- a/inc/tpl/settings-datastorage-files.snippet.tpl
+++ b/inc/tpl/settings-datastorage-files.snippet.tpl
@@ -1,0 +1,11 @@
+
+<tr class="%%SUCURI.DataStorage.CssClass%%">
+    <td class="check-column">
+        <input type="checkbox" name="sucuriscan_fnames[]"
+        %%SUCURI.DataStorage.DisabledInput%%
+        value="%%SUCURI.DataStorage.Fname%%" />
+    </td>
+    <td><span class="sucuriscan-monospace">%%SUCURI.DataStorage.Fpath%%</span></td>
+    <td><span class="sucuriscan-monospace">%%SUCURI.DataStorage.Exists%%</span></td>
+    <td><span class="sucuriscan-monospace">%%SUCURI.DataStorage.IsWritable%%</span></td>
+</tr>

--- a/inc/tpl/settings-general-datastorage.html.tpl
+++ b/inc/tpl/settings-general-datastorage.html.tpl
@@ -14,29 +14,13 @@
 
         <div class="sucuriscan-inline-alert-warning">
             <p>
-                Note that the virtual protection added by the plugin to these files is not bullet
-                proof, it may be bypassed and depending on the configuration of the server it may
-                leak information, but this is better than to store the data in the database and
-                wait for a SQL injection to be used to attack the rest of the site.
-            </p>
-        </div>
 
-        <div class="sucuriscan-inline-alert-info">
-            <p>
-                There are some entries in the options table that will be moved to a plain text
-                file during the development of the next version of the plugin, this is part of
-                a plan to include a way to import and export the settings of this extension to
-                other sites in an easy way. This is necessary as importing data into a database
-                may open security holes <em>(depending on how the code is written)</em> to reduce
-                the risk we will use plain text files which makes things a bit safer.
-            </p>
-        </div>
-
-        <div class="sucuriscan-inline-alert-info">
-            <p>
-                An alternative to this setting you can opt to set the directory path from the
-                WordPress configuration file using a constant named <em>"SUCURI_DATA_STORAGE"</em>
-                it must contain a valid and existing absolute directory path.
+                The plugin requires write permissions in this directory as well
+                as the files contained in it. If you prefer to keep these files
+                in a non-public directory <em>(one level up the document root)
+                </em> please define a constant in the <em>"wp-config.php"</em>
+                file named <em>"SUCURI_DATA_STORAGE"</em> with the absolute path
+                to the new directory.
             </p>
         </div>
 
@@ -45,18 +29,31 @@
         </div>
 
         <p>
-            Some people may prefer to use a folder that is not in the document root of the
-            website to add another layer of protection to the data, feel free to change this
-            path if you want, make sure to use absolute paths.
+            As of version 1.7.18 the plugin started using a plain text file named
+            <em>"sucuri-settings.php"</em> to store its settings instead of the
+            database, this was both a security measure and a mechanism to simplify
+            the management of the settings for multisite installations. Options
+            created in the database by previous versions of the plugin will be
+            migrated to the settings file if it is writable, otherwise they will
+            remain in the database until the user grants write permissions.
         </p>
 
-        <form action="%%SUCURI.URL.Settings%%" method="post">
-            <input type="hidden" name="sucuriscan_page_nonce" value="%%SUCURI.PageNonce%%" />
-            <span class="sucuriscan-input-group">
-                <label>Data Storage Path:</label>
-                <input type="text" name="sucuriscan_datastore_path" class="input-text" />
-            </span>
-            <button type="submit" class="button-primary">Proceed</button>
-        </form>
+        <table class="wp-list-table widefat sucuriscan-table">
+            <thead>
+                <tr>
+                    <th class="manage-column column-cb check-column">
+                        <label class="screen-reader-text" for="cb-select-all-1">Select All</label>
+                        <input id="cb-select-all-1" type="checkbox">
+                    </th>
+                    <th class="manage-column">File</th>
+                    <th width="70" class="manage-column">Exists?</th>
+                    <th width="90" class="manage-column">Writable?</th>
+                </tr>
+            </thead>
+
+            <tbody>
+                %%%SUCURI.DataStorage.Files%%%
+            </tbody>
+        </table>
     </div>
 </div>

--- a/inc/tpl/settings-general-datastorage.html.tpl
+++ b/inc/tpl/settings-general-datastorage.html.tpl
@@ -14,7 +14,6 @@
 
         <div class="sucuriscan-inline-alert-warning">
             <p>
-
                 The plugin requires write permissions in this directory as well
                 as the files contained in it. If you prefer to keep these files
                 in a non-public directory <em>(one level up the document root)
@@ -37,6 +36,16 @@
             migrated to the settings file if it is writable, otherwise they will
             remain in the database until the user grants write permissions.
         </p>
+
+        <div class="sucuriscan-inline-alert-info">
+            <p>
+                Add this <code>define('SUCURI_SETTINGS_IN', 'database');</code>
+                in the configuration file if you want to keep using the database.
+                However, we encourage you to keep using the plain text files as
+                this guarantees that the automated tests will cover all the code
+                that powers the plugin.
+            </p>
+        </div>
 
         <table class="wp-list-table widefat sucuriscan-table">
             <thead>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: dd@sucuri.net
 Donate Link: https://sucuri.net/
 Tags: malware, security, firewall, scan, spam, virus, sucuri, protection,WordPress Security, Login Security,Security Auditing,File Integrity,htaccess,phishing,backdoors,SQL Injection, RFI, LFI, XSS, CSRF, website firewall, Website Security, Performance Optimization, Zero Day, Software Vulnerability, Exploits, Hacks, Attackers, Bad Actors, Reverse Proxy, Two Factor Security, Two Factor Authentication, Security Logs, HeatBleed Vulnerability, Website Protection, Bash Vulnerability, RevSlider Vulnerability, MailPoet Vulnerability, Malware Prevention, Website Firewall, Website AntiVirus, Security Response, Security Detection, Security Prevention
 Requires at least:3.2
-Stable tag: 1.8.1
+Stable tag: 1.8.2
 Tested up to: 4.5.3
 
 The Sucuri WordPress Security plugin is a security toolset for security integrity monitoring, malware detection and security hardening.
@@ -353,6 +353,16 @@ service from the WordPress dashboard.
 
 
 == Changelog ==
+
+= 1.8.2 =
+* Modified logic of the settings in database checker
+* Modified default value for the available updates alerts
+* Fixed undefined array and object keys in audit logs
+* Fixed incompatibilities with foreign API service responses
+* Added development option to keep using the database
+* Added panel with information about the plugin settings
+* Added conditional to prevent redeclaration of class
+* Fixed cache flush function used to delete datastore
 
 = 1.8.1 =
 * Modified default setting for the core integrity alerts

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: dd@sucuri.net
 Donate Link: https://sucuri.net/
 Tags: malware, security, firewall, scan, spam, virus, sucuri, protection,WordPress Security, Login Security,Security Auditing,File Integrity,htaccess,phishing,backdoors,SQL Injection, RFI, LFI, XSS, CSRF, website firewall, Website Security, Performance Optimization, Zero Day, Software Vulnerability, Exploits, Hacks, Attackers, Bad Actors, Reverse Proxy, Two Factor Security, Two Factor Authentication, Security Logs, HeatBleed Vulnerability, Website Protection, Bash Vulnerability, RevSlider Vulnerability, MailPoet Vulnerability, Malware Prevention, Website Firewall, Website AntiVirus, Security Response, Security Detection, Security Prevention
 Requires at least:3.2
-Stable tag: 1.8.0
+Stable tag: 1.8.1
 Tested up to: 4.5.3
 
 The Sucuri WordPress Security plugin is a security toolset for security integrity monitoring, malware detection and security hardening.
@@ -353,6 +353,14 @@ service from the WordPress dashboard.
 
 
 == Changelog ==
+
+= 1.8.1 =
+* Modified default setting for the core integrity alerts
+* Added more files to the core integrity ignore list
+* Fixed support for custom data storage directory
+* Fixed admin notices after changing alert settings
+* Fixed settings and audit logs for the firewall page
+* Fixed regression with clear cache in firewall page
 
 = 1.8.0 =
 * Added error message when storage is not writable

--- a/sucuri.php
+++ b/sucuri.php
@@ -11279,19 +11279,34 @@ function sucuriscan_posthack_updates_content($send_email = false)
 
         foreach ($updates as $data) {
             $css_class = ($counter % 2 == 0) ? '' : 'alternate';
-            $response .= SucuriScanTemplate::getSnippet(
-                'posthack-updates',
-                array(
-                    'Update.CssClass' => $css_class,
-                    'Update.IconType' => 'plugins',
-                    'Update.Extension' => SucuriScan::excerpt($data->Name, 35),
-                    'Update.Version' => $data->Version,
-                    'Update.NewVersion' => $data->update->new_version,
-                    'Update.TestedWith' => "WordPress\x20" . $data->update->tested,
-                    'Update.ArchiveUrl' => $data->update->package,
-                    'Update.MarketUrl' => $data->update->url,
-                )
+            $params = array(
+                'Update.CssClass' => $css_class,
+                'Update.IconType' => 'plugins',
+                'Update.Extension' => SucuriScan::excerpt($data->Name, 35),
+                'Update.Version' => $data->Version,
+                'Update.NewVersion' => 'Unknown',
+                'Update.TestedWith' => 'Unknown',
+                'Update.ArchiveUrl' => 'Unknown',
+                'Update.MarketUrl' => 'Unknown',
             );
+
+            if (property_exists($data->update, 'new_version')) {
+                $params['Update.NewVersion'] = $data->update->new_version;
+            }
+
+            if (property_exists($data->update, 'tested')) {
+                $params['Update.TestedWith'] = "WordPress\x20" . $data->update->tested;
+            }
+
+            if (property_exists($data->update, 'package')) {
+                $params['Update.ArchiveUrl'] = $data->update->package;
+            }
+
+            if (property_exists($data->update, 'url')) {
+                $params['Update.MarketUrl'] = $data->update->url;
+            }
+
+            $response .= SucuriScanTemplate::getSnippet('posthack-updates', $params);
             $counter++;
         }
     }

--- a/sucuri.php
+++ b/sucuri.php
@@ -3035,6 +3035,16 @@ class SucuriScanOption extends SucuriScanRequest
     }
 
     /**
+     * Check if the settings will be stored in a plain text file.
+     *
+     * @return boolean True if the settings will be stored in a file.
+     */
+    public static function settingsInTextFile()
+    {
+        return (bool) (self::settingsInDatabase() === false);
+    }
+
+    /**
      * Returns path of the options storage.
      *
      * Returns the absolute path of the file that will store the options
@@ -3199,11 +3209,8 @@ class SucuriScanOption extends SucuriScanRequest
             $options[$option] = $value;
 
             // Skip if user wants to use the database.
-            if (self::settingsInDatabase()) {
-                // Try to write in file, otherwise in database.
-                if (self::writeNewOptions($options)) {
-                    return true;
-                }
+            if (self::settingsInTextFile() && self::writeNewOptions($options)) {
+                return true;
             }
         }
 
@@ -12930,7 +12937,7 @@ function sucuriscan_settings_general_apikey($nonce)
     $display_manual_key_form = (bool) (SucuriScanRequest::post(':recover_key') !== false);
 
     if ($nonce) {
-        if (!empty($_POST) && !SucuriScanOption::settingsInDatabase()) {
+        if (!empty($_POST) && SucuriScanOption::settingsInTextFile()) {
             $fpath = SucuriScanOption::optionsFilePath();
 
             if (!is_writable($fpath)) {

--- a/sucuri.php
+++ b/sucuri.php
@@ -4,7 +4,7 @@ Plugin Name: Sucuri Security - Auditing, Malware Scanner and Hardening
 Plugin URI: https://wordpress.sucuri.net/
 Description: The <a href="https://sucuri.net/" target="_blank">Sucuri</a> plugin provides the website owner the best Activity Auditing, SiteCheck Remote Malware Scanning, Effective Security Hardening and Post-Hack features. SiteCheck will check for malware, spam, blacklisting and other security issues like .htaccess redirects, hidden eval code, etc. The best thing about it is it's completely free.
 Author: Sucuri, INC
-Version: 1.8.0
+Version: 1.8.1
 Author URI: https://sucuri.net
 */
 
@@ -65,7 +65,7 @@ define('SUCURISCAN', 'sucuriscan');
 /**
  * Current version of the plugin's code.
  */
-define('SUCURISCAN_VERSION', '1.8.0');
+define('SUCURISCAN_VERSION', '1.8.1');
 
 /**
  * The name of the Sucuri plugin main file.

--- a/sucuri.php
+++ b/sucuri.php
@@ -4,7 +4,7 @@ Plugin Name: Sucuri Security - Auditing, Malware Scanner and Hardening
 Plugin URI: https://wordpress.sucuri.net/
 Description: The <a href="https://sucuri.net/" target="_blank">Sucuri</a> plugin provides the website owner the best Activity Auditing, SiteCheck Remote Malware Scanning, Effective Security Hardening and Post-Hack features. SiteCheck will check for malware, spam, blacklisting and other security issues like .htaccess redirects, hidden eval code, etc. The best thing about it is it's completely free.
 Author: Sucuri, INC
-Version: 1.8.1
+Version: 1.8.2
 Author URI: https://sucuri.net
 */
 
@@ -65,7 +65,7 @@ define('SUCURISCAN', 'sucuriscan');
 /**
  * Current version of the plugin's code.
  */
-define('SUCURISCAN_VERSION', '1.8.1');
+define('SUCURISCAN_VERSION', '1.8.2');
 
 /**
  * The name of the Sucuri plugin main file.

--- a/sucuri.php
+++ b/sucuri.php
@@ -2900,7 +2900,7 @@ class SucuriScanOption extends SucuriScanRequest
             'sucuriscan_lastlogin_redirection' => 'enabled',
             'sucuriscan_logs4report' => 500,
             'sucuriscan_maximum_failed_logins' => 30,
-            'sucuriscan_notify_available_updates' => 'enabled',
+            'sucuriscan_notify_available_updates' => 'disabled',
             'sucuriscan_notify_bruteforce_attack' => 'disabled',
             'sucuriscan_notify_failed_login' => 'enabled',
             'sucuriscan_notify_plugin_activated' => 'disabled',

--- a/sucuri.php
+++ b/sucuri.php
@@ -2869,6 +2869,10 @@ class SucuriScanCache extends SucuriScan
     {
         $finfo = $this->getDatastoreContent();
 
+        if (array_key_exists('entries', $finfo)) {
+            $finfo['entries'] = array();
+        }
+
         return $this->saveNewEntries($finfo);
     }
 }

--- a/sucuri.php
+++ b/sucuri.php
@@ -13555,6 +13555,7 @@ function sucuriscan_settings_corefiles_cache($nonce)
     return SucuriScanTemplate::getSection('settings-corefiles-cache', $params);
 }
 
+if (!class_exists('SucuriScanSiteCheck')) {
 class SucuriScanSiteCheck extends SucuriScanSettings
 {
     public static function isEnabled()
@@ -13646,6 +13647,7 @@ class SucuriScanSiteCheck extends SucuriScanSettings
 
         return SucuriScanTemplate::getSection('settings-sitecheck-timeout', $params);
     }
+}
 }
 
 /**

--- a/sucuri.php
+++ b/sucuri.php
@@ -10247,6 +10247,7 @@ function sucuriscan_audit_logs_ajax()
     if (SucuriScanRequest::post('form_action') == 'get_audit_logs') {
         $response = array();
         $response['count'] = 0;
+        $response['content'] = '';
         $response['enable_report'] = false;
 
         // Initialize the values for the pagination.
@@ -10319,7 +10320,7 @@ function sucuriscan_audit_logs_ajax()
             $response['count'] = $counter_i;
 
             if ($total_items > 1) {
-                $max_pages = ceil($audit_logs->total_entries / $max_per_page);
+                $max_pages = ceil($audit_logs['total_entries'] / $max_per_page);
 
                 if ($max_pages > SUCURISCAN_MAX_PAGINATION_BUTTONS) {
                     $max_pages = SUCURISCAN_MAX_PAGINATION_BUTTONS;


### PR DESCRIPTION
#### Modified logic of the settings in database checker

The naming of the function used to check if the user has decided to keep using the database to store the plugin's settings was ambiguous; this adds a new function with a clear definition of the boolean check.

#### Modified default value for the available updates alerts

After complains from some users we decided to revert the default value for the availalbe plugin and themes email alerts back to "disabled" as we found that some web agencies have several WordPress websites running with outdated software and possibly not willing to update them all, so the notifications are being seen as annoying.

#### Fixed undefined array and object keys in audit logs

The audit logs is not responding if PHP is configured to be strict with the warnings, there is a missing initializator for an array key that was used to concatenate strings, as well as a read access to a non-existent object property.

#### Fixed incompatibilities with foreign API service responses

I have found that the WordPress API service is returning different responses when the available updates endpoint for plugins is contacted, for instance, the property _"tested"_ in the JSON object does not exists; this commit adds conditions to prevent unnecessary PHP warnings for non-existent object properties for the 3rd-party WordPress API service.

#### Added development option to keep using the database

Some power users have complained because they do not agree with the idea introduced in version 1.7.18 to force the plugin to store its settings in a plain text file for security reasons; I have decided to offer a way to go around this by defining a constant _"SUCURI_SETTINGS_IN"_ with value "database" in the configuration file to force the plugin to keep using the database to store its settings.

#### Added panel with information about the plugin settings

Since version 1.7.18 the plugin started storing its settings in a plain text file located in the `/wp-content/uploads/sucuri` directory or the directory defined by the user with the _"SUCURI_DATA_STORAGE"_ constant, some users raised complains that not using the database is a bad idea but in fact this is a good security measure to reduce the number of attacks against the database and to simplify the management of the settings for multisite installations; information about these changes and solutions for common issues were added with this commit.

#### Added conditional to prevent redeclaration of class

Some users have reported that using APC and/or FastCGI causes an internal server error with the declaration of the class used to manage the code for the malware scanner settings; this is because APC has a bug that duplicates the autoloaders thinking that a class was defined twice, the only apparent solution is to set these settings:

```
apc.include_once_override = 0
apc.canonicalize = 0
apc.stat = 0
```

#### Fixed cache flush function used to delete datastore

The function that flushes the content of the cache files was intended to take the information from the file and then reset its entries before the new content is written, leaving only the original headers; however, the piece of code that was supposed to reset the array of entries is missing