### PR TITLE
Add dynamic core directories in the hardening whitelist option

### DIFF
--- a/inc/tpl/settings-hardening-whitelist-phpfiles.html.tpl
+++ b/inc/tpl/settings-hardening-whitelist-phpfiles.html.tpl
@@ -11,9 +11,7 @@
                 <label>File Path:</label>
                 <input type="text" name="sucuriscan_hardening_whitelist" placeholder="e.g. wp-tinymce.php" />
                 <select name="sucuriscan_hardening_folder">
-                    <option value="wp-includes">wp-includes</option>
-                    <option value="wp-content">wp-content</option>
-                    <option value="wp-content/uploads">wp-content/uploads</option>
+                    %%%SUCURI.HardeningWhitelist.AllowedFolders%%%
                 </select>
                 <button type="submit" class="button button-primary">Submit</button>
             </fieldset>

--- a/src/base.lib.php
+++ b/src/base.lib.php
@@ -273,13 +273,7 @@ class SucuriScan
      */
     public static function dataStorePath($path = '')
     {
-        if (defined('WP_CONTENT_DIR')) {
-            $content_dir = rtrim(WP_CONTENT_DIR, '/');
-        } else {
-            $content_dir = ABSPATH . '/wp-content';
-        }
-
-        $folder = $content_dir . '/uploads/sucuri';
+        $folder = WP_CONTENT_DIR . '/uploads/sucuri';
 
         /* custom path no matter its existence */
         if (defined('SUCURI_DATA_STORAGE')) {

--- a/src/fileinfo.lib.php
+++ b/src/fileinfo.lib.php
@@ -149,14 +149,16 @@ class SucuriScanFileInfo extends SucuriScan
      */
     private function ignoreFolder($path)
     {
+        $content = basename(WP_CONTENT_DIR);
+
         return (bool) ($this->ignore_directories && (
             strpos($path, '/.hg') !== false
             || strpos($path, '/.git') !== false
             || strpos($path, '/.svn') !== false
-            || strpos($path, 'wp-content/backup') !== false
-            || strpos($path, 'wp-content/cache') !== false
-            || strpos($path, 'wp-content/uploads') !== false
-            || strpos($path, 'wp-content/w3tc') !== false
+            || strpos($path, $content . '/backup') !== false
+            || strpos($path, $content . '/cache') !== false
+            || strpos($path, $content . '/uploads') !== false
+            || strpos($path, $content . '/w3tc') !== false
         ));
     }
 
@@ -347,11 +349,13 @@ class SucuriScanFileInfo extends SucuriScan
             return self::throwException('Directory does not exists');
         }
 
-        if ($directory === ABSPATH . 'wp-content') {
+        if ($directory === WP_CONTENT_DIR) {
             return self::throwException('Cannot delete content directory');
         }
 
-        if ($directory === ABSPATH . 'wp-content/uploads') {
+        $upload_dir = wp_upload_dir();
+
+        if ($directory === $upload_dir['basedir']) {
             return self::throwException('Cannot delete uploads directory');
         }
 

--- a/src/settings-hardening.php
+++ b/src/settings-hardening.php
@@ -669,12 +669,15 @@ class SucuriScanHardeningPage extends SucuriScan
     {
         $params = array(
             'HardeningWhitelist.List' => '',
+            'HardeningWhitelist.AllowedFolders' => '',
             'HardeningWhitelist.NoItemsVisibility' => 'visible',
         );
+
+        $upload_dir = wp_upload_dir();
         $allowed_folders = array(
-            'wp-includes',
-            'wp-content',
-            'wp-content/uploads',
+            rtrim(ABSPATH, '/') . '/' . WPINC,
+            WP_CONTENT_DIR,
+            $upload_dir['basedir']
         );
 
         if (SucuriScanInterface::checkNonce()) {
@@ -713,6 +716,12 @@ class SucuriScanHardeningPage extends SucuriScan
         // Read the access control file and retrieve the whitelisted files.
         foreach ($allowed_folders as $folder) {
             $files = SucuriScanHardening::getWhitelisted($folder);
+
+            $params['HardeningWhitelist.AllowedFolders'] .= sprintf(
+                '<option value="%s">%s</option>',
+                SucuriScan::escape($folder),
+                SucuriScan::escape($folder)
+            );
 
             if (is_array($files) && !empty($files)) {
                 $params['HardeningWhitelist.NoItemsVisibility'] = 'hidden';

--- a/sucuri.php
+++ b/sucuri.php
@@ -59,7 +59,7 @@ foreach ($sucuriscan_dependencies as $dependency) {
 }
 
 /* check if installation path is available */
-if (!defined('ABSPATH')) {
+if (!defined('ABSPATH') || !defined('WP_CONTENT_DIR')) {
     /* Report invalid access if possible. */
     header('HTTP/1.1 403 Forbidden');
     exit(0);


### PR DESCRIPTION
When the website owner decides to rename the content or uploads directory, they find that the plugin stops offering the option to whitelist the execution of PHP files in the aforementioned folders, this is because the path is hardcoded in the HTML files. This pull-request also includes the replacement of some hardcoded references to the `wp-content` directory with the standard `WP_CONTENT_DIR` constant.

Reference: https://wordpress.org/support/topic/i-cannot-use-whitelist-blocked-php-files-function/