### PR TITLE
Add message and button to reset the audit logs cache

### DIFF
--- a/inc/css/styles.css
+++ b/inc/css/styles.css
@@ -793,7 +793,7 @@ body.sucuri-security_page_sucuriscan_hardening {
     padding-top: 0;
 }
 .sucuriscan-auditlog-entry {
-    padding: 20px 0;
+    padding: 10px 0;
     border-bottom: 1px solid #dbdbdb;
 }
 .sucuriscan-auditlog-entry-title,
@@ -828,7 +828,7 @@ body.sucuri-security_page_sucuriscan_hardening {
     font-size: 11px;
 }
 .sucuriscan-auditlog-entry-extra ul {
-    margin-top: 20px;
+    margin-top: 5px;
 }
 .sucuriscan-auditlog-entry-extra li {
     margin-bottom: 0;

--- a/inc/tpl/auditlogs.html.tpl
+++ b/inc/tpl/auditlogs.html.tpl
@@ -53,6 +53,18 @@ jQuery(function ($) {
         event.preventDefault();
         sucuriscanLoadAuditLogs($(this).attr('data-page'));
     });
+
+    $('.sucuriscan-auditlog-table').on('click', '.sucuriscan-reset-auditlogs', function (event) {
+        event.preventDefault();
+        $.post('%%SUCURI.AjaxURL.Dashboard%%', {
+            action: 'sucuriscan_ajax',
+            sucuriscan_page_nonce: '%%SUCURI.PageNonce%%',
+            form_action: 'reset_auditlogs_cache',
+        }, function (data) {
+            console.log(data);
+            sucuriscanLoadAuditLogs(0, true);
+        });
+    });
 });
 </script>
 
@@ -70,6 +82,13 @@ jQuery(function ($) {
 
     <div class="sucuriscan-auditlog-response">
         <em>Loading...</em>
+    </div>
+
+    <div>
+        <small>
+            This data is cached for %%SUCURI.AuditLogs.Lifetime%% seconds
+            &mdash; <a href="#" class="sucuriscan-reset-auditlogs">refresh</a>
+        </small>
     </div>
 
     <div class="sucuriscan-clearfix">

--- a/inc/tpl/auditlogs.snippet.tpl
+++ b/inc/tpl/auditlogs.snippet.tpl
@@ -7,7 +7,7 @@
     </div>
 
     <div class="sucuriscan-pull-left sucuriscan-auditlog-entry-event">
-        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="15.5px" height="18.5px" class="sucuriscan-auditlog-%%SUCURI.AuditLog.Event%%"">
+        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="15.5px" height="18.5px" class="sucuriscan-pull-left sucuriscan-auditlog-%%SUCURI.AuditLog.Event%%"">
             <path fill-rule="evenodd" stroke="rgb(0, 0, 0)" stroke-width="1px" stroke-linecap="butt" stroke-linejoin="miter" d="M9.845,4.505 L14.481,7.098 L13.639,11.471 L8.498,11.503 L9.845,4.505 Z" />
             <path fill-rule="evenodd" stroke="rgb(0, 0, 0)" stroke-width="1px" stroke-linecap="butt" stroke-linejoin="miter" d="M3.500,1.500 L10.500,3.750 L10.500,9.375 L3.500,10.500 L3.500,1.500 Z" />
             <path class="flag-bar" fill-rule="evenodd" stroke="rgb(0, 0, 0)" stroke-width="1px" stroke-linecap="butt" stroke-linejoin="miter" fill="rgb(255, 255, 255)" d="M1.500,1.500 L3.500,1.500 L3.500,16.500 L1.500,16.500 L1.500,1.500 Z" />

--- a/src/auditlogs.lib.php
+++ b/src/auditlogs.lib.php
@@ -167,6 +167,11 @@ class SucuriScanAuditLogs
                     $snippet_data['AuditLog.Extra'] .= '</ul>';
                 }
 
+                /* simplify the details of events with low metadata */
+                if (strpos($audit_log['message'], 'status has been changed')) {
+                    $snippet_data['AuditLog.Extra'] = implode(",\x20", $audit_log['file_list']);
+                }
+
                 $response['content'] .= SucuriScanTemplate::getSnippet('auditlogs', $snippet_data);
                 $counter_i += 1;
             }

--- a/src/pagehandler.php
+++ b/src/pagehandler.php
@@ -179,6 +179,7 @@ function sucuriscan_ajax()
     if (SucuriScanInterface::checkNonce()) {
         SucuriScanAuditLogs::ajaxAuditLogs();
         SucuriScanAuditLogs::ajaxAuditLogsReport();
+        SucuriScanAuditLogs::ajaxAuditLogsResetCache();
         SucuriScanFirewall::auditlogsAjax();
         SucuriScanIntegrity::ajaxIntegrity();
         SucuriScanIntegrity::ajaxIntegrityDiffUtility();

--- a/src/settings-general.php
+++ b/src/settings-general.php
@@ -149,9 +149,11 @@ function sucuriscan_settings_general_datastorage()
     $params = array();
     $files = array(
         '', /* <root> */
+        'auditlogs',
         'auditqueue',
         'blockedusers',
         'failedlogins',
+        'hookdata',
         'ignorescanning',
         'integrity',
         'lastlogins',


### PR DESCRIPTION
The data in the _"Audit Logs"_ panel is cached for 600 seconds _(as of the time of writing this)_ to reduce the number of HTTP requests sent to the API service. However, some people may want to see updated data depending on how often they check the plugin's dashboard. For this, I have added a button that allows them to refresh the cache and load the new logs. This pull-request also reduces the margins between each log in the interface to make them more compact.