### PR TITLE
Fix invalid array when resetting the integrity cache

### DIFF
--- a/src/settings-integrity.php
+++ b/src/settings-integrity.php
@@ -101,7 +101,7 @@ class SucuriScanSettingsIntegrity extends SucuriScanSettings
             $deletedFiles = array();
             $files = SucuriScanRequest::post(':corefile_path', '_array');
 
-            foreach ($files as $path) {
+            foreach ((array) $files as $path) {
                 if ($cache->delete(md5($path))) {
                     $deletedFiles[] = $path;
                 }


### PR DESCRIPTION
In the settings page, under the panel with the list of files marked as fixed from the WordPress Integrity tool, there is a button to reset the list. The button is part of a form that is supposed to send a POST parameter named `"sucuriscan_ corefile_path"` as an array, the plugin walks through the array and removes the files marked as fixed from the cache. However, when the request is missing the parameter, the plugin fails to process the request because the iterator is expecting an array but is receiving a `"null"`.