### PR TITLE
Make default plugin options filterable

### DIFF
--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -104,7 +104,7 @@ class SucuriScanOption extends SucuriScanRequest
             'sucuriscan_use_wpmail' => 'enabled',
         );
 
-        return (array) apply_filters( 'sucuriscan_option_defaults', $defaults );
+        return (array) apply_filters('sucuriscan_option_defaults', $defaults);
     }
 
     /**

--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -104,7 +104,7 @@ class SucuriScanOption extends SucuriScanRequest
             'sucuriscan_use_wpmail' => 'enabled',
         );
 
-        return $defaults;
+        return (array) apply_filters( 'sucuriscan_option_defaults', $defaults );
     }
 
     /**


### PR DESCRIPTION
Allows site owners and platforms to define their own option defaults on fresh installs.