### PR TITLE
Multiple improvements in the settings page and support for WP-CLI

### DIFF
--- a/inc/css/styles.css
+++ b/inc/css/styles.css
@@ -89,7 +89,7 @@ body.sucuri-security_page_sucuriscan_hardening {
 }
 .sucuriscan-container .sucuriscan-full-textarea {
     width: 100%;
-    min-height: 300px;
+    min-height: 400px;
     background: #efefef;
     word-break: break-all;
     padding: 20px;

--- a/inc/css/styles.css
+++ b/inc/css/styles.css
@@ -46,7 +46,7 @@ body.sucuri-security_page_sucuriscan_hardening {
     height: 30px;
     line-height: normal;
 }
-.sucuriscan-container input[type=text] {
+.sucuriscan-container input[type='text'] {
     margin: 0;
     padding: 0 7px;
     line-height: 28px;
@@ -62,6 +62,7 @@ body.sucuri-security_page_sucuriscan_hardening {
     text-transform: uppercase;
     line-height: 30px;
     font-weight: 700;
+    cursor: initial;
 }
 .sucuriscan-container fieldset span {
     line-height: 30px;
@@ -71,8 +72,8 @@ body.sucuri-security_page_sucuriscan_hardening {
 .sucuriscan-container fieldset label,
 .sucuriscan-container fieldset select,
 .sucuriscan-container fieldset button,
-.sucuriscan-container fieldset input[type=text],
-.sucuriscan-container fieldset input[type=checkbox],
+.sucuriscan-container fieldset input[type='text'],
+.sucuriscan-container fieldset input[type='checkbox'],
 .wp-core-ui .sucuriscan-container fieldset .button,
 .wp-core-ui .sucuriscan-container fieldset .button-primary,
 .wp-core-ui .sucuriscan-container fieldset .button-secondary {
@@ -83,7 +84,7 @@ body.sucuri-security_page_sucuriscan_hardening {
 .sucuriscan-container fieldset label {
     margin-left: 0;
 }
-.sucuriscan-container fieldset input[type=checkbox] {
+.sucuriscan-container fieldset input[type='checkbox'] {
     margin-top: 7px;
     margin-bottom: 7px;
 }
@@ -898,8 +899,8 @@ body.sucuri-security_page_sucuriscan_hardening {
 .rtl .sucuriscan-container fieldset label,
 .rtl .sucuriscan-container fieldset select,
 .rtl .sucuriscan-container fieldset button,
-.rtl .sucuriscan-container fieldset input[type=text],
-.rtl .sucuriscan-container fieldset input[type=checkbox],
+.rtl .sucuriscan-container fieldset input[type='text'],
+.rtl .sucuriscan-container fieldset input[type='checkbox'],
 .rtl .wp-core-ui .sucuriscan-container fieldset .button,
 .rtl .wp-core-ui .sucuriscan-container fieldset .button-primary,
 .rtl .wp-core-ui .sucuriscan-container fieldset .button-secondary {

--- a/inc/js/scripts.js
+++ b/inc/js/scripts.js
@@ -1,29 +1,35 @@
 /* global jQuery */
-/* jshint unused:false */
 
-function sucuriscanAlertClose (id) {
+/* jshint ignore:start */
+function sucuriscanAlertClose(id) {
     var element = document.getElementById('sucuriscan-alert-' + id);
     element.parentNode.removeChild(element);
 }
+/* jshint ignore:end */
 
-jQuery(document).ready(function ($) {
-    $('.sucuriscan-container').on('click', '.sucuriscan-modal-button', function (event) {
+jQuery(document).ready(function($) {
+    $('.sucuriscan-container').on('click', '.sucuriscan-modal-button', function(event) {
         event.preventDefault();
+
         var modalid = $(this).data('modalid');
+
         $('div.' + modalid + '-modal').removeClass('sucuriscan-hidden');
     });
 
-    $('.sucuriscan-container').on('click', '.sucuriscan-overlay, .sucuriscan-modal-close', function (event) {
+    $('.sucuriscan-container').on('click', '.sucuriscan-overlay, .sucuriscan-modal-close', function(event) {
         event.preventDefault();
+
         $('.sucuriscan-overlay').addClass('sucuriscan-hidden');
         $('.sucuriscan-modal').addClass('sucuriscan-hidden');
     });
 
-    $('.sucuriscan-container').on('click', '.sucuriscan-show-more', function (event) {
+    $('.sucuriscan-container').on('click', '.sucuriscan-show-more', function(event) {
         event.preventDefault();
+
         var button = $(this);
         var target = button.attr('data-target');
         var status = button.attr('data-status');
+
         if (status === 'more') {
             button.attr('data-status', 'less');
             $(target).removeClass('sucuriscan-hidden');
@@ -41,36 +47,44 @@ jQuery(document).ready(function ($) {
         var activeState = 'sucuriscan-tab-active';
         var locationHash = location.href.split('#')[1];
 
-        $('.sucuriscan-container').on('click', '.sucuriscan-tabs-buttons a', function (event) {
+        $('.sucuriscan-container').on('click', '.sucuriscan-tabs-buttons a', function(event) {
             event.preventDefault();
 
             var button = $(this);
             var uniqueid = button.attr('href').split('#')[1];
 
-            if (uniqueid !== undefined) {
-                var container = $('.sucuriscan-tabs-containers > #sucuriscan-tabs-' + uniqueid);
-
-                if (container.length) {
-                    var rawurl = location.href.replace(location.hash, '');
-                    var newurl = rawurl + '#' + uniqueid;
-
-                    window.history.pushState({}, document.title, newurl);
-
-                    $('.sucuriscan-tabs-buttons a').removeClass(activeState);
-                    $('.sucuriscan-tabs-containers > div').addClass(hiddenState);
-
-                    button.addClass(activeState);
-                    container.addClass(visibleState);
-                    container.removeClass(hiddenState);
-                }
+            if (!uniqueid) {
+                return;
             }
+
+            var container = $('.sucuriscan-tabs-containers > #sucuriscan-tabs-' + uniqueid);
+
+            if (!container.length) {
+                return;
+            }
+
+            var rawurl = location.href.replace(location.hash, '');
+            var newurl = rawurl + '#' + uniqueid;
+
+            window.history.pushState({}, document.title, newurl);
+
+            $('.sucuriscan-tabs-buttons a').removeClass(activeState);
+            $('.sucuriscan-tabs-containers > div').addClass(hiddenState);
+
+            button.addClass(activeState);
+            container.addClass(visibleState);
+            container.removeClass(hiddenState);
         });
 
         $('.sucuriscan-tabs-containers > div').addClass(hiddenState);
 
         if (locationHash !== undefined) {
-            $('.sucuriscan-tabs-buttons a').each(function (e, button) {
-                if ($(button).attr('href').split('#')[1] === locationHash) {
+            $('.sucuriscan-tabs-buttons a').each(function(e, button) {
+                var buttonHash = $(button)
+                    .attr('href')
+                    .split('#')[1];
+
+                if (buttonHash === locationHash) {
                     $(button).trigger('click');
                 }
             });
@@ -79,7 +93,7 @@ jQuery(document).ready(function ($) {
         }
     }
 
-    $('.sucuriscan-container').on('mouseover', '.sucuriscan-tooltip', function (event) {
+    $('.sucuriscan-container').on('mouseover', '.sucuriscan-tooltip', function() {
         var element = $(this);
         var content = element.attr('content');
 
@@ -88,7 +102,7 @@ jQuery(document).ready(function ($) {
         }
 
         /* create instance of tooltip container */
-        var tooltip = $('<div>', { 'class': 'sucuriscan-tooltip-object' });
+        var tooltip = $('<div>', { class: 'sucuriscan-tooltip-object' });
 
         if (element.attr('tooltip-width')) {
             var customWidth = element.attr('tooltip-width');
@@ -107,7 +121,6 @@ jQuery(document).ready(function ($) {
         var tooltipHeight = tooltip.outerHeight();
         tooltip.css('top', (tooltipHeight + arrowHeight) * -1);
 
-        var positionLeft = 0;
         var elementWidth = element.outerWidth();
         var tooltipWidth = tooltip.outerWidth();
 
@@ -116,11 +129,13 @@ jQuery(document).ready(function ($) {
         } else if (elementWidth > tooltipWidth) {
             tooltip.css('left', (elementWidth - tooltipWidth) / 2);
         } else if (elementWidth < tooltipWidth) {
-            tooltip.css('left', ((tooltipWidth - elementWidth) / 2) * -1);
+            tooltip.css('left', (tooltipWidth - elementWidth) / 2 * -1);
         }
     });
 
-    $('.sucuriscan-container').on('mouseout', '.sucuriscan-tooltip', function (event) {
-        $(this).find('.sucuriscan-tooltip-object').remove();
+    $('.sucuriscan-container').on('mouseout', '.sucuriscan-tooltip', function() {
+        $(this)
+            .find('.sucuriscan-tooltip-object')
+            .remove();
     });
 });

--- a/inc/js/scripts.js
+++ b/inc/js/scripts.js
@@ -138,4 +138,22 @@ jQuery(document).ready(function($) {
             .find('.sucuriscan-tooltip-object')
             .remove();
     });
+
+    $('.sucuriscan-container').on('click', 'button.sucuriscan-show-section', function(event) {
+        event.preventDefault();
+
+        var button = $(this);
+        var current = button.text();
+        var onText = button.attr('on');
+        var offText = button.attr('off');
+        var section = button.attr('section');
+
+        if (current === onText) {
+            $('#' + section).removeClass('sucuriscan-hidden');
+            button.html(offText);
+        } else {
+            $('#' + section).addClass('sucuriscan-hidden');
+            button.html(onText);
+        }
+    });
 });

--- a/inc/tpl/lastlogins-failedlogins.html.tpl
+++ b/inc/tpl/lastlogins-failedlogins.html.tpl
@@ -16,7 +16,6 @@
                             <input id="cb-select-all-1" type="checkbox">
                         </td>
                         <th class="manage-column">Username</th>
-                        <th class="manage-column">Password</th>
                         <th class="manage-column">IP Address</th>
                         <th class="manage-column">Date/Time</th>
                         <th class="manage-column" width="300">Web Browser</th>
@@ -27,13 +26,13 @@
                     %%%SUCURI.FailedLogins.List%%%
 
                     <tr class="sucuriscan-%%SUCURI.FailedLogins.NoItemsVisibility%%">
-                        <td colspan="6">
+                        <td colspan="5">
                             <em>no data available</em>
                         </td>
                     </tr>
 
                     <tr class="sucuriscan-%%SUCURI.FailedLogins.PaginationVisibility%%">
-                        <td colspan="6">
+                        <td colspan="5">
                             <ul class="sucuriscan-pagination">
                                 %%%SUCURI.FailedLogins.PaginationLinks%%%
                             </ul>

--- a/inc/tpl/lastlogins-failedlogins.snippet.tpl
+++ b/inc/tpl/lastlogins-failedlogins.snippet.tpl
@@ -6,8 +6,6 @@
 
     <td><span class="sucuriscan-monospace">%%SUCURI.FailedLogins.Username%%</span></td>
 
-    <td><span class="sucuriscan-monospace">%%SUCURI.FailedLogins.Password%%</span></td>
-
     <td><span class="sucuriscan-monospace">%%SUCURI.FailedLogins.RemoteAddr%%</span></td>
 
     <td><em>%%SUCURI.FailedLogins.Datetime%%</em></td>

--- a/inc/tpl/notification-pretty.html.tpl
+++ b/inc/tpl/notification-pretty.html.tpl
@@ -18,6 +18,7 @@
                 <p style="margin:0 0 10px 0">
                     Website: <a href="http://%%SUCURI.Website%%">%%SUCURI.Website%%</a><br>
                     IP Address: %%SUCURI.RemoteAddress%%<br>
+                    Reverse IP: %%SUCURI.ReverseAddress%%<br>
                     Date/Time: %%SUCURI.Time%%<br>
                     %%SUCURI.User%%
                 </p>

--- a/inc/tpl/notification-simple.html.tpl
+++ b/inc/tpl/notification-simple.html.tpl
@@ -2,6 +2,7 @@
 Event: %%SUCURI.Subject%%
 Website: http://%%SUCURI.Website%%
 IP Address: %%SUCURI.RemoteAddress%%
+Reverse IP: %%SUCURI.ReverseAddress%%
 Date/Time: %%SUCURI.Time%%
 %%SUCURI.User%%
 

--- a/inc/tpl/settings-alerts-ignore-posts.html.tpl
+++ b/inc/tpl/settings-alerts-ignore-posts.html.tpl
@@ -22,29 +22,35 @@
 
         <hr>
 
-        <form action="%%SUCURI.URL.Settings%%#alerts" method="post">
-            <input type="hidden" name="sucuriscan_page_nonce" value="%%SUCURI.PageNonce%%" />
-            <input type="hidden" name="sucuriscan_ignorerule_action" value="batch" />
+        <button class="button button-primary sucuriscan-show-section" section="sucuriscan-ignorerules" on="Show Post-Types Table" off="Hide Post-Types Table">Show Post-Types Table</button>
 
-            <table class="wp-list-table widefat sucuriscan-table sucuriscan-settings-ignorerules">
-                <thead>
-                    <tr>
-                        <td id="cb" class="manage-column column-cb check-column">
-                            <label class="screen-reader-text" for="cb-select-all-1">Select All</label>
-                            <input id="cb-select-all-1" type="checkbox">
-                        </td>
-                        <th class="manage-column">Post Type</th>
-                        <th class="manage-column">Post Type ID</th>
-                        <th class="manage-column">Ignored At (optional)</th>
-                    </tr>
-                </thead>
+        <div class="sucuriscan-hidden" id="sucuriscan-ignorerules">
+            <hr>
 
-                <tbody>
-                    %%%SUCURI.PostTypes.List%%%
-                </tbody>
-            </table>
+            <form action="%%SUCURI.URL.Settings%%#alerts" method="post">
+                <input type="hidden" name="sucuriscan_page_nonce" value="%%SUCURI.PageNonce%%" />
+                <input type="hidden" name="sucuriscan_ignorerule_action" value="batch" />
 
-            <button type="submit" class="button button-primary">Submit</button>
-        </form>
+                <table class="wp-list-table widefat sucuriscan-table sucuriscan-settings-ignorerules">
+                    <thead>
+                        <tr>
+                            <td id="cb" class="manage-column column-cb check-column">
+                                <label class="screen-reader-text" for="cb-select-all-1">Select All</label>
+                                <input id="cb-select-all-1" type="checkbox">
+                            </td>
+                            <th class="manage-column">Post Type</th>
+                            <th class="manage-column">Post Type ID</th>
+                            <th class="manage-column">Ignored At (optional)</th>
+                        </tr>
+                    </thead>
+
+                    <tbody>
+                        %%%SUCURI.PostTypes.List%%%
+                    </tbody>
+                </table>
+
+                <button type="submit" class="button button-primary">Submit</button>
+            </form>
+        </div>
     </div>
 </div>

--- a/src/auditlogs.lib.php
+++ b/src/auditlogs.lib.php
@@ -170,7 +170,6 @@ class SucuriScanAuditLogs
         $outdata = (array) $auditlogs['output_data'];
         $todaysDate = SucuriScan::datetime(null, 'M d, Y');
         $iterator_start = ($pageNumber - 1) * $maxPerPage;
-        $show_password = SucuriScanOption::isEnabled(':notify_failed_password');
         $total_items = count($outdata);
 
         usort($outdata, array('SucuriScanAuditLogs', 'sortByDate'));
@@ -186,7 +185,7 @@ class SucuriScanAuditLogs
 
             $audit_log = (array) $outdata[$i];
 
-            if (!$show_password && strpos($audit_log['message'], ";\x20password:")) {
+            if (strpos($audit_log['message'], ";\x20password:")) {
                 $idx = strpos($audit_log['message'], ";\x20password:");
                 $audit_log['message'] = substr($audit_log['message'], 0, $idx);
             }

--- a/src/cli.lib.php
+++ b/src/cli.lib.php
@@ -3,9 +3,15 @@
 /**
  * Code related to the cli.lib.php interface.
  *
- * @package Sucuri Security
- * @subpackage cli.lib.php
- * @copyright Since 2010 Sucuri Inc.
+ * PHP version 5
+ *
+ * @category   Library
+ * @package    Sucuri
+ * @subpackage SucuriScanCLI
+ * @author     Daniel Cid <dcid@sucuri.net>
+ * @copyright  2010-2017 Sucuri Inc.
+ * @license    https://www.gnu.org/licenses/gpl-2.0.txt GPL2
+ * @link       https://wordpress.org/plugins/sucuri-scanner
  */
 
 if (!defined('SUCURISCAN_INIT') || SUCURISCAN_INIT !== true) {
@@ -18,6 +24,14 @@ if (!defined('SUCURISCAN_INIT') || SUCURISCAN_INIT !== true) {
 
 /**
  * Manage Sucuri API registration.
+ *
+ * @category   Library
+ * @package    Sucuri
+ * @subpackage SucuriScanner
+ * @author     Daniel Cid <dcid@sucuri.net>
+ * @copyright  2010-2017 Sucuri Inc.
+ * @license    https://www.gnu.org/licenses/gpl-2.0.txt GPL2
+ * @link       https://wordpress.org/plugins/sucuri-scanner
  */
 class SucuriScanCLI extends WP_CLI_Command
 {
@@ -43,6 +57,9 @@ class SucuriScanCLI extends WP_CLI_Command
      *     # Registration recovery
      *     wp sucuri register
      *     Warning: We already have an API key created for this site. It has been sent to the email admin@example.com for recovery.
+     *
+     * @param  array $args Arguments from the command line interface.
+     * @return void
      */
     public function register($args)
     {

--- a/src/hook.lib.php
+++ b/src/hook.lib.php
@@ -176,13 +176,7 @@ class SucuriScanHook extends SucuriScanEvent
         $title = empty($title) ? 'Unknown' : sanitize_user($title, true);
         $message = 'User authentication failed: ' . $title;
 
-        /* send the submitted password along with the alert */
-        if (SucuriScanOption::isEnabled(':notify_failed_password')) {
-            $message .= '; password: ' . $password;
-            sucuriscan_log_failed_login($title, $password);
-        } else {
-            sucuriscan_log_failed_login($title, '[hidden]');
-        }
+        sucuriscan_log_failed_login($title);
 
         self::reportErrorEvent($message);
 

--- a/src/interface.lib.php
+++ b/src/interface.lib.php
@@ -67,7 +67,7 @@ class SucuriScanInterface
             'sucuriscan1',
             SUCURISCAN_URL . '/inc/css/styles.css',
             array(/* empty */),
-            '3eeb7af'
+            SucuriScan::fileVersion('inc/css/styles.css')
         );
         wp_enqueue_style('sucuriscan1');
 
@@ -75,7 +75,7 @@ class SucuriScanInterface
             'sucuriscan1',
             SUCURISCAN_URL . '/inc/js/scripts.js',
             array(/* empty */),
-            '81f6bb4'
+            SucuriScan::fileVersion('inc/js/scripts.js')
         );
         wp_enqueue_script('sucuriscan1');
 
@@ -84,7 +84,7 @@ class SucuriScanInterface
                 'sucuriscan3',
                 SUCURISCAN_URL . '/inc/css/flags.min.css',
                 array(/* empty */),
-                substr(md5(time()), 0, 7)
+                SucuriScan::fileVersion('inc/css/flags.min.css')
             );
             wp_enqueue_style('sucuriscan3');
         }

--- a/src/lastlogins-failed.php
+++ b/src/lastlogins-failed.php
@@ -57,7 +57,6 @@ function sucuriscan_failed_logins_panel()
     $max_failed_logins = SucuriScanOption::getOption(':maximum_failed_logins');
     $notify_bruteforce_attack = SucuriScanOption::getOption(':notify_bruteforce_attack');
     $failed_logins = sucuriscan_get_all_failed_logins($page_offset, $max_per_page);
-    $show_password = SucuriScanOption::isEnabled(':notify_failed_password');
 
     if ($failed_logins) {
         $counter = 0;
@@ -70,21 +69,6 @@ function sucuriscan_failed_logins_panel()
                     continue;
                 }
 
-                $wrong_user_password = 'hidden';
-                $wrong_user_password_color = 'default';
-
-                if (isset($login_data['user_password']) && !empty($login_data['user_password'])) {
-                    $wrong_user_password = $login_data['user_password'];
-                    $wrong_user_password_color = 'danger';
-                } else {
-                    $wrong_user_password = 'empty';
-                    $wrong_user_password_color = 'info';
-                }
-
-                if (!$show_password) {
-                    $wrong_user_password = 'hidden';
-                }
-
                 $template_variables['FailedLogins.List'] .= SucuriScanTemplate::getSnippet(
                     'lastlogins-failedlogins',
                     array(
@@ -92,8 +76,6 @@ function sucuriscan_failed_logins_panel()
                         'FailedLogins.Username' => $login_data['user_login'],
                         'FailedLogins.RemoteAddr' => $login_data['remote_addr'],
                         'FailedLogins.UserAgent' => $login_data['user_agent'],
-                        'FailedLogins.Password' => $wrong_user_password,
-                        'FailedLogins.PasswordColor' => $wrong_user_password_color,
                         'FailedLogins.Datetime' => SucuriScan::datetime($login_data['attempt_time']),
                     )
                 );
@@ -314,11 +296,10 @@ function sucuriscan_get_failed_logins($get_old_logs = false, $offset = 0, $limit
  * this entry will contain the username, timestamp of the login attempt, remote
  * address of the computer sending the request, and the user-agent.
  *
- * @param  string $user_login     Information from the current failed login event.
- * @param  string $wrong_password Wrong password used during the supposed attack.
- * @return bool                   Whether the information of the current failed login event was stored or not.
+ * @param  string $user_login Information from the current failed login event.
+ * @return bool               True if the information was saved, false otherwise.
  */
-function sucuriscan_log_failed_login($user_login = '', $wrong_password = '')
+function sucuriscan_log_failed_login($user_login = '')
 {
     $storage = sucuriscan_failed_logins_datastore_path();
 
@@ -329,7 +310,6 @@ function sucuriscan_log_failed_login($user_login = '', $wrong_password = '')
     $login_data = json_encode(
         array(
             'user_login' => $user_login,
-            'user_password' => $wrong_password,
             'attempt_time' => time(),
             'remote_addr' => SucuriScan::getRemoteAddr(),
             'user_agent' => SucuriScan::getUserAgent(),

--- a/src/mail.lib.php
+++ b/src/mail.lib.php
@@ -204,6 +204,7 @@ class SucuriScanMail extends SucuriScanOption
         $params['Subject'] = $subject;
         $params['Website'] = $website;
         $params['RemoteAddress'] = self::getRemoteAddr();
+        $params['ReverseAddress'] = gethostbyaddr($params['RemoteAddress']);
         $params['Message'] = $message;
         $params['User'] = $display_name;
         $params['Time'] = SucuriScan::datetime();

--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -82,7 +82,6 @@ class SucuriScanOption extends SucuriScanRequest
             'sucuriscan_notify_available_updates' => 'disabled',
             'sucuriscan_notify_bruteforce_attack' => 'disabled',
             'sucuriscan_notify_failed_login' => 'enabled',
-            'sucuriscan_notify_failed_password' => 'disabled',
             'sucuriscan_notify_plugin_activated' => 'enabled',
             'sucuriscan_notify_plugin_change' => 'enabled',
             'sucuriscan_notify_plugin_deactivated' => 'disabled',

--- a/src/settings-alerts.php
+++ b/src/settings-alerts.php
@@ -405,7 +405,6 @@ function sucuriscan_settings_alerts_events($nonce)
         'sucuriscan_notify_user_registration' => 'user:' . 'Receive email alerts for new user registration',
         'sucuriscan_notify_success_login' => 'user:' . 'Receive email alerts for successful login attempts',
         'sucuriscan_notify_failed_login' => 'user:' . 'Receive email alerts for failed login attempts <em>(you may receive tons of emails)</em>',
-        'sucuriscan_notify_failed_password' => 'user:' . 'Receive email alerts for failed login attempts including the submitted password',
         'sucuriscan_notify_bruteforce_attack' => 'user:' . 'Receive email alerts for password guessing attacks <em>(summary of failed logins per hour)</em>',
         'sucuriscan_notify_post_publication' => 'setting:' . 'Receive email alerts for changes in the post status <em>(configure from Ignore Posts Changes)</em>',
         'sucuriscan_notify_website_updated' => 'setting:' . 'Receive email alerts when the WordPress version is updated',
@@ -441,7 +440,6 @@ function sucuriscan_settings_alerts_events($nonce)
         $params['Alerts.NoAlertsVisibility'] = 'visible';
         unset($notify_options['sucuriscan_notify_success_login']);
         unset($notify_options['sucuriscan_notify_failed_login']);
-        unset($notify_options['sucuriscan_notify_failed_password']);
     }
 
     // Process form submission to change the alert settings.
@@ -449,11 +447,6 @@ function sucuriscan_settings_alerts_events($nonce)
         // Update the notification settings.
         if (SucuriScanRequest::post(':save_alert_events') !== false) {
             $ucounter = 0;
-
-            /* disable password tracker for failed logins as well */
-            if (SucuriScanRequest::post(':notify_failed_login') === '0') {
-                $_POST['sucuriscan_notify_failed_password'] = '0';
-            }
 
             foreach ($notify_options as $alert_type => $alert_label) {
                 $option_value = SucuriScanRequest::post($alert_type, '(1|0)');

--- a/src/settings-alerts.php
+++ b/src/settings-alerts.php
@@ -139,8 +139,8 @@ function sucuriscan_settings_alerts_trustedips()
         if ($trust_ip) {
             if (SucuriScan::isValidIP($trust_ip) || SucuriScan::isValidCIDR($trust_ip)) {
                 $ip_info = SucuriScan::getIPInfo($trust_ip);
-                $ip_info['added_at'] = time();
                 $cache_key = md5($ip_info['remote_addr']);
+                $ip_info['added_at'] = time();
 
                 if ($cache->exists($cache_key)) {
                     SucuriScanInterface::error('The IP specified address was already added.');

--- a/src/settings-general.php
+++ b/src/settings-general.php
@@ -476,7 +476,6 @@ function sucuriscan_settings_general_importexport($nonce)
     $params = array();
     $allowed = array(
         ':addr_header',
-        ':api_key',
         ':api_protocol',
         ':api_service',
         ':cloudproxy_apikey',

--- a/src/sucuriscan.lib.php
+++ b/src/sucuriscan.lib.php
@@ -906,4 +906,15 @@ class SucuriScan
     {
         return (bool) (stripos(@$_SERVER['SERVER_SOFTWARE'], 'Microsoft-IIS') !== false);
     }
+
+    /**
+     * Returns the md5 hash representing the content of a file.
+     *
+     * @param  string $file Relative path to the file.
+     * @return string       Seven first characters in the hash of the file.
+     */
+    public static function fileVersion($file = '')
+    {
+        return substr(md5_file(SUCURISCAN_PLUGIN_PATH . '/' . $file), 0, 7);
+    }
 }

--- a/src/sucuriscan.lib.php
+++ b/src/sucuriscan.lib.php
@@ -770,15 +770,15 @@ class SucuriScan
      */
     public static function isValidCIDR($remote_addr = '')
     {
-        $status = false;
-
-        if (preg_match('/^([0-9\.]{7,15})\/(8|16|24)$/', $remote_addr, $match)) {
-            if (self::isValidIP($match[1])) {
-                $status = true;
-            }
+        if (!is_string($remote_addr)) {
+            return false;
         }
 
-        return $status;
+        if (preg_match('/^([0-9\.]{7,15})\/(8|16|24)$/', $remote_addr, $match)) {
+            return self::isValidIP($match[1]);
+        }
+
+        return false;
     }
 
     /**

--- a/sucuri.php
+++ b/sucuri.php
@@ -234,7 +234,7 @@ require_once 'src/globals.php';
 
 /* Load WP-CLI command */
 if (defined('WP_CLI') && WP_CLI) {
-    require_once('src/cli.lib.php');
+    include_once 'src/cli.lib.php';
 }
 
 /**


### PR DESCRIPTION
#### Self-explanatory Changes

* Add support to export and import trusted IP addresses
* Add reverse ip address in all email alerts from visitor
* Add support for WP-CLI, initially with a command to generate the API key

#### Remove API key from the settings that can be exported

If an user is replicating the settings from website A into website B and the API key is among the options that can be imported, this will force website B to send all the security logs to the API service as if the events were triggered in website A. An user can always request a copy of the API key from the general settings so having this piece of data in the export list is not necessary.

#### Fix coding standard in CSS and JavaScript files

After the adoption of [Prettier](https://prettier.io), the opinionated code formatter for JavaScript files, I decided to fix the content of the main CSS and JS files, as well as the regeneration of the cache for the assets using an unique hash at the end of the URL, hash that is dynamically generated from the content of each file itself.

#### Add button to toggle the visibility of the post-types table

In some websites with a lot of plugins, the admin user is having a hard time to explore the settings page because the list of post-types available in the alerts panel is too big. When the admin user is not trying to whitelist or blacklist these post-types it makes no sense to show them. This commit hides the whole table and offers a button to toggle the visibility.

#### Remove option to log passwords during a failed login

This feature, added some time ago after multiple requests from the WordPress community, has been reviewed again this year by our security team and we determined that the benefits of knowing the password using during a failed login attempt are not enough to justify having such a dangerous logging mechanism.

The scenario used to justify the existence of this feature was that, if a malicious user was trying to brute force the account of one of the administrators, one of them could take a look at the logs and determine if the malicious user was getting close or not to the real password, in which case would decide to change it.

However, after the security review, we found that knowing the password used during a failed login attempt is not really useful and on the contrary opens a hole in the application as a legit admin user could mistakingly type the semi-correct password in the login form, the plugin will log the wrong credentials, and if the API key has been leaked, a malicious user could take this information to access the admin dashboard by making educated guesses over the mistyped password.