### PR TITLE
Add additional type check in custom array implode

### DIFF
--- a/src/base.lib.php
+++ b/src/base.lib.php
@@ -877,6 +877,10 @@ class SucuriScan
      */
     public static function implode($separator = '', $list = array())
     {
+        if (!is_array($list)) {
+            return 'INVALID_ARGS';
+        }
+
         if (self::isMultiList($list)) {
             $pieces = array();
 


### PR DESCRIPTION
When the user visits **“Settings > Scanner > Scheduled Tasks”** the plugin calls a function provided by WordPress called `wp_get_schedules` which is supposed to return a list with all the active scheduled tasks (aka. cronjobs). According to the documentation, each item in the list has an attribute with the arguments that will be passed to the corresponding functions that will run once the cronjob is executed. This attribute is supposed to be an array, but in some cases the value uses a different data type which breaks the implode function.