### PR TITLE
Ignore new JSON based language files after WordPress 5.x

### DIFF
--- a/src/integrity.lib.php
+++ b/src/integrity.lib.php
@@ -668,6 +668,7 @@ class SucuriScanIntegrity
             '^pinterest-[0-9a-z]{5}\.html$',
             '^wp-content\/languages\/.+\.mo$',
             '^wp-content\/languages\/.+\.po$',
+            '^wp-content\/languages\/.+\.json$',
             '\.ico$',
         );
 


### PR DESCRIPTION
Since version 5.0, WordPress stores some JSON files in `/wp-content/languages`. Unfortunately, these aren’t being excluded from the core integrity checks in the way that `.mo` and `.po` files are, resulting in false positives.

Reference: https://wordpress.org/support/topic/not-compatible-with-the-new-javascript-i18n-support-in-wordpress-5-0/