### PR TITLE
1.8.21

### DIFF
--- a/inc/tpl/base.html.tpl
+++ b/inc/tpl/base.html.tpl
@@ -17,7 +17,7 @@
 
         <div class="sucuriscan-pull-right sucuriscan-navbar">
             <ul>
-                <li><a href="https://goo.gl/aByqP5" target="_blank" rel="noopener" class="button button-secondary">{{Review}}</a></li>
+                <li><a href="https://wordpress.org/support/plugin/sucuri-scanner/reviews/" target="_blank" rel="noopener" class="button button-secondary">{{Review}}</a></li>
 
                 <li class="sucuriscan-%%SUCURI.GenerateAPIKey.Visibility%%">
                     <a href="#" class="button button-primary sucuriscan-modal-button sucuriscan-register-site-button"

--- a/inc/tpl/dashboard.html.tpl
+++ b/inc/tpl/dashboard.html.tpl
@@ -84,5 +84,7 @@ jQuery(document).ready(function ($) {
         %%%SUCURI.SiteCheck.Blacklist%%%
 
         %%%SUCURI.SiteCheck.Recommendations%%%
+        
+        %%%SUCURI.WordPress.Recommendations%%%
     </div>
 </div>

--- a/inc/tpl/lastlogins-failedlogins.html.tpl
+++ b/inc/tpl/lastlogins-failedlogins.html.tpl
@@ -36,8 +36,7 @@
                     </tr>
                 </tbody>
             </table>
-
-            <button type="submit" class="button button-primary">{{Block}}</button>
+            
         </form>
     </div>
 </div>

--- a/inc/tpl/settings-general-timezone.html.tpl
+++ b/inc/tpl/settings-general-timezone.html.tpl
@@ -1,6 +1,6 @@
 
 <div class="sucuriscan-panel">
-    <h3 class="sucuriscan-title">{{Timezone}}</h3>
+    <h3 class="sucuriscan-title">{{Timezone Override}}</h3>
 
     <div class="inside">
         <p>{{This option defines the timezone that will be used through out the entire plugin to print the dates and times whenever is necessary. This option also affects the date and time of the logs visible in the audit logs panel which is data that comes from a remote server configured to use Eastern Daylight Time (EDT). WordPress offers an option in the general settings page to allow you to configure the timezone for the entire website, however, if you are experiencing problems with the time in the audit logs, this option will help you fix them.}}</p>

--- a/inc/tpl/wordpress-recommendations.html.tpl
+++ b/inc/tpl/wordpress-recommendations.html.tpl
@@ -1,0 +1,8 @@
+
+<div class="sucuriscan-panel sucuriscan-sitecheck-list sucuriscan-sitecheck-recommendations sucuriscan-wordpress-recommendations">
+    <h3 class="sucuriscan-tag-title sucuriscan-tag-%%SUCURI.WordPress.Recommendations.Color%%">{{WordPress Security Recommendations}}</h3>
+
+    <ul>
+        %%%SUCURI.WordPress.Recommendations.Content%%%
+    </ul>
+</div>

--- a/inc/tpl/wordpress-recommendations.snippet.tpl
+++ b/inc/tpl/wordpress-recommendations.snippet.tpl
@@ -1,0 +1,5 @@
+
+<li class="sucuriscan-sitecheck-list-NOTICE">
+        <b>%%SUCURI.WordPress.Recommendations.Title%%</b><br>
+        <span>%%SUCURI.WordPress.Recommendations.Value%%</span>
+</li>

--- a/lang/sucuri-scanner.pot
+++ b/lang/sucuri-scanner.pot
@@ -1373,7 +1373,7 @@ msgstr ""
 #: src/settings-hardening.php:102
 msgid ""
 "The firewall is a premium service that you need purchase at - <a href="
-"\"https://goo.gl/qfNkMq\" target=\"_blank\">Sucuri Firewall</a>"
+"\"https://sucuri.net/website-firewall/signup\" target=\"_blank\">Sucuri Firewall</a>"
 msgstr ""
 
 #: src/settings-hardening.php:107

--- a/lang/sucuri-scanner.pot
+++ b/lang/sucuri-scanner.pot
@@ -1080,7 +1080,7 @@ msgid "The alert settings have been updated"
 msgstr ""
 
 #: src/settings-alerts.php:542
-msgid "Only lowercase letters, underscores and hyphens are allowed."
+msgid "Only lowercase letters, numbers, underscores and hyphens are allowed. Post Types cannot exceed 20 characters as well."
 msgstr ""
 
 #: src/settings-alerts.php:544

--- a/lang/sucuri-scanner.pot
+++ b/lang/sucuri-scanner.pot
@@ -2799,7 +2799,7 @@ msgid "File Path:"
 msgstr ""
 
 #: src/strings.php:366
-msgid "Timezone"
+msgid "Timezone Override"
 msgstr ""
 
 #: src/strings.php:367

--- a/lang/sucuri-scanner.pot
+++ b/lang/sucuri-scanner.pot
@@ -59,12 +59,12 @@ msgstr ""
 msgid "API key recovery for domain: %s"
 msgstr ""
 
-#: src/api.lib.php:609
+#: src/api.lib.php:648
 #, php-format
 msgid "WP Engine PHP Compatibility Checker: %s (created post #%d as cache)"
 msgstr ""
 
-#: src/api.lib.php:952 src/api.lib.php:957
+#: src/api.lib.php:991 src/api.lib.php:994
 msgid "WordPress version is not supported anymore"
 msgstr ""
 
@@ -3203,8 +3203,26 @@ msgstr ""
 msgid "Malware Scan Target:"
 msgstr ""
 
+#: src/strings.php:526
+msgid "WordPress Security Recommendations"
+msgstr ""
+
 #: src/template.lib.php:277
 msgid "Invalid template type"
+msgstr ""
+
+#: src/wordpress-recommendations.php:62
+msgid "Upgrade PHP to a supported version"
+msgstr ""
+
+#: src/wordpress-recommendations.php:63
+msgid "The PHP version you are using no longer receives security support and could be exposed to unpatched security vulnerabilities."
+msgstr ""
+
+#: src/wordpress-recommendations.php:76
+msgid ""
+"Your WordPress install is following <a href=\"https://sucuri.net/guides/wordpress-security\" target=\"_blank\" rel=\"noopener\">"
+"the security best practices</a>."
 msgstr ""
 
 #: sucuri.php:316

--- a/readme.txt
+++ b/readme.txt
@@ -190,6 +190,15 @@ This version adds an option to refresh the malware scan results on demand, as we
 
 == Changelog ==
 
+= 1.8.21 =
+* Replace goo.gl links
+* Fix post_type pattern match
+* Removed block button from failed logins page
+* Fixed Audit Logs queue timezone issue
+* Added WordPress security recommendations library
+* Added php version check
+* Updated translation file to match the changes
+
 = 1.8.20 =
 * Add dynamic core directories in the hardening whitelist options
 * Modify scheduled tasks panel to load the table via Ajax

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate Link: https://sucuri.net/
 Tags: malware, security, firewall, scan, spam, virus, sucuri, protection, blacklist, detection, hardening, file integrity
 Requires at least: 3.6
 Tested up to: 5.0.3
-Stable tag: 1.8.20
+Stable tag: 1.8.21
 
 The Sucuri WordPress Security plugin is a security toolset for security integrity monitoring, malware detection and security hardening.
 
@@ -191,13 +191,15 @@ This version adds an option to refresh the malware scan results on demand, as we
 == Changelog ==
 
 = 1.8.21 =
-* Replace goo.gl links
-* Fix post_type pattern match
-* Removed block button from failed logins page
-* Fixed Audit Logs queue timezone issue
-* Added WordPress security recommendations library
-* Added php version check
-* Updated translation file to match the changes
+* Add WordPress Security Recommendations section in the dashboard
+* Add PHP version check
+* Fix goo.gl links
+* Fix post_type pattern match to allow numbers and max of 20 chars
+* Fix Audit Logs queue timezone issue
+* Fix regex in template string replacement
+* Update translation file to include WordPress Security Recommendations section fields
+* Make the menu icon use the menu color styling
+* Remove block button from failed logins page
 
 = 1.8.20 =
 * Add dynamic core directories in the hardening whitelist options

--- a/src/pagehandler.php
+++ b/src/pagehandler.php
@@ -50,6 +50,9 @@ function sucuriscan_page()
     $params['SiteCheck.Malware'] = '<div id="sucuriscan-malware"></div>';
     $params['SiteCheck.Blacklist'] = '<div id="sucuriscan-blacklist"></div>';
     $params['SiteCheck.Recommendations'] = '<div id="sucuriscan-recommendations"></div>';
+    
+    /* load data for the WordPress best practices section */
+    $params['WordPress.Recommendations'] = SucuriWordPressRecomendations::pageWordPressRecommendations();
 
     if (SucuriScanRequest::get(':sitecheck_refresh') !== false) {
         $params['SiteCheck.Refresh'] = 'true';

--- a/src/settings-alerts.php
+++ b/src/settings-alerts.php
@@ -538,8 +538,8 @@ function sucuriscan_settings_alerts_ignore_posts()
         $selected = SucuriScanRequest::post(':posttypes', '_array');
 
         if ($action === 'add') {
-            if (!preg_match('/^[a-z_\-]+$/', $ignore_rule)) {
-                SucuriScanInterface::error(__('Only lowercase letters, underscores and hyphens are allowed.', 'sucuri-scanner'));
+            if (!preg_match('/^[a-z0-9_\-]{1,20}+$/', $ignore_rule)) {
+                SucuriScanInterface::error(__('Only lowercase letters, numbers, underscores and hyphens are allowed. Post Types cannot exceed 20 characters as well.', 'sucuri-scanner'));
             } elseif (array_key_exists($ignore_rule, $ignored_events)) {
                 SucuriScanInterface::error(__('The post-type is already being ignored (duplicate).', 'sucuri-scanner'));
             } else {

--- a/src/settings-general.php
+++ b/src/settings-general.php
@@ -638,7 +638,7 @@ function sucuriscan_settings_general_timezone($nonce)
         $fill = (abs($hour) < 10) ? '0' : '';
         $keyname = sprintf('UTC%s%s%.2f', $sign, $fill, abs($hour));
         $label = date('d M, Y H:i:s', $current + ($hour * 3600));
-        $options[$keyname] = $label;
+        $options[$keyname] = $keyname . ' (' . $label . ')';
     }
 
     if ($nonce) {

--- a/src/settings-hardening.php
+++ b/src/settings-hardening.php
@@ -99,7 +99,7 @@ class SucuriScanHardeningPage extends SucuriScan
 
         if (self::processRequest(__FUNCTION__)) {
             SucuriScanInterface::error(
-                __('The firewall is a premium service that you need purchase at - <a href="https://goo.gl/qfNkMq" target="_blank">Sucuri Firewall</a>', 'sucuri-scanner')
+                __('The firewall is a premium service that you need purchase at - <a href="https://sucuri.net/website-firewall/signup" target="_blank">Sucuri Firewall</a>', 'sucuri-scanner')
             );
         }
 

--- a/src/settings-hardening.php
+++ b/src/settings-hardening.php
@@ -77,10 +77,8 @@ class SucuriScanHardeningPage extends SucuriScan
      */
     private static function processRequest($function)
     {
-        return (bool) (
-            SucuriScanInterface::checkNonce() /* CSRF protection */
-            && SucuriScanRequest::post(':hardening_' . $function)
-        );
+        return (bool)(SucuriScanInterface::checkNonce() /* CSRF protection */
+            && SucuriScanRequest::post(':hardening_' . $function));
     }
 
     /**
@@ -184,7 +182,7 @@ class SucuriScanHardeningPage extends SucuriScan
         $params['Hardening.Title'] = __('Verify PHP Version', 'sucuri-scanner');
         $params['Hardening.Description'] = sprintf(__('PHP %s is installed.', 'sucuri-scanner'), PHP_VERSION);
 
-        if (intval(version_compare(PHP_VERSION, '5.6.0') >= 0)) {
+        if (intval(version_compare(PHP_VERSION, '7.1.0') >= 0)) {
             $params['Hardening.Status'] = 1;
             $params['Hardening.FieldAttrs'] = 'disabled';
             $params['Hardening.FieldText'] = __('Revert Hardening', 'sucuri-scanner');
@@ -512,7 +510,7 @@ class SucuriScanHardeningPage extends SucuriScan
     public static function fileeditor()
     {
         $params = array();
-        $fileEditorWasDisabled = (bool) (defined('DISALLOW_FILE_EDIT') && DISALLOW_FILE_EDIT);
+        $fileEditorWasDisabled = (bool)(defined('DISALLOW_FILE_EDIT') && DISALLOW_FILE_EDIT);
 
         if (self::processRequest(__FUNCTION__)) {
             $config = SucuriScan::getConfigPath();

--- a/src/strings.php
+++ b/src/strings.php
@@ -521,3 +521,6 @@ __('The remote malware scanner provided by the plugin is powered by <a href="htt
 __('Malware Scan Target', 'sucuri-scanner');
 __('Malware Scan Target:', 'sucuri-scanner');
 __('Submit', 'sucuri-scanner');
+
+// wordpress-recommendations.html.tpl
+__('WordPress Security Recommendations', 'sucuri-scanner');

--- a/src/strings.php
+++ b/src/strings.php
@@ -363,7 +363,7 @@ __('File Path:', 'sucuri-scanner');
 __('Submit', 'sucuri-scanner');
 
 // settings-general-timezone.html.tpl
-__('Timezone', 'sucuri-scanner');
+__('Timezone Override', 'sucuri-scanner');
 __('This option defines the timezone that will be used through out the entire plugin to print the dates and times whenever is necessary. This option also affects the date and time of the logs visible in the audit logs panel which is data that comes from a remote server configured to use Eastern Daylight Time (EDT). WordPress offers an option in the general settings page to allow you to configure the timezone for the entire website, however, if you are experiencing problems with the time in the audit logs, this option will help you fix them.', 'sucuri-scanner');
 __('Timezone:', 'sucuri-scanner');
 __('Submit', 'sucuri-scanner');

--- a/src/wordpress-recommendations.lib.php
+++ b/src/wordpress-recommendations.lib.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Code related to the wprecommendations.lib.php checks.
+ *
+ * PHP version 5
+ *
+ * @category   Library
+ * @package    Sucuri
+ * @subpackage SucuriScanner
+ * @author     Northon Torga <northon.torga@sucuri.net>
+ * @copyright  2010-2019 Sucuri Inc.
+ * @license    https://www.gnu.org/licenses/gpl-2.0.txt GPL2
+ * @link       https://wordpress.org/plugins/sucuri-scanner
+ */
+
+if (!defined('SUCURISCAN_INIT') || SUCURISCAN_INIT !== true) {
+    if (!headers_sent()) {
+        /* Report invalid access if possible. */
+        header('HTTP/1.1 403 Forbidden');
+    }
+    exit(1);
+}
+
+/**
+ * Make sure the WordPress install follows security best practices.
+ *
+ * @category   Library
+ * @package    Sucuri
+ * @subpackage SucuriScanner
+ * @author     Northon Torga <northon.torga@sucuri.net>
+ * @copyright  2010-2019 Sucuri Inc.
+ * @license    https://www.gnu.org/licenses/gpl-2.0.txt GPL2
+ * @link       https://wordpress.org/plugins/sucuri-scanner
+ * @see        https://sitecheck.sucuri.net/
+ */
+class SucuriWordPressRecomendations
+{
+    
+    /**
+     * Generates the HTML section for the WordPress recommendations section.
+     *
+     * @return string HTML code to render the recommendations section.
+     */
+    public static function pageWordPressRecommendations()
+    {
+        
+        $params = array();
+        $recommendations = array();
+        $params['WordPress.Recommendations.Content'] = '';
+        
+        /**
+         * BEGIN security checks.
+         * 
+         * Each check must register a second array inside $recommendations,
+         * containing the title and description of the recommendation.
+         */
+
+        // Check if php version needs to be upgraded.
+        if (defined('PHP_MAJOR_VERSION') && PHP_MAJOR_VERSION <= 5) {
+            $recommendations['PHPVersionCheck'] = array(
+                __('Upgrade PHP to a supported version', 'sucuri-scanner') => 
+                __('The PHP version you are using no longer receives security support and could be exposed to unpatched security vulnerabilities.', 'sucuri-scanner')
+            );
+        }
+        
+        /**
+         * BEGIN delivery of results.
+         * 
+         * When recommendations array is empty, delivery an "all is good" message,
+         * otherwise display each item that needs fixing individually.
+        */
+        if(count($recommendations) == 0) {
+            
+            $params['WordPress.Recommendations.Color'] = 'green';
+            $params['WordPress.Recommendations.Content'] = __('Your WordPress install is following <a href="https://sucuri.net/guides/wordpress-security" target="_blank" rel="noopener">the security best practices</a>.', 'sucuri-scanner');
+
+        } else {
+
+            /* set title to blue as not all recommendations have been fullfilled */
+            $params['WordPress.Recommendations.Color'] = 'blue';
+
+            /* delivery the recommendations using the getSnippet function */
+            $recommendation = array_keys($recommendations);
+            foreach ($recommendation as $checkid) {
+
+                foreach ($recommendations[$checkid] as $title => $description) {
+
+                    $params['WordPress.Recommendations.Content'] .= SucuriScanTemplate::getSnippet(
+                        'wordpress-recommendations',
+                        array(
+                            'WordPress.Recommendations.Title' => $title,
+                           'WordPress.Recommendations.Value' => $description
+                        )
+                    );
+
+                }
+
+            }
+
+        }
+
+        return SucuriScanTemplate::getSection('wordpress-recommendations', $params);
+
+    }
+}

--- a/src/wordpress-recommendations.lib.php
+++ b/src/wordpress-recommendations.lib.php
@@ -36,7 +36,7 @@ if (!defined('SUCURISCAN_INIT') || SUCURISCAN_INIT !== true) {
  */
 class SucuriWordPressRecomendations
 {
-    
+
     /**
      * Generates the HTML section for the WordPress recommendations section.
      *
@@ -44,11 +44,11 @@ class SucuriWordPressRecomendations
      */
     public static function pageWordPressRecommendations()
     {
-        
+
         $params = array();
         $recommendations = array();
         $params['WordPress.Recommendations.Content'] = '';
-        
+
         /**
          * BEGIN security checks.
          * 
@@ -57,24 +57,23 @@ class SucuriWordPressRecomendations
          */
 
         // Check if php version needs to be upgraded.
-        if (defined('PHP_MAJOR_VERSION') && PHP_MAJOR_VERSION <= 5) {
+        if (version_compare(phpversion(), '7.1', '<')) {
             $recommendations['PHPVersionCheck'] = array(
-                __('Upgrade PHP to a supported version', 'sucuri-scanner') => 
+                __('Upgrade PHP to a supported version', 'sucuri-scanner') =>
                 __('The PHP version you are using no longer receives security support and could be exposed to unpatched security vulnerabilities.', 'sucuri-scanner')
             );
         }
-        
+
         /**
          * BEGIN delivery of results.
          * 
          * When recommendations array is empty, delivery an "all is good" message,
          * otherwise display each item that needs fixing individually.
-        */
-        if(count($recommendations) == 0) {
-            
+         */
+        if (count($recommendations) == 0) {
+
             $params['WordPress.Recommendations.Color'] = 'green';
             $params['WordPress.Recommendations.Content'] = __('Your WordPress install is following <a href="https://sucuri.net/guides/wordpress-security" target="_blank" rel="noopener">the security best practices</a>.', 'sucuri-scanner');
-
         } else {
 
             /* set title to blue as not all recommendations have been fullfilled */
@@ -90,17 +89,13 @@ class SucuriWordPressRecomendations
                         'wordpress-recommendations',
                         array(
                             'WordPress.Recommendations.Title' => $title,
-                           'WordPress.Recommendations.Value' => $description
+                            'WordPress.Recommendations.Value' => $description
                         )
                     );
-
                 }
-
             }
-
         }
 
         return SucuriScanTemplate::getSection('wordpress-recommendations', $params);
-
     }
 }

--- a/sucuri.php
+++ b/sucuri.php
@@ -8,7 +8,7 @@
  * Author: Sucuri Inc.
  * Text Domain: sucuri-scanner
  * Domain Path: /lang
- * Version: 1.8.20
+ * Version: 1.8.21
  *
  * PHP version 5
  *
@@ -85,7 +85,7 @@ define('SUCURISCAN', 'sucuriscan');
 /**
  * Current version of the plugin's code.
  */
-define('SUCURISCAN_VERSION', '1.8.20');
+define('SUCURISCAN_VERSION', '1.8.21');
 
 /**
  * Defines the human readable name of the plugin.
@@ -218,6 +218,7 @@ require_once 'src/hardening.lib.php';
 require_once 'src/interface.lib.php';
 require_once 'src/auditlogs.lib.php';
 require_once 'src/sitecheck.lib.php';
+require_once 'src/wordpress-recommendations.lib.php';
 require_once 'src/integrity.lib.php';
 require_once 'src/firewall.lib.php';
 require_once 'src/installer-skin.lib.php';


### PR DESCRIPTION
1) "goo.gl" links have been discontinued:
https://developers.googleblog.com/2018/03/transitioning-google-url-shortener.html

2) According to [WP Codex](https://codex.wordpress.org/Post_Types), there is no reason to restrict numbers on post types and it cannot have more than 20 chars, thus the regex was updated to match the proper restriction.

3) The Block button on Failed Logins has no action, it must be removed.

4) The timezone of audit logs was broken cause the logs from the queue were being parsed using EDT instead of respecting the timezone override or the WordPress default timezone.

5) Add WordPress Security Recommendations library.

6) Increment plugin version.