### PR TITLE
Make template match ungreedy

### DIFF
--- a/src/template.lib.php
+++ b/src/template.lib.php
@@ -83,10 +83,10 @@ class SucuriScanTemplate extends SucuriScanRequest
 
         global $locale;
 
-        preg_match_all('~{{(.+)}}~', $content, $matches);
+        preg_match_all('~{{(.+?)}}~', $content, $matches);
 
-        if ( ! empty( $matches[1] ) ) {
-            foreach($matches[1] as $string) {
+        if (! empty($matches[1])) {
+            foreach ($matches[1] as $string) {
                 $pattern = sprintf('~{{%s}}~', preg_quote($string, '~'));
                 $replacement = ('en_US' !== $locale) ? translate($string, 'sucuri-scanner') : $string;
                 $content = preg_replace($pattern, $replacement, $content);


### PR DESCRIPTION
This PR proposes a fix to a greedy match that must be causing the templating issue shown below, found in a Brazilian WP website that uses the Sucuri plugin:

<img width="823" alt="Screen Shot 2019-03-25 at 10 41 39 AM" src="https://user-images.githubusercontent.com/506789/54924196-9889eb00-4eea-11e9-856d-a9f00edd4c29.png">

The other line formatting fixes are result of an automatic PSR-2 fix, which I believe are harmless.