### PR TITLE
Add positive confirmation for existing security headers

### DIFF
--- a/inc/tpl/sitecheck-recommendations.html.tpl
+++ b/inc/tpl/sitecheck-recommendations.html.tpl
@@ -1,6 +1,6 @@
 
-<div class="sucuriscan-panel sucuriscan-sitecheck-list sucuriscan-sitecheck-recommendations sucuriscan-%%SUCURI.Recommendations.Visibility%%">
-    <h3 class="sucuriscan-tag-title sucuriscan-tag-blue">Recomendations</h3>
+<div class="sucuriscan-panel sucuriscan-sitecheck-list sucuriscan-sitecheck-recommendations">
+    <h3 class="sucuriscan-tag-title sucuriscan-tag-%%SUCURI.Recommendations.Color%%">Recomendations</h3>
 
     <ul>
         %%%SUCURI.Recommendations.Content%%%

--- a/src/sitecheck.lib.php
+++ b/src/sitecheck.lib.php
@@ -332,9 +332,14 @@ class SucuriScanSiteCheck extends SucuriScanAPI
     {
         $params = array();
         $data = self::scanAndCollectData();
+        $sechead = array(
+            'x-content-type-options' => 'X-Content-Type-Options Header',
+            'x-frame-options' => 'X-Frame-Options Security Header',
+            'x-xss-protection' => 'X-XSS-Protection Security Header',
+        );
 
         $params['Recommendations.Content'] = '';
-        $params['Recommendations.Visibility'] = 'hidden';
+        $params['Recommendations.Color'] = 'green';
 
         if (isset($data['RECOMMENDATIONS'])) {
             foreach ($data['RECOMMENDATIONS'] as $recommendation) {
@@ -342,7 +347,19 @@ class SucuriScanSiteCheck extends SucuriScanAPI
                     continue;
                 }
 
-                $params['Recommendations.Visibility'] = 'visible';
+                if (stripos($recommendation[0], 'x-content-type')) {
+                    unset($sechead['x-content-type-options']);
+                }
+
+                if (stripos($recommendation[0], 'x-frame-options')) {
+                    unset($sechead['x-frame-options']);
+                }
+
+                if (stripos($recommendation[0], 'x-xss-protection')) {
+                    unset($sechead['x-xss-protection']);
+                }
+
+                $params['Recommendations.Color'] = 'blue';
                 $params['Recommendations.Content'] .= SucuriScanTemplate::getSnippet(
                     'sitecheck-recommendations',
                     array(
@@ -352,6 +369,12 @@ class SucuriScanSiteCheck extends SucuriScanAPI
                     )
                 );
             }
+        }
+
+        foreach ($sechead as $header => $message) {
+            $params['Recommendations.Content'] .=
+                '<li class="sucuriscan-sitecheck-list-INFO">'
+                . $message . '</li>';
         }
 
         return SucuriScanTemplate::getSection('sitecheck-recommendations', $params);


### PR DESCRIPTION
When SiteCheck detects that the website is missing one or more recommended security headers, the plugin displays an additional box on the right side of the dashboard with a link to the KB website explaining the important of such header(s). However, there is no positive feedback after the user adds the missing security headers and refreshes the malware scan cache. This pull-request adds checkmarks for the visible headers to notify the user that they have been set correctly.

<img width="348" alt="b" src="https://user-images.githubusercontent.com/1933999/42721162-96fad808-86ea-11e8-9f23-70826a4393f5.png">