### PR TITLE
Store options in object cache

### DIFF
--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -171,9 +171,9 @@ class SucuriScanOption extends SucuriScanRequest
      */
     public static function getAllOptions()
     {
-        $options = wp_cache_get( 'alloptions', SUCURISCAN, WP_DEBUG );
+        $options = wp_cache_get('alloptions', SUCURISCAN, WP_DEBUG);
 
-        if ( $options && is_array( $options ) ) {
+        if ($options && is_array($options)) {
             return $options;
         }
 
@@ -196,7 +196,7 @@ class SucuriScanOption extends SucuriScanRequest
             }
         }
 
-        wp_cache_set( 'alloptions', $options, SUCURISCAN );
+        wp_cache_set('alloptions', $options, SUCURISCAN);
 
         return $options;
     }
@@ -209,7 +209,7 @@ class SucuriScanOption extends SucuriScanRequest
      */
     public static function writeNewOptions($options = array())
     {
-        wp_cache_delete( 'alloptions', SUCURISCAN );
+        wp_cache_delete('alloptions', SUCURISCAN);
 
         $fpath = self::optionsFilePath();
         $content = "<?php exit(0); ?>\n";

--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -171,6 +171,12 @@ class SucuriScanOption extends SucuriScanRequest
      */
     public static function getAllOptions()
     {
+        $options = wp_cache_get( 'alloptions', SUCURISCAN, WP_DEBUG );
+
+        if ( $options && is_array( $options ) ) {
+            return $options;
+        }
+
         $options = array();
         $fpath = self::optionsFilePath();
 
@@ -190,6 +196,8 @@ class SucuriScanOption extends SucuriScanRequest
             }
         }
 
+        wp_cache_set( 'alloptions', $options, SUCURISCAN );
+
         return $options;
     }
 
@@ -201,6 +209,8 @@ class SucuriScanOption extends SucuriScanRequest
      */
     public static function writeNewOptions($options = array())
     {
+        wp_cache_delete( 'alloptions', SUCURISCAN );
+
         $fpath = self::optionsFilePath();
         $content = "<?php exit(0); ?>\n";
         $content .= @json_encode($options) . "\n";


### PR DESCRIPTION
Greatly reduce calls to the file system by storing all options in object cache for the life of the request.