### PR TITLE
Add logs in the function used to deactivate and uninstall the plugin

### DIFF
--- a/sucuri.php
+++ b/sucuri.php
@@ -252,6 +252,7 @@ function sucuriscanResetAndDeactivate()
 {
     /* Delete scheduled task from the system */
     wp_clear_scheduled_hook('sucuriscan_scheduled_scan');
+    SucuriScanEvent::reportDebugEvent('Sucuri plugin has been deactivated');
 }
 
 /**
@@ -303,6 +304,8 @@ function sucuriscanUninstall()
     $fifo->run_recursively = false;
     $directory = SucuriScan::dataStorePath();
     $fifo->removeDirectoryTree($directory);
+
+    SucuriScanEvent::reportDebugEvent('Sucuri plugin has been uninstalled');
 }
 
 register_deactivation_hook(__FILE__, 'sucuriscanResetAndDeactivate');


### PR DESCRIPTION
This is part of an on-going investigation to determine what is the cause of the random deletion of the plugin settings that some users have been reporting in the WordPress forums. The discussion is being tracked here:

https://wordpress.org/support/topic/sucuri-email-notifications-resetting/