### PR TITLE
Fix handling of the actions in the core integrity checks

### DIFF
--- a/src/integrity.lib.php
+++ b/src/integrity.lib.php
@@ -122,7 +122,7 @@ class SucuriScanIntegrity
                 @list($status_type, $file_path) =
                 explode('@', $file_meta, 2);
 
-                if ($file_path && $status_type && $status_type === $action) {
+                if ($file_path && $status_type) {
                     $full_path = ABSPATH . '/' . $file_path;
 
                     switch ($action) {


### PR DESCRIPTION
This pull-request fixes a problem with the WordPress core integrity panel where files were not being marked as fixed, restored, nor deleted because the action that was executed was different than the flag that was marking each file, this flag was not supposed to be used as a check. This commit fixed this problem for all cases.