### PR TITLE
Fix regex in template string replacement

### DIFF
--- a/src/template.lib.php
+++ b/src/template.lib.php
@@ -83,7 +83,7 @@ class SucuriScanTemplate extends SucuriScanRequest
 
         global $locale;
 
-        preg_match_all('~{{(.+)}}~', $content, $matches);
+        preg_match_all('~{{(.+?)}}~', $content, $matches);
 
         if ( ! empty( $matches[1] ) ) {
             foreach($matches[1] as $string) {

--- a/src/template.lib.php
+++ b/src/template.lib.php
@@ -86,10 +86,10 @@ class SucuriScanTemplate extends SucuriScanRequest
         preg_match_all('~{{(.+?)}}~', $content, $matches);
 
         if ( ! empty( $matches[1] ) ) {
-            foreach($matches[1] as $string) {
-                $pattern = sprintf('~{{%s}}~', preg_quote($string, '~'));
-                $replacement = ('en_US' !== $locale) ? translate($string, 'sucuri-scanner') : $string;
-                $content = preg_replace($pattern, $replacement, $content);
+            foreach($matches[1] as $index => $string) {
+                $search  = $matches[0][$index];
+                $replace = ('en_US' !== $locale) ? translate($string, 'sucuri-scanner') : $string;
+                $content = str_replace($search, $replace, $content);
             }
         }
 


### PR DESCRIPTION
- Multiple matches per line should be supported
- Regex replacement was unnecessary overhead

<img width="297" alt="screenshot 2019-03-01 13 30 12" src="https://user-images.githubusercontent.com/522158/53662558-cd2abf80-3c28-11e9-9bf5-774536910cfc.png">