### PR TITLE
1.8.22

### DIFF
--- a/inc/css/styles.css
+++ b/inc/css/styles.css
@@ -576,7 +576,10 @@ body.sucuri-security_page_sucuriscan_hardening {
 .sucuriscan-auditlog-critical path {
     fill: #000;
 }
-.sucuriscan-container .sucuriscan-table {
+.sucuriscan-container .sucuriscan-table,
+.sucuriscan-container .sucuriscan-panel table.sucuriscan-last-logins,
+.sucuriscan-container .sucuriscan-panel table.sucuriscan-lastlogins-failed
+{
     margin-bottom: 20px;
 }
 .sucuriscan-container .sucuriscan-table:last-child {

--- a/inc/tpl/lastlogins-all.html.tpl
+++ b/inc/tpl/lastlogins-all.html.tpl
@@ -39,4 +39,9 @@
             </tbody>
         </table>
     </div>
+    <form action="%%SUCURI.URL.Lastlogins%%#allusers" method="post">
+        <input type="hidden" name="sucuriscan_page_nonce" value="%%SUCURI.PageNonce%%" />
+        <input type="hidden" name="sucuriscan_delete_lastlogins" value="1" />
+        <input type="submit" value="{{Delete}}" class="button button-primary" />
+    </form>
 </div>

--- a/inc/tpl/lastlogins-failedlogins.html.tpl
+++ b/inc/tpl/lastlogins-failedlogins.html.tpl
@@ -38,5 +38,10 @@
             </table>
             
         </form>
+        <form action="%%SUCURI.URL.Lastlogins%%#failed" method="post">
+        <input type="hidden" name="sucuriscan_page_nonce" value="%%SUCURI.PageNonce%%" />
+        <input type="hidden" name="sucuriscan_delete_failedlogins" value="1" />
+        <input type="submit" value="{{Delete}}" class="button button-primary" />
+    </form>
     </div>
 </div>

--- a/inc/tpl/lastlogins.html.tpl
+++ b/inc/tpl/lastlogins.html.tpl
@@ -4,7 +4,7 @@
         <li><a href="%%SUCURI.URL.Lastlogins%%#allusers">{{All Users}}</a></li>
         <li><a href="%%SUCURI.URL.Lastlogins%%#admins">{{Admins}}</a></li>
         <li><a href="%%SUCURI.URL.Lastlogins%%#loggedin">{{Logged-in Users}}</a></li>
-        <li><a href="%%SUCURI.URL.Lastlogins%%#failed">{{Failed logins}}</a></li>
+        <li><a href="%%SUCURI.URL.Lastlogins%%#failed">{{Failed Logins}}</a></li>
     </ul>
 
     <div class="sucuriscan-tabs-containers">

--- a/inc/tpl/settings-webinfo-htaccess.html.tpl
+++ b/inc/tpl/settings-webinfo-htaccess.html.tpl
@@ -13,6 +13,10 @@
             <p>{{Your website has no <code>.htaccess</code> file or it was not found in the default location.}}</p>
         </div>
 
+        <div class="sucuriscan-inline-alert-info sucuriscan-%%SUCURI.HTAccess.NotApache%%">
+            <p>{{Your web server does not support .htaccess files.}}</p>
+        </div>
+
         <div class="sucuriscan-inline-alert-info sucuriscan-%%SUCURI.HTAccess.StandardVisible%%">
             <p>{{The main <code>.htaccess</code> file in your site has the standard rules for a WordPress installation. You can customize it to improve the performance and change the behaviour of the redirections for pages and posts in your site. To get more information visit the official documentation at <a target="_blank" rel="noopener" href="https://codex.wordpress.org/Using_Permalinks#Creating_and_editing_.28.htaccess.29"> Codex WordPress - Creating and editing (.htaccess)</a>}}</p>
         </div>

--- a/inc/tpl/settings.html.tpl
+++ b/inc/tpl/settings.html.tpl
@@ -48,8 +48,6 @@
 
                     %%%SUCURI.Settings.Hardening.WPVersion%%%
 
-                    %%%SUCURI.Settings.Hardening.PHPVersion%%%
-
                     %%%SUCURI.Settings.Hardening.RemoveGenerator%%%
 
                     %%%SUCURI.Settings.Hardening.NginxPHPFPM%%%

--- a/lang/sucuri-scanner.pot
+++ b/lang/sucuri-scanner.pot
@@ -184,6 +184,21 @@ msgstr ""
 msgid "Password Change"
 msgstr ""
 
+#: src/event.lib.php:752
+#, php-format
+msgid "%s is empty or can not be deleted."
+msgstr ""
+
+#: src/event.lib.php:764
+#, php-format
+msgid "%s was deleted."
+msgstr ""
+
+#: src/event.lib.php:770
+#, php-format
+msgid "%s was deleted. Please refresh this page."
+msgstr ""
+
 #: src/fileinfo.lib.php:291
 msgid "No files were found"
 msgstr ""
@@ -1286,9 +1301,14 @@ msgid ""
 "of these IPs will not be reported to the remote monitoring API service."
 msgstr ""
 
-#: src/settings-general.php:211
+#: src/settings-general.php:212
 #, php-format
-msgid "%d out of %d files has been deleted"
+msgid "%s were deleted."
+msgstr ""
+
+#: src/settings-general.php:219
+#, php-format
+msgid "%d out of %d files has been deleted."
 msgstr ""
 
 #: src/settings-general.php:229 src/settings-posthack.php:308
@@ -1958,7 +1978,7 @@ msgstr ""
 
 #: src/strings.php:74 src/strings.php:88 src/strings.php:256
 #: src/strings.php:276 src/strings.php:318 src/strings.php:329
-#: src/strings.php:381
+#: src/strings.php:381 src/strings.php:172 src/strings.php:186
 msgid "Delete"
 msgstr ""
 

--- a/lang/sucuri-scanner.pot
+++ b/lang/sucuri-scanner.pot
@@ -2,9 +2,8 @@
 msgid ""
 msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
-"Project-Id-Version: Sucuri Security - Auditing, Malware Scanner and "
-"Hardening\n"
-"POT-Creation-Date: 2019-02-18 18:58-0700\n"
+"Project-Id-Version: Sucuri Security - Auditing, Malware Scanner and Hardening\n"
+"POT-Creation-Date: 2019-08-26 17:12-0500\n"
 "PO-Revision-Date: 2019-02-07 02:39-0600\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -15,9 +14,8 @@ msgstr ""
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-WPHeader: sucuri.php\n"
 "X-Poedit-SourceCharset: UTF-8\n"
-"X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;"
-"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;"
-"_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
+"X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;"
+"esc_html_e;esc_html_x:1,2c;_n_noop:1,2;_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
 "X-Poedit-SearchPath-0: .\n"
 "X-Poedit-SearchPathExcluded-0: *.js\n"
 
@@ -64,7 +62,7 @@ msgstr ""
 msgid "WP Engine PHP Compatibility Checker: %s (created post #%d as cache)"
 msgstr ""
 
-#: src/api.lib.php:991 src/api.lib.php:994
+#: src/api.lib.php:991 src/api.lib.php:996
 msgid "WordPress version is not supported anymore"
 msgstr ""
 
@@ -101,8 +99,7 @@ msgstr ""
 msgid "Info:"
 msgstr ""
 
-#: src/cache.lib.php:392 src/cache.lib.php:412 src/cache.lib.php:453
-#: src/cache.lib.php:470
+#: src/cache.lib.php:392 src/cache.lib.php:412 src/cache.lib.php:453 src/cache.lib.php:470
 msgid "Invalid cache key name"
 msgstr ""
 
@@ -165,38 +162,34 @@ msgstr ""
 msgid ""
 "<br><br>\n"
 "\n"
-"<em>Explanation: Someone failed to login to your site. If you are getting "
-"too many of these messages, it is likely your site is under a password "
-"guessing brute-force attack [1]. You can disable the failed login alerts "
-"from here [2]. Alternatively, you can consider to install a firewall between "
-"your website and your visitors to filter out these and other attacks, take a "
-"look at Sucuri Firewall [3].</em><br><br>\n"
+"<em>Explanation: Someone failed to login to your site. If you are getting too many of these messages, it is likely your "
+"site is under a password guessing brute-force attack [1]. You can disable the failed login alerts from here [2]. "
+"Alternatively, you can consider to install a firewall between your website and your visitors to filter out these and other "
+"attacks, take a look at Sucuri Firewall [3].</em><br><br>\n"
 "\n"
-"[1] <a href='https://kb.sucuri.net/definitions/attacks/brute-force/password-"
-"guessing'>https://kb.sucuri.net/definitions/attacks/brute-force/password-"
-"guessing</a><br>\n"
+"[1] <a href='https://kb.sucuri.net/definitions/attacks/brute-force/password-guessing'>https://kb.sucuri.net/definitions/"
+"attacks/brute-force/password-guessing</a><br>\n"
 "[2] <a href='%s'>%s</a> <br>\n"
-"[3] <a href='https://sucuri.net/website-firewall/?wpalert'>https://sucuri."
-"net/website-firewall/</a><br>\n"
+"[3] <a href='https://sucuri.net/website-firewall/?wpalert'>https://sucuri.net/website-firewall/</a><br>\n"
 msgstr ""
 
 #: src/event.lib.php:642
 msgid "Password Change"
 msgstr ""
 
-#: src/event.lib.php:752
+#: src/event.lib.php:747
 #, php-format
-msgid "%s is empty or can not be deleted."
+msgid "%s cannot be deleted."
 msgstr ""
 
-#: src/event.lib.php:764
+#: src/event.lib.php:759
 #, php-format
 msgid "%s was deleted."
 msgstr ""
 
-#: src/event.lib.php:770
+#: src/event.lib.php:765
 #, php-format
-msgid "%s was deleted. Please refresh this page."
+msgid "%s was deleted."
 msgstr ""
 
 #: src/fileinfo.lib.php:291
@@ -239,8 +232,8 @@ msgstr ""
 msgid "caching disabled (use with caution)"
 msgstr ""
 
-#: src/firewall.lib.php:253 src/firewall.lib.php:349 src/firewall.lib.php:567
-#: src/firewall.lib.php:602 src/firewall.lib.php:643 src/firewall.lib.php:735
+#: src/firewall.lib.php:253 src/firewall.lib.php:349 src/firewall.lib.php:567 src/firewall.lib.php:602
+#: src/firewall.lib.php:643 src/firewall.lib.php:735
 msgid "Firewall API key was not found."
 msgstr ""
 
@@ -314,7 +307,7 @@ msgstr ""
 msgid "IP has been unblacklisted: %s"
 msgstr ""
 
-#: src/globals.php:80 src/strings.php:39 src/strings.php:287
+#: src/globals.php:80 src/strings.php:39 src/strings.php:289
 msgid "Dashboard"
 msgstr ""
 
@@ -326,7 +319,7 @@ msgstr ""
 msgid "Last Logins"
 msgstr ""
 
-#: src/globals.php:83 src/strings.php:41 src/strings.php:95 src/strings.php:288
+#: src/globals.php:83 src/strings.php:41 src/strings.php:95 src/strings.php:290
 msgid "Settings"
 msgstr ""
 
@@ -359,36 +352,28 @@ msgstr ""
 msgid "Media file added; ID: %s; name: %s; type: %s"
 msgstr ""
 
-#: src/hook.lib.php:82 src/hook.lib.php:108 src/hook.lib.php:197
-#: src/hook.lib.php:1001 src/hook.lib.php:1012 src/hook.lib.php:1042
-#: src/settings-general.php:408 src/settings-general.php:409
-#: src/settings-general.php:410 src/settings-general.php:411
-#: src/settings-general.php:412 src/settings-webinfo.php:40
+#: src/hook.lib.php:82 src/hook.lib.php:108 src/hook.lib.php:197 src/hook.lib.php:1001 src/hook.lib.php:1012
+#: src/hook.lib.php:1042 src/settings-general.php:416 src/settings-general.php:417 src/settings-general.php:418
+#: src/settings-general.php:419 src/settings-general.php:420 src/settings-webinfo.php:40
 msgid "unknown"
 msgstr ""
 
-#: src/hook.lib.php:83 src/hook.lib.php:109 src/hook.lib.php:1002
-#: src/hook.lib.php:1013 src/hook.lib.php:1043
+#: src/hook.lib.php:83 src/hook.lib.php:109 src/hook.lib.php:1002 src/hook.lib.php:1013 src/hook.lib.php:1043
 msgid "user@domain.com"
 msgstr ""
 
 #: src/hook.lib.php:91
 #, php-format
-msgid ""
-"User added to website; user_id: %s; role: %s; blog_id: %s; name: %s; email: "
-"%s"
+msgid "User added to website; user_id: %s; role: %s; blog_id: %s; name: %s; email: %s"
 msgstr ""
 
 #: src/hook.lib.php:117
 #, php-format
-msgid ""
-"User removed from website; user_id: %s; blog_id: %s; name: %s; email: %s"
+msgid "User removed from website; user_id: %s; blog_id: %s; name: %s; email: %s"
 msgstr ""
 
-#: src/hook.lib.php:134 src/hook.lib.php:229 src/hook.lib.php:296
-#: src/hook.lib.php:408 src/hook.lib.php:533 src/hook.lib.php:744
-#: src/hook.lib.php:770 src/hook.lib.php:870 src/hook.lib.php:912
-#: src/lastlogins-failed.php:246
+#: src/hook.lib.php:134 src/hook.lib.php:229 src/hook.lib.php:296 src/hook.lib.php:408 src/hook.lib.php:533
+#: src/hook.lib.php:744 src/hook.lib.php:770 src/hook.lib.php:870 src/hook.lib.php:912 src/lastlogins-failed.php:251
 msgid "Unknown"
 msgstr ""
 
@@ -428,9 +413,7 @@ msgstr ""
 
 #: src/hook.lib.php:326
 #, php-format
-msgid ""
-"The value of the option <b>%s</b> was changed from <b>'%s'</b> to <b>'%s'</"
-"b>.<br>\n"
+msgid "The value of the option <b>%s</b> was changed from <b>'%s'</b> to <b>'%s'</b>.<br>\n"
 msgstr ""
 
 #: src/hook.lib.php:332
@@ -591,9 +574,7 @@ msgstr ""
 
 #: src/hook.lib.php:1022
 #, php-format
-msgid ""
-"User account edited; ID: %s; name: %s; old_name: %s; email: %s; old_email: "
-"%s; roles: %s; old_roles: %s"
+msgid "User account edited; ID: %s; name: %s; old_name: %s; email: %s; old_email: %s; roles: %s; old_roles: %s"
 msgstr ""
 
 #: src/hook.lib.php:1054
@@ -606,8 +587,7 @@ msgstr ""
 msgid "Widget %s (%s) %s %s (#%d; size %dx%d)"
 msgstr ""
 
-#: src/integrity.lib.php:113 src/settings-general.php:46
-#: src/settings-general.php:594 src/settings-posthack.php:58
+#: src/integrity.lib.php:113 src/settings-general.php:46 src/settings-general.php:602 src/settings-posthack.php:58
 msgid "You need to confirm that you understand the risk of this operation."
 msgstr ""
 
@@ -632,9 +612,7 @@ msgid "Nothing was selected from the list."
 msgstr ""
 
 #: src/integrity.lib.php:228
-msgid ""
-"Server is not fast enough to process this action; maximum execution time "
-"reached"
+msgid "Server is not fast enough to process this action; maximum execution time reached"
 msgstr ""
 
 #: src/integrity.lib.php:234
@@ -649,26 +627,23 @@ msgstr ""
 
 #: src/integrity.lib.php:321
 msgid ""
-"The plugin has no permission to delete this file because it was created by a "
-"different system user who has more privileges than your account. Please use "
-"FTP to delete it."
+"The plugin has no permission to delete this file because it was created by a different system user who has more privileges "
+"than your account. Please use FTP to delete it."
 msgstr ""
 
 #: src/integrity.lib.php:323
 msgid ""
-"The plugin has no permission to restore this file because it was modified by "
-"a different system user who has more privileges than your account. Please "
-"use FTP to restore it."
+"The plugin has no permission to restore this file because it was modified by a different system user who has more "
+"privileges than your account. Please use FTP to restore it."
 msgstr ""
 
 #: src/integrity.lib.php:325
 msgid ""
-"The plugin has no permission to restore this file because its directory is "
-"owned by a different system user who has more privileges than your account. "
-"Please use FTP to restore it."
+"The plugin has no permission to restore this file because its directory is owned by a different system user who has more "
+"privileges than your account. Please use FTP to restore it."
 msgstr ""
 
-#: src/integrity.lib.php:405 src/strings.php:475 src/strings.php:477
+#: src/integrity.lib.php:405 src/strings.php:477 src/strings.php:479
 msgid "WordPress Integrity Diff Utility"
 msgstr ""
 
@@ -683,17 +658,14 @@ msgstr ""
 
 #: src/interface.lib.php:240
 msgid ""
-"API service communication is disabled, if you just updated the plugin this "
-"might be a good opportunity to test this feature once again with the new "
-"code. Enable it again from the \"API Service\" panel located in the settings "
-"page."
+"API service communication is disabled, if you just updated the plugin this might be a good opportunity to test this "
+"feature once again with the new code. Enable it again from the \"API Service\" panel located in the settings page."
 msgstr ""
 
 #: src/interface.lib.php:253
 msgid ""
-"Do you want to get vulnerability disclosures? Subscribe to our newsletter <a "
-"href=\"http://sucuri.hs-sites.com/subscribe-to-security\" target=\"_blank\" "
-"rel=\"noopener\">here</a>"
+"Do you want to get vulnerability disclosures? Subscribe to our newsletter <a href=\"http://sucuri.hs-sites.com/subscribe-"
+"to-security\" target=\"_blank\" rel=\"noopener\">here</a>"
 msgstr ""
 
 #: src/interface.lib.php:266
@@ -711,57 +683,51 @@ msgstr ""
 
 #: src/interface.lib.php:288
 msgid ""
-"WordPress CSRF verification failed. The submitted form is missing an "
-"important unique code that prevents the execution of automated malicious "
-"scanners. Go back and try again. If you did not submit a form, this error "
-"message could be an indication of an incompatibility between this plugin and "
-"another add-on; one of them is inserting data into the global POST variable "
-"when the HTTP request is coming via GET. Disable them one by one (while "
-"reloading this page) to find the culprit."
+"WordPress CSRF verification failed. The submitted form is missing an important unique code that prevents the execution of "
+"automated malicious scanners. Go back and try again. If you did not submit a form, this error message could be an "
+"indication of an incompatibility between this plugin and another add-on; one of them is inserting data into the global "
+"POST variable when the HTTP request is coming via GET. Disable them one by one (while reloading this page) to find the "
+"culprit."
 msgstr ""
 
-#: src/lastlogins-failed.php:344 src/lastlogins-failed.php:368
-#: src/strings.php:154 src/strings.php:167 src/strings.php:179
-#: src/strings.php:190 src/strings.php:410
+#: src/lastlogins-failed.php:349 src/lastlogins-failed.php:373 src/strings.php:154 src/strings.php:167 src/strings.php:180
+#: src/strings.php:192 src/strings.php:412
 msgid "Username"
 msgstr ""
 
-#: src/lastlogins-failed.php:345 src/lastlogins-failed.php:369
+#: src/lastlogins-failed.php:350 src/lastlogins-failed.php:374
 msgid "Password"
 msgstr ""
 
-#: src/lastlogins-failed.php:346 src/lastlogins-failed.php:370
-#: src/strings.php:81 src/strings.php:160 src/strings.php:168
-#: src/strings.php:180 src/strings.php:193 src/strings.php:272
+#: src/lastlogins-failed.php:351 src/lastlogins-failed.php:375 src/strings.php:81 src/strings.php:160 src/strings.php:168
+#: src/strings.php:181 src/strings.php:195 src/strings.php:274
 msgid "IP Address"
 msgstr ""
 
-#: src/lastlogins-failed.php:347 src/lastlogins-failed.php:371
+#: src/lastlogins-failed.php:352 src/lastlogins-failed.php:376
 msgid "Attempt Timestamp"
 msgstr ""
 
-#: src/lastlogins-failed.php:348 src/lastlogins-failed.php:372
+#: src/lastlogins-failed.php:353 src/lastlogins-failed.php:377
 msgid "Attempt Date/Time"
 msgstr ""
 
-#: src/lastlogins.php:124
+#: src/lastlogins.php:129
 #, php-format
 msgid "Last-logins data file is not writable: <code>%s</code>"
 msgstr ""
 
-#: src/lastlogins.php:300
+#: src/lastlogins.php:305
 msgid "Invalid last-logins storage file"
 msgstr ""
 
-#: src/lastlogins.php:307
+#: src/lastlogins.php:312
 msgid "No last-logins data is available"
 msgstr ""
 
-#: src/lastlogins.php:451
+#: src/lastlogins.php:456
 #, php-format
-msgid ""
-"Last login was at <b>%s</b> from <b>%s</b> <em>(%s)</em> <a href=\"%s\" "
-"target=\"_self\">view all logs</a>"
+msgid "Last login was at <b>%s</b> from <b>%s</b> <em>(%s)</em> <a href=\"%s\" target=\"_self\">view all logs</a>"
 msgstr ""
 
 #: src/mail.lib.php:80
@@ -777,8 +743,7 @@ msgstr ""
 msgid "Sucuri Alert"
 msgstr ""
 
-#: src/option.lib.php:148 src/settings-alerts.php:209
-#: src/settings-alerts.php:210 src/settings-alerts.php:211
+#: src/option.lib.php:148 src/settings-alerts.php:209 src/settings-alerts.php:210 src/settings-alerts.php:211
 #, php-format
 msgid "Sucuri Alert, %s, %s, %s"
 msgstr ""
@@ -795,18 +760,17 @@ msgstr ""
 msgid "Scripts"
 msgstr ""
 
-#: src/pagehandler.php:47 src/pagehandler.php:48 src/pagehandler.php:49
-#: src/strings.php:26 src/strings.php:53 src/strings.php:65 src/strings.php:76
-#: src/strings.php:108 src/strings.php:143 src/strings.php:397
-#: src/strings.php:407 src/strings.php:418 src/strings.php:449
+#: src/pagehandler.php:47 src/pagehandler.php:48 src/pagehandler.php:49 src/strings.php:26 src/strings.php:53
+#: src/strings.php:65 src/strings.php:76 src/strings.php:108 src/strings.php:143 src/strings.php:399 src/strings.php:409
+#: src/strings.php:420 src/strings.php:451
 msgid "Loading..."
 msgstr ""
 
-#: src/pagehandler.php:97
+#: src/pagehandler.php:100
 msgid "Last-Logins logs were successfully reset."
 msgstr ""
 
-#: src/pagehandler.php:99
+#: src/pagehandler.php:102
 msgid "Could not reset the last-logins data file."
 msgstr ""
 
@@ -873,8 +837,7 @@ msgstr ""
 msgid "n/a"
 msgstr ""
 
-#: src/settings-alerts.php:208 src/settings-alerts.php:212
-#: src/settings-alerts.php:213
+#: src/settings-alerts.php:208 src/settings-alerts.php:212 src/settings-alerts.php:213
 #, php-format
 msgid "Sucuri Alert, %s, %s"
 msgstr ""
@@ -960,15 +923,14 @@ msgstr ""
 
 #: src/settings-alerts.php:364
 #, php-format
-msgid ""
-"Consider brute-force attack after <code>%s</code> failed logins per hour"
+msgid "Consider brute-force attack after <code>%s</code> failed logins per hour"
 msgstr ""
 
 #: src/settings-alerts.php:369
 #, php-format
 msgid ""
-"The plugin will assume that your website is under a brute-force attack after "
-"%s failed logins are detected during the same hour"
+"The plugin will assume that your website is under a brute-force attack after %s failed logins are detected during the same "
+"hour"
 msgstr ""
 
 #: src/settings-alerts.php:371
@@ -980,15 +942,11 @@ msgid "Receive email alerts for changes in the settings of the plugin"
 msgstr ""
 
 #: src/settings-alerts.php:397
-msgid ""
-"Receive email alerts in HTML <em>(there may be issues with some mail "
-"services)</em>"
+msgid "Receive email alerts in HTML <em>(there may be issues with some mail services)</em>"
 msgstr ""
 
 #: src/settings-alerts.php:398
-msgid ""
-"Use WordPress functions to send mails <em>(uncheck to use native PHP "
-"functions)</em>"
+msgid "Use WordPress functions to send mails <em>(uncheck to use native PHP functions)</em>"
 msgstr ""
 
 #: src/settings-alerts.php:399
@@ -1012,21 +970,15 @@ msgid "Receive email alerts for successful login attempts"
 msgstr ""
 
 #: src/settings-alerts.php:404
-msgid ""
-"Receive email alerts for failed login attempts <em>(you may receive tons of "
-"emails)</em>"
+msgid "Receive email alerts for failed login attempts <em>(you may receive tons of emails)</em>"
 msgstr ""
 
 #: src/settings-alerts.php:405
-msgid ""
-"Receive email alerts for password guessing attacks <em>(summary of failed "
-"logins per hour)</em>"
+msgid "Receive email alerts for password guessing attacks <em>(summary of failed logins per hour)</em>"
 msgstr ""
 
 #: src/settings-alerts.php:406
-msgid ""
-"Receive email alerts for changes in the post status <em>(configure from "
-"Ignore Posts Changes)</em>"
+msgid "Receive email alerts for changes in the post status <em>(configure from Ignore Posts Changes)</em>"
 msgstr ""
 
 #: src/settings-alerts.php:407
@@ -1119,21 +1071,17 @@ msgstr ""
 msgid "List of monitored post-types has been updated"
 msgstr ""
 
-#: src/settings-alerts.php:574 src/settings-scanner.php:179
-#: src/settings-scanner.php:239 src/strings.php:46 src/strings.php:159
-#: src/strings.php:171 src/strings.php:183 src/strings.php:275
-#: src/strings.php:380 src/strings.php:471
+#: src/settings-alerts.php:574 src/settings-scanner.php:179 src/settings-scanner.php:239 src/strings.php:46
+#: src/strings.php:159 src/strings.php:171 src/strings.php:184 src/strings.php:277 src/strings.php:382 src/strings.php:473
 msgid "no data available"
 msgstr ""
 
-#: src/settings-apiservice.php:36 src/settings-general.php:304
-#: src/settings-general.php:370 src/settings-general.php:417
+#: src/settings-apiservice.php:36 src/settings-general.php:312 src/settings-general.php:378 src/settings-general.php:425
 #: src/settings-integrity.php:80
 msgid "Enabled"
 msgstr ""
 
-#: src/settings-apiservice.php:37 src/settings-general.php:305
-#: src/settings-general.php:371 src/settings-general.php:418
+#: src/settings-apiservice.php:37 src/settings-general.php:313 src/settings-general.php:379 src/settings-general.php:426
 #: src/settings-integrity.php:81
 msgid "Disable"
 msgstr ""
@@ -1147,13 +1095,11 @@ msgstr ""
 msgid "The status of the API service has been changed"
 msgstr ""
 
-#: src/settings-apiservice.php:63 src/settings-general.php:347
-#: src/settings-general.php:391 src/settings-general.php:452
+#: src/settings-apiservice.php:63 src/settings-general.php:355 src/settings-general.php:399 src/settings-general.php:460
 msgid "Disabled"
 msgstr ""
 
-#: src/settings-apiservice.php:64 src/settings-general.php:348
-#: src/settings-general.php:392 src/settings-general.php:453
+#: src/settings-apiservice.php:64 src/settings-general.php:356 src/settings-general.php:400 src/settings-general.php:461
 msgid "Enable"
 msgstr ""
 
@@ -1192,9 +1138,7 @@ msgid "Sucuri API key was added manually."
 msgstr ""
 
 #: src/settings-general.php:100
-msgid ""
-"You must accept the Terms of Service and Privacy Policy in order to request "
-"an API key."
+msgid "You must accept the Terms of Service and Privacy Policy in order to request an API key."
 msgstr ""
 
 #: src/settings-general.php:107
@@ -1223,82 +1167,66 @@ msgstr ""
 
 #: src/settings-general.php:165
 #, php-format
-msgid ""
-"Cache to store the system logs obtained from the API service; expires after "
-"%s seconds."
+msgid "Cache to store the system logs obtained from the API service; expires after %s seconds."
 msgstr ""
 
 #: src/settings-general.php:166
-msgid ""
-"Local queue to store the most recent logs before they are sent to the remote "
-"API service."
+msgid "Local queue to store the most recent logs before they are sent to the remote API service."
 msgstr ""
 
 #: src/settings-general.php:167
-msgid ""
-"Deprecated on 1.8.12; it was used to store a list of blocked user names."
+msgid "Deprecated on 1.8.12; it was used to store a list of blocked user names."
 msgstr ""
 
 #: src/settings-general.php:168
 msgid ""
-"Stores the data for every failed login attempt. The data is moved to "
-"\"oldfailedlogins\" every hour during a brute force password attack."
+"Stores the data for every failed login attempt. The data is moved to \"oldfailedlogins\" every hour during a brute force "
+"password attack."
 msgstr ""
 
 #: src/settings-general.php:169
 msgid ""
-"Temporarily stores data to complement the logs during destructive operations "
-"like deleting a post, page, comment, etc."
+"Temporarily stores data to complement the logs during destructive operations like deleting a post, page, comment, etc."
 msgstr ""
 
 #: src/settings-general.php:170
-msgid ""
-"Stores a list of files and folders chosen by the user to be ignored by the "
-"file system scanner."
+msgid "Stores a list of files and folders chosen by the user to be ignored by the file system scanner."
 msgstr ""
 
 #: src/settings-general.php:171
-msgid ""
-"Stores a list of files marked as fixed by the user via the WordPress "
-"Integrity tool."
+msgid "Stores a list of files marked as fixed by the user via the WordPress Integrity tool."
 msgstr ""
 
 #: src/settings-general.php:172
 msgid ""
-"Stores the data associated to every successful user login. The data never "
-"expires; manually delete if the file is too large."
+"Stores the data associated to every successful user login. The data never expires; manually delete if the file is too "
+"large."
 msgstr ""
 
 #: src/settings-general.php:173
 msgid ""
-"Stores the data for every failed login attempt after the plugin sends a "
-"report about a brute force password attack via email."
+"Stores the data for every failed login attempt after the plugin sends a report about a brute force password attack via "
+"email."
 msgstr ""
 
 #: src/settings-general.php:174
 #, php-format
-msgid ""
-"Cache to store the data associated to the installed plugins listed in the "
-"Post-Hack page. Expires after %s seconds."
+msgid "Cache to store the data associated to the installed plugins listed in the Post-Hack page. Expires after %s seconds."
 msgstr ""
 
 #: src/settings-general.php:175
-msgid ""
-"Stores all the options used to configure the functionality and behavior of "
-"the plugin."
+msgid "Stores all the options used to configure the functionality and behavior of the plugin."
 msgstr ""
 
 #: src/settings-general.php:176
 #, php-format
-msgid ""
-"Cache to store the result of the malware scanner. Expires after %s seconds, "
-"reset at any time to force a re-scan."
+msgid "Cache to store the result of the malware scanner. Expires after %s seconds, reset at any time to force a re-scan."
 msgstr ""
 
 #: src/settings-general.php:177
 msgid ""
-"Stores a list of IP addresses trusted by the plugin, events triggered by one "
-"of these IPs will not be reported to the remote monitoring API service."
+"Stores a list of IP addresses trusted by the plugin, events triggered by one of these IPs will not be reported to the "
+"remote monitoring API service."
 msgstr ""
 
 #: src/settings-general.php:212
@@ -1308,323 +1236,284 @@ msgstr ""
 
 #: src/settings-general.php:219
 #, php-format
-msgid "%d out of %d files has been deleted."
+msgid "%d out of %d files have been deleted."
 msgstr ""
 
-#: src/settings-general.php:229 src/settings-posthack.php:308
+#: src/settings-general.php:237 src/settings-posthack.php:308
 msgid "Not Writable"
 msgstr ""
 
-#: src/settings-general.php:230
+#: src/settings-general.php:238
 msgid "Does Not Exist"
 msgstr ""
 
-#: src/settings-general.php:236
+#: src/settings-general.php:244
 msgid "Exists"
 msgstr ""
 
-#: src/settings-general.php:242 src/strings.php:328
+#: src/settings-general.php:250 src/strings.php:330
 msgid "Writable"
 msgstr ""
 
-#: src/settings-general.php:316
+#: src/settings-general.php:324
 msgid "Log exporter was disabled"
 msgstr ""
 
-#: src/settings-general.php:322
+#: src/settings-general.php:330
 msgid "The log exporter feature has been disabled"
 msgstr ""
 
-#: src/settings-general.php:324
+#: src/settings-general.php:332
 msgid "File should not be publicly accessible."
 msgstr ""
 
-#: src/settings-general.php:326
+#: src/settings-general.php:334
 msgid "File already exists and will not be overwritten."
 msgstr ""
 
-#: src/settings-general.php:328
+#: src/settings-general.php:336
 msgid "File parent directory is not writable."
 msgstr ""
 
-#: src/settings-general.php:332
+#: src/settings-general.php:340
 msgid "Log exporter file path was correctly set"
 msgstr ""
 
-#: src/settings-general.php:338
-msgid ""
-"The log exporter feature has been enabled and the data file was successfully "
-"set."
+#: src/settings-general.php:346
+msgid "The log exporter feature has been enabled and the data file was successfully set."
 msgstr ""
 
-#: src/settings-general.php:414
+#: src/settings-general.php:422
 msgid "INVALID"
 msgstr ""
 
-#: src/settings-general.php:432
+#: src/settings-general.php:440
 #, php-format
 msgid "DNS lookups for reverse proxy detection <code>%s</code>"
 msgstr ""
 
-#: src/settings-general.php:437
-msgid ""
-"The status of the DNS lookups for the reverse proxy detection has been "
-"changed"
+#: src/settings-general.php:445
+msgid "The status of the DNS lookups for the reverse proxy detection has been changed"
 msgstr ""
 
-#: src/settings-general.php:585
+#: src/settings-general.php:593
 #, php-format
 msgid "%d out of %d option have been successfully imported"
 msgstr ""
 
-#: src/settings-general.php:591
+#: src/settings-general.php:599
 msgid "Data is incorrectly encoded"
 msgstr ""
 
-#: src/settings-general.php:649
+#: src/settings-general.php:657
 #, php-format
 msgid "Timezone override will use %s"
 msgstr ""
 
-#: src/settings-general.php:654
+#: src/settings-general.php:662
 msgid "The timezone for the date and time in the audit logs has been changed"
 msgstr ""
 
-#: src/settings-hardening.php:102
+#: src/settings-hardening.php:100
 msgid ""
-"The firewall is a premium service that you need purchase at - <a href="
-"\"https://sucuri.net/website-firewall/signup\" target=\"_blank\">Sucuri Firewall</a>"
+"The firewall is a premium service that you need purchase at - <a href=\"https://sucuri.net/website-firewall/signup\" "
+"target=\"_blank\">Sucuri Firewall</a>"
 msgstr ""
 
-#: src/settings-hardening.php:107
+#: src/settings-hardening.php:105
 msgid "Website Firewall Protection"
 msgstr ""
 
-#: src/settings-hardening.php:108
+#: src/settings-hardening.php:106
 msgid ""
-"A WAF is a protection layer for your web site, blocking all sort of attacks "
-"(brute force attempts, DDoS, SQL injections, etc) and helping it remain "
-"malware and blacklist free. This test checks if your site is using Sucuri "
-"Firewall to protect your site."
+"A WAF is a protection layer for your web site, blocking all sort of attacks (brute force attempts, DDoS, SQL injections, "
+"etc) and helping it remain malware and blacklist free. This test checks if your site is using Sucuri Firewall to protect "
+"your site."
 msgstr ""
 
-#: src/settings-hardening.php:112 src/settings-hardening.php:193
-#: src/settings-hardening.php:301 src/settings-hardening.php:360
-#: src/settings-hardening.php:429 src/settings-hardening.php:461
-#: src/settings-hardening.php:501 src/settings-hardening.php:594
+#: src/settings-hardening.php:110 src/settings-hardening.php:256 src/settings-hardening.php:315
+#: src/settings-hardening.php:384 src/settings-hardening.php:416 src/settings-hardening.php:456
+#: src/settings-hardening.php:549
 msgid "Apply Hardening"
 msgstr ""
 
-#: src/settings-hardening.php:116 src/settings-hardening.php:190
-#: src/settings-hardening.php:212 src/settings-hardening.php:293
-#: src/settings-hardening.php:297 src/settings-hardening.php:352
-#: src/settings-hardening.php:356 src/settings-hardening.php:421
-#: src/settings-hardening.php:425 src/settings-hardening.php:464
-#: src/settings-hardening.php:497 src/settings-hardening.php:590
+#: src/settings-hardening.php:114 src/settings-hardening.php:167 src/settings-hardening.php:248
+#: src/settings-hardening.php:252 src/settings-hardening.php:307 src/settings-hardening.php:311
+#: src/settings-hardening.php:376 src/settings-hardening.php:380 src/settings-hardening.php:419
+#: src/settings-hardening.php:452 src/settings-hardening.php:545
 msgid "Revert Hardening"
 msgstr ""
 
-#: src/settings-hardening.php:141
+#: src/settings-hardening.php:139
 msgid "Check Updates Now"
 msgstr ""
 
-#: src/settings-hardening.php:142
+#: src/settings-hardening.php:140
 msgid "Verify WordPress Version"
 msgstr ""
 
-#: src/settings-hardening.php:143
+#: src/settings-hardening.php:141
 msgid ""
-"Why keep your site updated? WordPress is an open-source project which means "
-"that with every update the details of the changes made to the source code "
-"are made public, if there were security fixes then someone with malicious "
-"intent can use this information to attack any site that has not been "
-"upgraded."
+"Why keep your site updated? WordPress is an open-source project which means that with every update the details of the "
+"changes made to the source code are made public, if there were security fixes then someone with malicious intent can use "
+"this information to attack any site that has not been upgraded."
 msgstr ""
 
-#: src/settings-hardening.php:147
+#: src/settings-hardening.php:145
 msgid "WordPress Update Available"
 msgstr ""
 
-#: src/settings-hardening.php:179
-msgid ""
-"Ask your hosting provider to install an updated version of PHP - <a href="
-"\"http://php.net/supported-versions.php\" target=\"_blank\" rel=\"noopener"
-"\">List of PHP Supported Versions</a>"
-msgstr ""
-
-#: src/settings-hardening.php:184
-msgid "Verify PHP Version"
-msgstr ""
-
-#: src/settings-hardening.php:185
-#, php-format
-msgid "PHP %s is installed."
-msgstr ""
-
-#: src/settings-hardening.php:210
+#: src/settings-hardening.php:165
 msgid "Remove WordPress Version"
 msgstr ""
 
-#: src/settings-hardening.php:214
+#: src/settings-hardening.php:169
 msgid ""
-"It checks if your WordPress version is being leaked to the public via a HTML "
-"meta-tag. Many web vulnerability scanners use this to determine which "
-"version of the code is running in your website. They use this to find "
-"disclosed vulnerabilities associated to this version number. A vulnerability "
-"scanner can still guess which version of WordPress is installed by comparing "
-"the checksum of some static files."
+"It checks if your WordPress version is being leaked to the public via a HTML meta-tag. Many web vulnerability scanners use "
+"this to determine which version of the code is running in your website. They use this to find disclosed vulnerabilities "
+"associated to this version number. A vulnerability scanner can still guess which version of WordPress is installed by "
+"comparing the checksum of some static files."
 msgstr ""
 
-#: src/settings-hardening.php:234
+#: src/settings-hardening.php:189
 msgid ""
-"Read the official WordPress guidelines to learn how to restrict access to "
-"PHP files in sensitive directories - <a href=\"https://codex.wordpress.org/"
-"Nginx#Global_restrictions_file\" target=\"_blank\" rel=\"noopener\">Nginx "
-"Global Restrictions For WordPress</a>"
+"Read the official WordPress guidelines to learn how to restrict access to PHP files in sensitive directories - <a href="
+"\"https://codex.wordpress.org/Nginx#Global_restrictions_file\" target=\"_blank\" rel=\"noopener\">Nginx Global "
+"Restrictions For WordPress</a>"
 msgstr ""
 
-#: src/settings-hardening.php:238
+#: src/settings-hardening.php:193
 msgid "Block of Certain PHP Files"
 msgstr ""
 
-#: src/settings-hardening.php:241
+#: src/settings-hardening.php:196
 msgid "Check Hardening"
 msgstr ""
 
-#: src/settings-hardening.php:242 src/settings-hardening.php:288
-#: src/settings-hardening.php:347 src/settings-hardening.php:416
+#: src/settings-hardening.php:197 src/settings-hardening.php:243 src/settings-hardening.php:302
+#: src/settings-hardening.php:371
 msgid ""
-"Block the execution of PHP files in sensitive directories. Be careful while "
-"applying this hardening option as there are many plugins and theme which "
-"rely on the ability to execute PHP files in the content directory to "
-"generate images or save temporary data. Use the \"Whitelist PHP Files\" tool "
-"to add exceptions to individual files."
+"Block the execution of PHP files in sensitive directories. Be careful while applying this hardening option as there are "
+"many plugins and theme which rely on the ability to execute PHP files in the content directory to generate images or save "
+"temporary data. Use the \"Whitelist PHP Files\" tool to add exceptions to individual files."
 msgstr ""
 
-#: src/settings-hardening.php:269 src/settings-hardening.php:270
+#: src/settings-hardening.php:224 src/settings-hardening.php:225
 msgid "Hardening applied to the uploads directory"
 msgstr ""
 
-#: src/settings-hardening.php:272 src/settings-hardening.php:331
-#: src/settings-hardening.php:398
+#: src/settings-hardening.php:227 src/settings-hardening.php:286 src/settings-hardening.php:353
 msgid "Error hardening directory, check the permissions."
 msgstr ""
 
-#: src/settings-hardening.php:280 src/settings-hardening.php:281
+#: src/settings-hardening.php:235 src/settings-hardening.php:236
 msgid "Hardening reverted in the uploads directory"
 msgstr ""
 
-#: src/settings-hardening.php:283 src/settings-hardening.php:342
-#: src/settings-hardening.php:411
+#: src/settings-hardening.php:238 src/settings-hardening.php:297 src/settings-hardening.php:366
 msgid "Access file is not writable, check the permissions."
 msgstr ""
 
-#: src/settings-hardening.php:287
+#: src/settings-hardening.php:242
 msgid "Block PHP Files in Uploads Directory"
 msgstr ""
 
-#: src/settings-hardening.php:328 src/settings-hardening.php:329
+#: src/settings-hardening.php:283 src/settings-hardening.php:284
 msgid "Hardening applied to the content directory"
 msgstr ""
 
-#: src/settings-hardening.php:339 src/settings-hardening.php:340
+#: src/settings-hardening.php:294 src/settings-hardening.php:295
 msgid "Hardening reverted in the content directory"
 msgstr ""
 
-#: src/settings-hardening.php:346
+#: src/settings-hardening.php:301
 msgid "Block PHP Files in WP-CONTENT Directory"
 msgstr ""
 
-#: src/settings-hardening.php:392 src/settings-hardening.php:393
+#: src/settings-hardening.php:347 src/settings-hardening.php:348
 msgid "Hardening applied to the library directory"
 msgstr ""
 
-#: src/settings-hardening.php:408 src/settings-hardening.php:409
+#: src/settings-hardening.php:363 src/settings-hardening.php:364
 msgid "Hardening reverted in the library directory"
 msgstr ""
 
-#: src/settings-hardening.php:415
+#: src/settings-hardening.php:370
 msgid "Block PHP Files in WP-INCLUDES Directory"
 msgstr ""
 
-#: src/settings-hardening.php:448
+#: src/settings-hardening.php:403
 #, php-format
 msgid "Cannot delete <code>%s/readme.html</code>"
 msgstr ""
 
-#: src/settings-hardening.php:450 src/settings-hardening.php:451
+#: src/settings-hardening.php:405 src/settings-hardening.php:406
 msgid "Hardening applied to the <code>readme.html</code> file"
 msgstr ""
 
-#: src/settings-hardening.php:455
+#: src/settings-hardening.php:410
 msgid "Information Leakage"
 msgstr ""
 
-#: src/settings-hardening.php:456
+#: src/settings-hardening.php:411
 msgid ""
-"Checks if the WordPress README file still exists in the website. The "
-"information in this file can be used by malicious users to pin-point which "
-"disclosed vulnerabilities are associated to the website. Be aware that "
-"WordPress recreates this file automatically with every update."
+"Checks if the WordPress README file still exists in the website. The information in this file can be used by malicious "
+"users to pin-point which disclosed vulnerabilities are associated to the website. Be aware that WordPress recreates this "
+"file automatically with every update."
 msgstr ""
 
-#: src/settings-hardening.php:491
+#: src/settings-hardening.php:446
 msgid "Default Admin Account"
 msgstr ""
 
-#: src/settings-hardening.php:492
+#: src/settings-hardening.php:447
 msgid ""
-"Check if the primary user account still uses the name \"admin\". This allows "
-"malicious users to easily identify which account has the highest privileges "
-"to target an attack."
+"Check if the primary user account still uses the name \"admin\". This allows malicious users to easily identify which "
+"account has the highest privileges to target an attack."
 msgstr ""
 
-#: src/settings-hardening.php:521 src/settings-hardening.php:552
-#: src/settings-posthack.php:63
+#: src/settings-hardening.php:476 src/settings-hardening.php:507 src/settings-posthack.php:63
 msgid "WordPress configuration file was not found."
 msgstr ""
 
-#: src/settings-hardening.php:523 src/settings-hardening.php:554
-#: src/settings-posthack.php:76
+#: src/settings-hardening.php:478 src/settings-hardening.php:509 src/settings-posthack.php:76
 msgid "WordPress configuration file is not writable."
 msgstr ""
 
-#: src/settings-hardening.php:543 src/settings-hardening.php:544
+#: src/settings-hardening.php:498 src/settings-hardening.php:499
 msgid "Hardening applied to the plugin and theme editor"
 msgstr ""
 
-#: src/settings-hardening.php:572
+#: src/settings-hardening.php:527
 msgid ""
-"File Editor was not disabled using this tool. You must scan your project for "
-"a constant defined as DISALLOW_FILE_EDIT, then either delete it or set its "
-"value to False. Any plugin/theme can disable the file editor, so it is "
-"impossible to determine the origin of the constant."
+"File Editor was not disabled using this tool. You must scan your project for a constant defined as DISALLOW_FILE_EDIT, "
+"then either delete it or set its value to False. Any plugin/theme can disable the file editor, so it is impossible to "
+"determine the origin of the constant."
 msgstr ""
 
-#: src/settings-hardening.php:578 src/settings-hardening.php:579
+#: src/settings-hardening.php:533 src/settings-hardening.php:534
 msgid "Hardening reverted in the plugin and theme editor"
 msgstr ""
 
-#: src/settings-hardening.php:584
+#: src/settings-hardening.php:539
 msgid "Plugin and Theme Editor"
 msgstr ""
 
-#: src/settings-hardening.php:585
+#: src/settings-hardening.php:540
 msgid ""
-"Disables the theme and plugin editors to prevent unwanted modifications to "
-"the code. If you are having problems reverting this please open the wp-"
-"config.php file and delete the line with the constant DISALLOW_FILE_EDIT."
+"Disables the theme and plugin editors to prevent unwanted modifications to the code. If you are having problems reverting "
+"this please open the wp-config.php file and delete the line with the constant DISALLOW_FILE_EDIT."
 msgstr ""
 
-#: src/settings-hardening.php:636
+#: src/settings-hardening.php:591
 msgid "The file has been whitelisted from the hardening"
 msgstr ""
 
-#: src/settings-hardening.php:641
+#: src/settings-hardening.php:596
 msgid "Specified folder is not hardened by this plugin"
 msgstr ""
 
-#: src/settings-hardening.php:655
+#: src/settings-hardening.php:610
 msgid "Selected files have been removed"
 msgstr ""
 
@@ -1876,32 +1765,25 @@ msgstr ""
 
 #: src/strings.php:51
 msgid ""
-"The firewall logs every request involved in an attack and separates them "
-"from the legitimate requests. You can analyze the data from the latest "
-"entries in the logs using this tool and take action either enabling the "
-"advanced features of the IDS <em>(Intrusion Detection System)</em> from the "
-"<a href=\"https://waf.sucuri.net/?settings\" target=\"_blank\" rel=\"noopener"
-"\">Firewall Dashboard</a> and/or blocking IP addresses and URL paths "
-"directly from the <a href=\"https://waf.sucuri.net/?audit\" target=\"_blank"
-"\" rel=\"noopener\">Firewall Audit Trails</a> page."
+"The firewall logs every request involved in an attack and separates them from the legitimate requests. You can analyze the "
+"data from the latest entries in the logs using this tool and take action either enabling the advanced features of the IDS "
+"<em>(Intrusion Detection System)</em> from the <a href=\"https://waf.sucuri.net/?settings\" target=\"_blank\" rel="
+"\"noopener\">Firewall Dashboard</a> and/or blocking IP addresses and URL paths directly from the <a href=\"https://waf."
+"sucuri.net/?audit\" target=\"_blank\" rel=\"noopener\">Firewall Audit Trails</a> page."
 msgstr ""
 
 #: src/strings.php:52
 msgid "Non-blocked requests are hidden from the logs, this is intentional."
 msgstr ""
 
-#: src/strings.php:54 src/strings.php:75 src/strings.php:128
-#: src/strings.php:213 src/strings.php:219 src/strings.php:226
-#: src/strings.php:234 src/strings.php:246 src/strings.php:253
-#: src/strings.php:263 src/strings.php:270 src/strings.php:282
-#: src/strings.php:295 src/strings.php:335 src/strings.php:353
-#: src/strings.php:363 src/strings.php:369 src/strings.php:375
-#: src/strings.php:414 src/strings.php:427 src/strings.php:451
-#: src/strings.php:458 src/strings.php:523
+#: src/strings.php:54 src/strings.php:75 src/strings.php:128 src/strings.php:215 src/strings.php:221 src/strings.php:228
+#: src/strings.php:236 src/strings.php:248 src/strings.php:255 src/strings.php:265 src/strings.php:272 src/strings.php:284
+#: src/strings.php:297 src/strings.php:337 src/strings.php:355 src/strings.php:365 src/strings.php:371 src/strings.php:377
+#: src/strings.php:416 src/strings.php:429 src/strings.php:453 src/strings.php:460 src/strings.php:525
 msgid "Submit"
 msgstr ""
 
-#: src/strings.php:57 src/strings.php:200
+#: src/strings.php:57 src/strings.php:202
 msgid "Date/Time:"
 msgstr ""
 
@@ -1939,46 +1821,35 @@ msgstr ""
 
 #: src/strings.php:69
 msgid ""
-"The firewall offers multiple options to configure the cache level applied to "
-"your website. You can either enable the full cache which is the recommended "
-"setting, or you can set the cache level to minimal which will keep the pages "
-"static for a couple of minutes, or force the usage of the website headers "
-"<em>(only for advanced users)</em>, or in extreme cases where you do not "
-"need the cache you can simply disable it. Find more information about it in "
-"the <a href=\"https://kb.sucuri.net/firewall/Performance/caching-options\" "
-"target=\"_blank\" rel=\"noopener\">Sucuri Knowledge Base</a> website."
+"The firewall offers multiple options to configure the cache level applied to your website. You can either enable the full "
+"cache which is the recommended setting, or you can set the cache level to minimal which will keep the pages static for a "
+"couple of minutes, or force the usage of the website headers <em>(only for advanced users)</em>, or in extreme cases where "
+"you do not need the cache you can simply disable it. Find more information about it in the <a href=\"https://kb.sucuri.net/"
+"firewall/Performance/caching-options\" target=\"_blank\" rel=\"noopener\">Sucuri Knowledge Base</a> website."
 msgstr ""
 
 #: src/strings.php:70
 msgid ""
-"Note that the firewall has <a href=\"https://kb.sucuri.net/firewall/"
-"Performance/cache-exceptions\" target=\"_blank\" rel=\"noopener\">special "
-"caching rules</a> for Images, CSS, PDF, TXT, JavaScript, media files and a "
-"few more extensions that are stored on our <a href=\"https://en.wikipedia."
-"org/wiki/Edge_device\" target=\"_blank\" rel=\"noopener\">edge</a>. The only "
-"way to flush the cache for these files is by clearing the firewall’s cache "
-"completely <em>(for the whole website)</em>. Due to our caching of "
-"JavaScript and CSS files, often, as is best practice, the use of versioning "
-"during development will ensure updates going live as expected. This is done "
-"by adding a query string such as <code>?ver=1.2.3</code> and incrementing on "
-"each update."
+"Note that the firewall has <a href=\"https://kb.sucuri.net/firewall/Performance/cache-exceptions\" target=\"_blank\" rel="
+"\"noopener\">special caching rules</a> for Images, CSS, PDF, TXT, JavaScript, media files and a few more extensions that "
+"are stored on our <a href=\"https://en.wikipedia.org/wiki/Edge_device\" target=\"_blank\" rel=\"noopener\">edge</a>. The "
+"only way to flush the cache for these files is by clearing the firewall’s cache completely <em>(for the whole website)</"
+"em>. Due to our caching of JavaScript and CSS files, often, as is best practice, the use of versioning during development "
+"will ensure updates going live as expected. This is done by adding a query string such as <code>?ver=1.2.3</code> and "
+"incrementing on each update."
 msgstr ""
 
 #: src/strings.php:71
 msgid ""
-"A web cache (or HTTP cache) is an information technology for the temporary "
-"storage (caching) of web documents, such as HTML pages and images, to reduce "
-"bandwidth usage, server load, and perceived lag. A web cache system stores "
-"copies of documents passing through it; subsequent requests may be satisfied "
-"from the cache if certain conditions are met. A web cache system can refer "
-"either to an appliance, or to a computer program. &mdash; <a href=\"https://"
-"en.wikipedia.org/wiki/Web_cache\" target=\"_blank\" rel=\"noopener"
-"\">WikiPedia - Web Cache</a>"
+"A web cache (or HTTP cache) is an information technology for the temporary storage (caching) of web documents, such as "
+"HTML pages and images, to reduce bandwidth usage, server load, and perceived lag. A web cache system stores copies of "
+"documents passing through it; subsequent requests may be satisfied from the cache if certain conditions are met. A web "
+"cache system can refer either to an appliance, or to a computer program. &mdash; <a href=\"https://en.wikipedia.org/wiki/"
+"Web_cache\" target=\"_blank\" rel=\"noopener\">WikiPedia - Web Cache</a>"
 msgstr ""
 
-#: src/strings.php:74 src/strings.php:88 src/strings.php:256
-#: src/strings.php:276 src/strings.php:318 src/strings.php:329
-#: src/strings.php:381 src/strings.php:172 src/strings.php:186
+#: src/strings.php:74 src/strings.php:88 src/strings.php:172 src/strings.php:186 src/strings.php:258 src/strings.php:278
+#: src/strings.php:320 src/strings.php:331 src/strings.php:383
 msgid "Delete"
 msgstr ""
 
@@ -1988,13 +1859,10 @@ msgstr ""
 
 #: src/strings.php:78
 msgid ""
-"This tool allows you to whitelist and blacklist one or more IP addresses "
-"from accessing your website. You can also configure the plugin to "
-"automatically blacklist any IP address involved in a password guessing brute-"
-"force attack. If a legitimate user fails to submit the correct credentials "
-"of their account they will have to log into the Firewall dashboard in order "
-"to delete their IP address from the blacklist, or try to login once again "
-"through a VPN."
+"This tool allows you to whitelist and blacklist one or more IP addresses from accessing your website. You can also "
+"configure the plugin to automatically blacklist any IP address involved in a password guessing brute-force attack. If a "
+"legitimate user fails to submit the correct credentials of their account they will have to log into the Firewall dashboard "
+"in order to delete their IP address from the blacklist, or try to login once again through a VPN."
 msgstr ""
 
 #: src/strings.php:79
@@ -2011,20 +1879,16 @@ msgstr ""
 
 #: src/strings.php:85
 msgid ""
-"A powerful Web Application Firewall and <b>Intrusion Detection System</b> "
-"for any WordPress user and many other platforms. This page will help you to "
-"configure and monitor your site through the <b>Sucuri Firewall</b>. Once "
-"enabled, our firewall will act as a shield, protecting your site from "
-"attacks and preventing malware infections and reinfections. It will block "
-"SQL injection attempts, brute force attacks, XSS, RFI, backdoors and many "
-"other threats against your site."
+"A powerful Web Application Firewall and <b>Intrusion Detection System</b> for any WordPress user and many other platforms. "
+"This page will help you to configure and monitor your site through the <b>Sucuri Firewall</b>. Once enabled, our firewall "
+"will act as a shield, protecting your site from attacks and preventing malware infections and reinfections. It will block "
+"SQL injection attempts, brute force attacks, XSS, RFI, backdoors and many other threats against your site."
 msgstr ""
 
 #: src/strings.php:86
 msgid ""
-"Add your <a href=\"https://waf.sucuri.net/?settings&panel=api\" target="
-"\"_blank\" rel=\"noopener\">Firewall API key</a> in the form below to start "
-"communicating with the firewall API service."
+"Add your <a href=\"https://waf.sucuri.net/?settings&panel=api\" target=\"_blank\" rel=\"noopener\">Firewall API key</a> in "
+"the form below to start communicating with the firewall API service."
 msgstr ""
 
 #: src/strings.php:87
@@ -2035,24 +1899,21 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: src/strings.php:90 src/strings.php:385 src/strings.php:393
-#: src/strings.php:423 src/strings.php:434 src/strings.php:445
+#: src/strings.php:90 src/strings.php:387 src/strings.php:395 src/strings.php:425 src/strings.php:436 src/strings.php:447
 msgid "Name"
 msgstr ""
 
-#: src/strings.php:91 src/strings.php:435
+#: src/strings.php:91 src/strings.php:437
 msgid "Value"
 msgstr ""
 
 #: src/strings.php:92
 msgid ""
-"<em>[1]</em> More information about the <a href=\"https://sucuri.net/website-"
-"firewall/\" target=\"_blank\" rel=\"noopener\">Sucuri Firewall</a>, features "
-"and pricing.<br><em>[2]</em> Instructions and videos in the official <a href="
-"\"https://kb.sucuri.net/firewall\" target=\"_blank\" rel=\"noopener"
-"\">Knowledge Base</a> site.<br><em>[3]</em> <a href=\"https://login.sucuri."
-"net/signup2/create?CloudProxy\" target=\"_blank\" rel=\"noopener\">Sign up</"
-"a> for a new account and start protecting your site."
+"<em>[1]</em> More information about the <a href=\"https://sucuri.net/website-firewall/\" target=\"_blank\" rel=\"noopener"
+"\">Sucuri Firewall</a>, features and pricing.<br><em>[2]</em> Instructions and videos in the official <a href=\"https://kb."
+"sucuri.net/firewall\" target=\"_blank\" rel=\"noopener\">Knowledge Base</a> site.<br><em>[3]</em> <a href=\"https://login."
+"sucuri.net/signup2/create?CloudProxy\" target=\"_blank\" rel=\"noopener\">Sign up</a> for a new account and start "
+"protecting your site."
 msgstr ""
 
 #: src/strings.php:97
@@ -2066,11 +1927,9 @@ msgstr ""
 #: src/strings.php:102 src/strings.php:113 src/strings.php:142
 #, php-format
 msgid ""
-"We inspect your WordPress installation and look for modifications on the "
-"core files as provided by WordPress.org. Files located in the root "
-"directory, wp-admin and wp-includes will be compared against the files "
-"distributed with v%%SUCURI.WordPressVersion%%; all files with "
-"inconsistencies will be listed here. Any changes might indicate a hack."
+"We inspect your WordPress installation and look for modifications on the core files as provided by WordPress.org. Files "
+"located in the root directory, wp-admin and wp-includes will be compared against the files distributed with v%%SUCURI."
+"WordPressVersion%%; all files with inconsistencies will be listed here. Any changes might indicate a hack."
 msgstr ""
 
 #: src/strings.php:103
@@ -2079,11 +1938,9 @@ msgstr ""
 
 #: src/strings.php:104
 msgid ""
-"We have not identified additional files, deleted files, or relevant changes "
-"to the core files in your WordPress installation. If you are experiencing "
-"other malware issues, please use a <a href=\"https://sucuri.net/website-"
-"security/malware-removal\" target=\"_blank\" rel=\"noopener\">Server Side "
-"Scanner</a>."
+"We have not identified additional files, deleted files, or relevant changes to the core files in your WordPress "
+"installation. If you are experiencing other malware issues, please use a <a href=\"https://sucuri.net/website-security/"
+"malware-removal\" target=\"_blank\" rel=\"noopener\">Server Side Scanner</a>."
 msgstr ""
 
 #: src/strings.php:105 src/strings.php:116
@@ -2092,11 +1949,10 @@ msgstr ""
 
 #: src/strings.php:109
 msgid ""
-"Lines with a <b>minus</b> sign as the prefix <em>(here in red)</em> show the "
-"original code. Lines with a <b>plus</b> sign as the prefix <em>(here in "
-"green)</em> show the modified code. You can read more about the DIFF format "
-"from the WikiPedia article about the <a target=\"_blank\" href=\"https://en."
-"wikipedia.org/wiki/Diff_utility\" rel=\"noopener\">Unix Diff Utility</a>."
+"Lines with a <b>minus</b> sign as the prefix <em>(here in red)</em> show the original code. Lines with a <b>plus</b> sign "
+"as the prefix <em>(here in green)</em> show the modified code. You can read more about the DIFF format from the WikiPedia "
+"article about the <a target=\"_blank\" href=\"https://en.wikipedia.org/wiki/Diff_utility\" rel=\"noopener\">Unix Diff "
+"Utility</a>."
 msgstr ""
 
 #: src/strings.php:114
@@ -2105,11 +1961,9 @@ msgstr ""
 
 #: src/strings.php:115 src/strings.php:132
 msgid ""
-"We identified that some of your WordPress core files were modified. That "
-"might indicate a hack or a broken file on your installation. If you are "
-"experiencing other malware issues, please use a <a href=\"https://sucuri.net/"
-"website-security/malware-removal\" target=\"_blank\" rel=\"noopener\">Server "
-"Side Scanner</a>."
+"We identified that some of your WordPress core files were modified. That might indicate a hack or a broken file on your "
+"installation. If you are experiencing other malware issues, please use a <a href=\"https://sucuri.net/website-security/"
+"malware-removal\" target=\"_blank\" rel=\"noopener\">Server Side Scanner</a>."
 msgstr ""
 
 #: src/strings.php:117 src/strings.php:133
@@ -2119,20 +1973,17 @@ msgstr ""
 
 #: src/strings.php:118
 msgid ""
-"The Unix Diff Utility is enabled. You can click the files in the table to "
-"see the differences detected by the scanner. If you consider the differences "
-"to be harmless you can mark the file as fixed, otherwise it is advised to "
-"restore the original content immediately."
+"The Unix Diff Utility is enabled. You can click the files in the table to see the differences detected by the scanner. If "
+"you consider the differences to be harmless you can mark the file as fixed, otherwise it is advised to restore the "
+"original content immediately."
 msgstr ""
 
-#: src/strings.php:119 src/strings.php:224 src/strings.php:237
-#: src/strings.php:254 src/strings.php:271 src/strings.php:324
-#: src/strings.php:376 src/strings.php:409 src/strings.php:422
-#: src/strings.php:444 src/strings.php:459 src/strings.php:467
+#: src/strings.php:119 src/strings.php:226 src/strings.php:239 src/strings.php:256 src/strings.php:273 src/strings.php:326
+#: src/strings.php:378 src/strings.php:411 src/strings.php:424 src/strings.php:446 src/strings.php:461 src/strings.php:469
 msgid "Select All"
 msgstr ""
 
-#: src/strings.php:120 src/strings.php:135 src/strings.php:326
+#: src/strings.php:120 src/strings.php:135 src/strings.php:328
 msgid "File Size"
 msgstr ""
 
@@ -2140,17 +1991,15 @@ msgstr ""
 msgid "Modified At"
 msgstr ""
 
-#: src/strings.php:122 src/strings.php:137 src/strings.php:325
-#: src/strings.php:377 src/strings.php:460 src/strings.php:470
+#: src/strings.php:122 src/strings.php:137 src/strings.php:327 src/strings.php:379 src/strings.php:462 src/strings.php:472
 msgid "File Path"
 msgstr ""
 
-#: src/strings.php:123 src/strings.php:334 src/strings.php:352
-#: src/strings.php:436
+#: src/strings.php:123 src/strings.php:336 src/strings.php:354 src/strings.php:438
 msgid "I understand that this operation cannot be reverted."
 msgstr ""
 
-#: src/strings.php:124 src/strings.php:450
+#: src/strings.php:124 src/strings.php:452
 msgid "Action:"
 msgstr ""
 
@@ -2168,16 +2017,13 @@ msgstr ""
 
 #: src/strings.php:129 src/strings.php:138
 msgid ""
-"Marking one or more files as fixed will force the plugin to ignore them "
-"during the next scan, very useful when you find false positives. "
-"Additionally you can restore the original content of the core files that "
-"appear as modified or deleted, this will tell the plugin to download a copy "
-"of the original files from the official WordPress repository. Deleting a "
-"file is an irreversible action, be careful."
+"Marking one or more files as fixed will force the plugin to ignore them during the next scan, very useful when you find "
+"false positives. Additionally you can restore the original content of the core files that appear as modified or deleted, "
+"this will tell the plugin to download a copy of the original files from the official WordPress repository. Deleting a file "
+"is an irreversible action, be careful."
 msgstr ""
 
-#: src/strings.php:134 src/strings.php:327 src/strings.php:426
-#: src/strings.php:433 src/strings.php:461
+#: src/strings.php:134 src/strings.php:329 src/strings.php:428 src/strings.php:435 src/strings.php:463
 msgid "Status"
 msgstr ""
 
@@ -2193,8 +2039,8 @@ msgstr ""
 msgid "Logged-in Users"
 msgstr ""
 
-#: src/strings.php:149 src/strings.php:177
-msgid "Failed logins"
+#: src/strings.php:149
+msgid "Failed Logins"
 msgstr ""
 
 #: src/strings.php:152
@@ -2202,9 +2048,7 @@ msgid "Successful Logins (admins)"
 msgstr ""
 
 #: src/strings.php:153
-msgid ""
-"Here you can see a list of all the successful logins of accounts with admin "
-"privileges."
+msgid "Here you can see a list of all the successful logins of accounts with admin privileges."
 msgstr ""
 
 #: src/strings.php:155
@@ -2215,11 +2059,11 @@ msgstr ""
 msgid "Newest To Oldest"
 msgstr ""
 
-#: src/strings.php:161 src/strings.php:170 src/strings.php:181
+#: src/strings.php:161 src/strings.php:170 src/strings.php:182
 msgid "Date/Time"
 msgstr ""
 
-#: src/strings.php:162 src/strings.php:174 src/strings.php:196
+#: src/strings.php:162 src/strings.php:175 src/strings.php:198
 msgid "Edit"
 msgstr ""
 
@@ -2236,994 +2080,886 @@ msgid "Hostname"
 msgstr ""
 
 #: src/strings.php:178
-#, php-format
-msgid ""
-"This information will be used to determine if your site is being victim of "
-"<a href=\"https://kb.sucuri.net/definitions/attacks/brute-force/password-"
-"guessing\" target=\"_blank\" rel=\"noopener\">Password Guessing Brute Force "
-"Attacks</a>. These logs will be accumulated and the plugin will send a "
-"report via email if there are more than <code>%%SUCURI.FailedLogins."
-"MaxFailedLogins%%</code> failed login attempts during the same hour, you can "
-"change this number from <a href=\"%%SUCURI.URL.Settings%%#alerts\">here</a>. "
-"<b>NOTE:</b> Some <em>\"Two-Factor Authentication\"</em> plugins do not "
-"follow the same rules that WordPress have to report failed login attempts, "
-"so you may not see all the attempts in this panel if you have one of these "
-"plugins installed."
+msgid "Failed logins"
 msgstr ""
 
-#: src/strings.php:182
+#: src/strings.php:179
+#, php-format
+msgid ""
+"This information will be used to determine if your site is being victim of <a href=\"https://kb.sucuri.net/definitions/"
+"attacks/brute-force/password-guessing\" target=\"_blank\" rel=\"noopener\">Password Guessing Brute Force Attacks</a>. "
+"These logs will be accumulated and the plugin will send a report via email if there are more than <code>%%SUCURI."
+"FailedLogins.MaxFailedLogins%%</code> failed login attempts during the same hour, you can change this number from <a href="
+"\"%%SUCURI.URL.Settings%%#alerts\">here</a>. <b>NOTE:</b> Some <em>\"Two-Factor Authentication\"</em> plugins do not "
+"follow the same rules that WordPress have to report failed login attempts, so you may not see all the attempts in this "
+"panel if you have one of these plugins installed."
+msgstr ""
+
+#: src/strings.php:183
 msgid "Web Browser"
 msgstr ""
 
-#: src/strings.php:184
+#: src/strings.php:185
 msgid "Block"
 msgstr ""
 
-#: src/strings.php:187
+#: src/strings.php:189
 msgid "Logged-in Users}"
 msgstr ""
 
-#: src/strings.php:188
+#: src/strings.php:190
 msgid "Here you can see a list of the users that are currently logged-in."
 msgstr ""
 
-#: src/strings.php:189
+#: src/strings.php:191
 msgid "ID"
 msgstr ""
 
-#: src/strings.php:191
+#: src/strings.php:193
 msgid "Last Activity"
 msgstr ""
 
-#: src/strings.php:192 src/strings.php:412
+#: src/strings.php:194 src/strings.php:414
 msgid "Registered"
 msgstr ""
 
-#: src/strings.php:197 src/strings.php:206 src/strings.php:343
+#: src/strings.php:199 src/strings.php:208 src/strings.php:345
 msgid "Website:"
 msgstr ""
 
-#: src/strings.php:198 src/strings.php:268
+#: src/strings.php:200 src/strings.php:270
 msgid "IP Address:"
 msgstr ""
 
-#: src/strings.php:199
+#: src/strings.php:201
 msgid "Reverse IP:"
 msgstr ""
 
-#: src/strings.php:201
+#: src/strings.php:203
 msgid "Message:"
 msgstr ""
 
-#: src/strings.php:204
+#: src/strings.php:206
 msgid ""
-"An API key is required to activate some additional tools available in this "
-"plugin. The keys are free and you can virtually generate an unlimited number "
-"of them as long as the domain name and email address are unique. The key is "
-"used to authenticate the HTTP requests sent by the plugin to an API service "
-"managed by Sucuri Inc."
+"An API key is required to activate some additional tools available in this plugin. The keys are free and you can virtually "
+"generate an unlimited number of them as long as the domain name and email address are unique. The key is used to "
+"authenticate the HTTP requests sent by the plugin to an API service managed by Sucuri Inc."
 msgstr ""
 
-#: src/strings.php:205
+#: src/strings.php:207
 msgid ""
-"If you experience issues generating the API key you can request one by "
-"sending the domain name and email address that you want to use to <a href="
-"\"mailto:info@sucuri.net\">info@sucuri.net</a>. Note that generating a key "
-"for a website that is not facing the Internet is not possible because the "
-"API service needs to validate that the domain name exists."
+"If you experience issues generating the API key you can request one by sending the domain name and email address that you "
+"want to use to <a href=\"mailto:info@sucuri.net\">info@sucuri.net</a>. Note that generating a key for a website that is "
+"not facing the Internet is not possible because the API service needs to validate that the domain name exists."
 msgstr ""
 
-#: src/strings.php:207 src/strings.php:251
+#: src/strings.php:209 src/strings.php:253
 msgid "E-mail:"
 msgstr ""
 
-#: src/strings.php:208
-msgid "DNS Lookups"
-msgstr ""
-
-#: src/strings.php:209
-msgid ""
-"Check the box if your website is behind a known firewall service, this "
-"guarantees that the IP address of your visitors will be detected correctly "
-"for the security logs. You can change this later from the settings."
-msgstr ""
-
 #: src/strings.php:210
-msgid "Enable DNS Lookups On Startup"
+msgid "DNS Lookups"
 msgstr ""
 
 #: src/strings.php:211
 msgid ""
-"I agree to the <a target=\"_blank\" href=\"https://sucuri.net/terms\">Terms "
-"of Service</a>."
+"Check the box if your website is behind a known firewall service, this guarantees that the IP address of your visitors "
+"will be detected correctly for the security logs. You can change this later from the settings."
 msgstr ""
 
 #: src/strings.php:212
-msgid ""
-"I have read and understand the <a target=\"_blank\" href=\"https://sucuri."
-"net/privacy\">Privacy Policy</a>."
+msgid "Enable DNS Lookups On Startup"
 msgstr ""
 
-#: src/strings.php:216
-msgid "Password Guessing Brute Force Attacks"
+#: src/strings.php:213
+msgid "I agree to the <a target=\"_blank\" href=\"https://sucuri.net/terms\">Terms of Service</a>."
 msgstr ""
 
-#: src/strings.php:217
-msgid ""
-"<a href=\"https://kb.sucuri.net/definitions/attacks/brute-force/password-"
-"guessing\" target=\"_blank\" rel=\"noopener\">Password guessing brute force "
-"attacks</a> are very common against web sites and web servers. They are one "
-"of the most common vectors used to compromise web sites. The process is very "
-"simple and the attackers basically try multiple combinations of usernames "
-"and passwords until they find one that works. Once they get in, they can "
-"compromise the web site with malware, spam , phishing or anything else they "
-"want."
+#: src/strings.php:214
+msgid "I have read and understand the <a target=\"_blank\" href=\"https://sucuri.net/privacy\">Privacy Policy</a>."
 msgstr ""
 
 #: src/strings.php:218
+msgid "Password Guessing Brute Force Attacks"
+msgstr ""
+
+#: src/strings.php:219
+msgid ""
+"<a href=\"https://kb.sucuri.net/definitions/attacks/brute-force/password-guessing\" target=\"_blank\" rel=\"noopener"
+"\">Password guessing brute force attacks</a> are very common against web sites and web servers. They are one of the most "
+"common vectors used to compromise web sites. The process is very simple and the attackers basically try multiple "
+"combinations of usernames and passwords until they find one that works. Once they get in, they can compromise the web site "
+"with malware, spam , phishing or anything else they want."
+msgstr ""
+
+#: src/strings.php:220
 msgid "Consider Brute-Force Attack After:"
 msgstr ""
 
-#: src/strings.php:222
+#: src/strings.php:224
 msgid "Security Alerts"
 msgstr ""
 
-#: src/strings.php:223
+#: src/strings.php:225
 msgid ""
-"You have installed a plugin or theme that is not fully compatible with our "
-"plugin, some of the security alerts (like the successful and failed logins) "
-"will not be sent to you. To prevent an infinite loop while detecting these "
-"changes in the website and sending the email alerts via a custom SMTP "
-"plugin, we have decided to stop any attempt to send the emails to prevent "
-"fatal errors."
+"You have installed a plugin or theme that is not fully compatible with our plugin, some of the security alerts (like the "
+"successful and failed logins) will not be sent to you. To prevent an infinite loop while detecting these changes in the "
+"website and sending the email alerts via a custom SMTP plugin, we have decided to stop any attempt to send the emails to "
+"prevent fatal errors."
 msgstr ""
 
-#: src/strings.php:225
+#: src/strings.php:227
 msgid "Event"
 msgstr ""
 
-#: src/strings.php:229
+#: src/strings.php:231
 msgid "Post-Type Alerts"
 msgstr ""
 
-#: src/strings.php:230
-msgid ""
-"It seems that you disabled the email alerts for <b>new site content</b>, "
-"this panel is intended to provide a way to ignore specific events in your "
-"site and with that the alerts reported to your email. Since you have "
-"deactivated the <b>new site content</b> alerts, this panel will be disabled "
-"too."
-msgstr ""
-
-#: src/strings.php:231
-msgid ""
-"This is a list of registered <a href=\"https://codex.wordpress.org/Post_Types"
-"\" target=\"_blank\" rel=\"noopener\">Post Types</a>. You will receive an "
-"email alert when a custom page or post associated to any of these types is "
-"created or updated. If you don’t want to receive one or more of these "
-"alerts, feel free to uncheck the boxes in the table below. If you are "
-"receiving alerts for post types that are not listed in this table, it may be "
-"because there is an add-on that that is generating a custom post-type on "
-"runtime, you will have to find out by yourself what is the unique ID of that "
-"post-type and type it in the form below. The plugin will do its best to "
-"ignore these alerts as long as the unique ID is valid."
-msgstr ""
-
 #: src/strings.php:232
-msgid "Stop Alerts For This Post-Type:"
+msgid ""
+"It seems that you disabled the email alerts for <b>new site content</b>, this panel is intended to provide a way to ignore "
+"specific events in your site and with that the alerts reported to your email. Since you have deactivated the <b>new site "
+"content</b> alerts, this panel will be disabled too."
 msgstr ""
 
 #: src/strings.php:233
-msgid "e.g. unique_post_type_id"
+msgid ""
+"This is a list of registered <a href=\"https://codex.wordpress.org/Post_Types\" target=\"_blank\" rel=\"noopener\">Post "
+"Types</a>. You will receive an email alert when a custom page or post associated to any of these types is created or "
+"updated. If you don’t want to receive one or more of these alerts, feel free to uncheck the boxes in the table below. If "
+"you are receiving alerts for post types that are not listed in this table, it may be because there is an add-on that that "
+"is generating a custom post-type on runtime, you will have to find out by yourself what is the unique ID of that post-type "
+"and type it in the form below. The plugin will do its best to ignore these alerts as long as the unique ID is valid."
+msgstr ""
+
+#: src/strings.php:234
+msgid "Stop Alerts For This Post-Type:"
 msgstr ""
 
 #: src/strings.php:235
+msgid "e.g. unique_post_type_id"
+msgstr ""
+
+#: src/strings.php:237
 msgid "Show Post-Types Table"
 msgstr ""
 
-#: src/strings.php:236
+#: src/strings.php:238
 msgid "Hide Post-Types Table"
 msgstr ""
 
-#: src/strings.php:238
+#: src/strings.php:240
 msgid "Post Type"
 msgstr ""
 
-#: src/strings.php:239
+#: src/strings.php:241
 msgid "Post Type ID"
 msgstr ""
 
-#: src/strings.php:240
+#: src/strings.php:242
 msgid "Ignored At (optional)"
 msgstr ""
 
-#: src/strings.php:243
+#: src/strings.php:245
 msgid "Alerts Per Hour"
 msgstr ""
 
-#: src/strings.php:244
+#: src/strings.php:246
 msgid ""
-"Configure the maximum number of email alerts per hour. If the number is "
-"exceeded and the plugin detects more events during the same hour, it will "
-"still log the events into the audit logs but will not send the email alerts. "
-"Be careful with this as you will miss important information."
+"Configure the maximum number of email alerts per hour. If the number is exceeded and the plugin detects more events during "
+"the same hour, it will still log the events into the audit logs but will not send the email alerts. Be careful with this "
+"as you will miss important information."
 msgstr ""
 
-#: src/strings.php:245
+#: src/strings.php:247
 msgid "Maximum Alerts Per Hour:"
 msgstr ""
 
-#: src/strings.php:249
+#: src/strings.php:251
 msgid "Alerts Recipient"
 msgstr ""
 
-#: src/strings.php:250
+#: src/strings.php:252
 msgid ""
-"By default, the plugin will send the email alerts to the primary admin "
-"account, the same account created during the installation of WordPress in "
-"your web server. You can add more people to the list, they will receive a "
-"copy of the same security alerts."
+"By default, the plugin will send the email alerts to the primary admin account, the same account created during the "
+"installation of WordPress in your web server. You can add more people to the list, they will receive a copy of the same "
+"security alerts."
 msgstr ""
 
-#: src/strings.php:252
+#: src/strings.php:254
 msgid "e.g. user@example.com"
 msgstr ""
 
-#: src/strings.php:255 src/strings.php:411
+#: src/strings.php:257 src/strings.php:413
 msgid "E-mail"
 msgstr ""
 
-#: src/strings.php:257
+#: src/strings.php:259
 msgid "Test Alerts"
 msgstr ""
 
-#: src/strings.php:260
+#: src/strings.php:262
 msgid "Alert Subject"
 msgstr ""
 
-#: src/strings.php:261
+#: src/strings.php:263
 msgid ""
-"Format of the subject for the email alerts, by default the plugin will use "
-"the website name and the event identifier that is being reported, you can "
-"use this panel to include the IP address of the user that triggered the "
-"event and some additional data. You can create filters in your email client "
-"creating a custom email subject using the pseudo-tags shown below."
+"Format of the subject for the email alerts, by default the plugin will use the website name and the event identifier that "
+"is being reported, you can use this panel to include the IP address of the user that triggered the event and some "
+"additional data. You can create filters in your email client creating a custom email subject using the pseudo-tags shown "
+"below."
 msgstr ""
 
-#: src/strings.php:262
+#: src/strings.php:264
 msgid "Custom Format"
 msgstr ""
 
-#: src/strings.php:266
+#: src/strings.php:268
 msgid "Trusted IP Addresses"
 msgstr ""
 
-#: src/strings.php:267
+#: src/strings.php:269
 msgid ""
-"If you are working in a LAN <em>(Local Area Network)</em> you may want to "
-"include the IP addresses of all the nodes in the subnet, this will force the "
-"plugin to stop sending email alerts about actions executed from trusted IP "
-"addresses. Use the CIDR <em>(Classless Inter Domain Routing)</em> format to "
-"specify ranges of IP addresses <em>(only 8, 16, and 24)</em>."
+"If you are working in a LAN <em>(Local Area Network)</em> you may want to include the IP addresses of all the nodes in the "
+"subnet, this will force the plugin to stop sending email alerts about actions executed from trusted IP addresses. Use the "
+"CIDR <em>(Classless Inter Domain Routing)</em> format to specify ranges of IP addresses <em>(only 8, 16, and 24)</em>."
 msgstr ""
 
-#: src/strings.php:269
+#: src/strings.php:271
 msgid "e.g. 182.120.56.0/24"
 msgstr ""
 
-#: src/strings.php:273
+#: src/strings.php:275
 msgid "CIDR Format"
 msgstr ""
 
-#: src/strings.php:274
+#: src/strings.php:276
 msgid "IP Added At"
 msgstr ""
 
-#: src/strings.php:279
+#: src/strings.php:281
 msgid ""
-"If this operation was successful you will receive a message in the email "
-"used during the registration of the API key <em>(usually the email of the "
-"main admin user)</em>. This message contains the key in plain text, copy and "
-"paste the key in the form field below. The plugin will verify the "
-"authenticity of the key sending an initial HTTP request to the API service, "
-"if this fails the key will be removed automatically and you will have to "
-"start the process all over again."
+"If this operation was successful you will receive a message in the email used during the registration of the API key "
+"<em>(usually the email of the main admin user)</em>. This message contains the key in plain text, copy and paste the key "
+"in the form field below. The plugin will verify the authenticity of the key sending an initial HTTP request to the API "
+"service, if this fails the key will be removed automatically and you will have to start the process all over again."
 msgstr ""
 
-#: src/strings.php:280
+#: src/strings.php:282
 msgid ""
-"There are cases where this operation may fail, an example would be when the "
-"email address is not associated with the domain anymore, this happens when "
-"the base URL changes <em>(from www to none or viceversa)</em>. If you are "
-"having issues recovering the key please send an email explaining the "
-"situation to <a href=\"mailto:info@sucuri.net\">info@sucuri.net</a>"
+"There are cases where this operation may fail, an example would be when the email address is not associated with the "
+"domain anymore, this happens when the base URL changes <em>(from www to none or viceversa)</em>. If you are having issues "
+"recovering the key please send an email explaining the situation to <a href=\"mailto:info@sucuri.net\">info@sucuri.net</a>"
 msgstr ""
 
-#: src/strings.php:281 src/strings.php:319
+#: src/strings.php:283 src/strings.php:321
 msgid "API Key:"
 msgstr ""
 
-#: src/strings.php:285
+#: src/strings.php:287
 msgid ""
-"Congratulations! The rest of the features available in the plugin have been "
-"enabled. This product is designed to supplement existing security products. "
-"It’s not a silver bullet for your security needs, but it’ll give you greater "
+"Congratulations! The rest of the features available in the plugin have been enabled. This product is designed to "
+"supplement existing security products. It’s not a silver bullet for your security needs, but it’ll give you greater "
 "security awareness and better posture, all with the intent of reducing risk."
 msgstr ""
 
-#: src/strings.php:286
+#: src/strings.php:288
 msgid ""
-"Your website has been granted a new API key and it was associated to the "
-"email address that you chose during the registration process. You can use "
-"the same email to recover the key if you happen to lose it sometime. We "
-"encourage you to check the rest of the settings page and configure the "
-"plugin to your own needs."
+"Your website has been granted a new API key and it was associated to the email address that you chose during the "
+"registration process. You can use the same email to recover the key if you happen to lose it sometime. We encourage you to "
+"check the rest of the settings page and configure the plugin to your own needs."
 msgstr ""
 
-#: src/strings.php:291 src/strings.php:293
+#: src/strings.php:293 src/strings.php:295
 msgid "WordPress Checksums API"
 msgstr ""
 
-#: src/strings.php:292
+#: src/strings.php:294
 msgid ""
-"The WordPress integrity tool uses a remote API service maintained by the "
-"WordPress organization to determine which files in the installation were "
-"added, removed or modified. The API returns a list of files with their "
-"respective checksums, this information guarantees that the installation is "
-"not corrupt. You can, however, point the integrity tool to a GitHub "
-"repository in case that you are using a custom version of WordPress like the "
-"<a href=\"https://github.com/WordPress/WordPress\" target=\"_blank\" rel="
-"\"noopener\">development version of the code</a>."
+"The WordPress integrity tool uses a remote API service maintained by the WordPress organization to determine which files "
+"in the installation were added, removed or modified. The API returns a list of files with their respective checksums, this "
+"information guarantees that the installation is not corrupt. You can, however, point the integrity tool to a GitHub "
+"repository in case that you are using a custom version of WordPress like the <a href=\"https://github.com/WordPress/"
+"WordPress\" target=\"_blank\" rel=\"noopener\">development version of the code</a>."
 msgstr ""
 
-#: src/strings.php:294
+#: src/strings.php:296
 msgid "e.g. URL — or — user/repo"
 msgstr ""
 
-#: src/strings.php:298
+#: src/strings.php:300
 msgid "API Communication via Proxy"
 msgstr ""
 
-#: src/strings.php:299
-msgid ""
-"All the HTTP requests used to communicate with the API service are being "
-"sent using the WordPress built-in functions, so (almost) all its official "
-"features are inherited, this is useful if you need to pass these HTTP "
-"requests through a proxy. According to the <a href=\"https://developer."
-"wordpress.org/reference/classes/wp_http_proxy/\" target=\"_blank\" rel="
-"\"noopener\">official documentation</a> you have to add some constants to "
-"the main configuration file: <em>WP_PROXY_HOST, WP_PROXY_PORT, "
-"WP_PROXY_USERNAME, WP_PROXY_PASSWORD</em>."
-msgstr ""
-
-#: src/strings.php:300
-msgid "HTTP Proxy Hostname"
-msgstr ""
-
 #: src/strings.php:301
-msgid "HTTP Proxy Port num"
+msgid ""
+"All the HTTP requests used to communicate with the API service are being sent using the WordPress built-in functions, so "
+"(almost) all its official features are inherited, this is useful if you need to pass these HTTP requests through a proxy. "
+"According to the <a href=\"https://developer.wordpress.org/reference/classes/wp_http_proxy/\" target=\"_blank\" rel="
+"\"noopener\">official documentation</a> you have to add some constants to the main configuration file: <em>WP_PROXY_HOST, "
+"WP_PROXY_PORT, WP_PROXY_USERNAME, WP_PROXY_PASSWORD</em>."
 msgstr ""
 
 #: src/strings.php:302
-msgid "HTTP Proxy Username"
+msgid "HTTP Proxy Hostname"
 msgstr ""
 
 #: src/strings.php:303
+msgid "HTTP Proxy Port num"
+msgstr ""
+
+#: src/strings.php:304
+msgid "HTTP Proxy Username"
+msgstr ""
+
+#: src/strings.php:305
 msgid "HTTP Proxy Password"
 msgstr ""
 
-#: src/strings.php:306 src/strings.php:496
+#: src/strings.php:308 src/strings.php:498
 msgid "API Service Communication"
-msgstr ""
-
-#: src/strings.php:307
-msgid ""
-"Once the API key is generate the plugin will communicate with a remote API "
-"service that will act as a safe data storage for the audit logs generated "
-"when the website triggers certain events that the plugin monitors. If the "
-"website is hacked the attacker will not have access to these logs and that "
-"way you can investigate what was modified <em>(for malware infaction)</em> "
-"and/or how the malicious person was able to gain access to the website."
-msgstr ""
-
-#: src/strings.php:308
-#, php-format
-msgid ""
-"Disabling the API service communication will stop the event monitoring, "
-"consider to enable the <a href=\"%%SUCURI.URL.Settings%%#general\">Log "
-"Exporter</a> to keep the monitoring working while the HTTP requests are "
-"ignored, otherwise an attacker may execute an action that will not be "
-"registered in the security logs and you will not have a way to investigate "
-"the attack in the future."
 msgstr ""
 
 #: src/strings.php:309
 msgid ""
-"<strong>Are you a developer?</strong> You may be interested in our API. Feel "
-"free to use the URL shown below to access the latest 50 entries in your "
-"security log, change the value for the parameter <code>l=N</code> if you "
-"need more. Be aware that the API doesn’t provides an offset parameter, so if "
-"you have the intension to query specific sections of the log you will need "
-"to wrap the HTTP request around your own cache mechanism. We <strong>DO NOT</"
-"strong> take feature requests for the API, this is a semi-private service "
-"tailored for the specific needs of the plugin and not intended to be used by "
-"3rd-party apps, we may change the behavior of each API endpoint without "
-"previous notice, use it at your own risk."
+"Once the API key is generate the plugin will communicate with a remote API service that will act as a safe data storage "
+"for the audit logs generated when the website triggers certain events that the plugin monitors. If the website is hacked "
+"the attacker will not have access to these logs and that way you can investigate what was modified <em>(for malware "
+"infaction)</em> and/or how the malicious person was able to gain access to the website."
 msgstr ""
 
-#: src/strings.php:312
-msgid "API Key"
-msgstr ""
-
-#: src/strings.php:313
+#: src/strings.php:310
+#, php-format
 msgid ""
-"An API key is required to prevent attackers from deleting audit logs that "
-"can help you investigate and recover after a hack, and allows the plugin to "
-"display statistics. By generating an API key, you agree that Sucuri will "
-"collect and store anonymous data about your website. We take your privacy "
-"seriously."
+"Disabling the API service communication will stop the event monitoring, consider to enable the <a href=\"%%SUCURI.URL."
+"Settings%%#general\">Log Exporter</a> to keep the monitoring working while the HTTP requests are ignored, otherwise an "
+"attacker may execute an action that will not be registered in the security logs and you will not have a way to investigate "
+"the attack in the future."
+msgstr ""
+
+#: src/strings.php:311
+msgid ""
+"<strong>Are you a developer?</strong> You may be interested in our API. Feel free to use the URL shown below to access the "
+"latest 50 entries in your security log, change the value for the parameter <code>l=N</code> if you need more. Be aware "
+"that the API doesn’t provides an offset parameter, so if you have the intention to query specific sections of the log you "
+"will need to wrap the HTTP request around your own cache mechanism. We <strong>DO NOT</strong> take feature requests for "
+"the API, this is a semi-private service tailored for the specific needs of the plugin and not intended to be used by 3rd-"
+"party apps, we may change the behavior of each API endpoint without previous notice, use it at your own risk."
 msgstr ""
 
 #: src/strings.php:314
-#, php-format
-msgid ""
-"Your domain <code>%%SUCURI.CleanDomain%%</code> does not seems to have a DNS "
-"<code>A</code> record so it will be considered as <em>invalid</em> by the "
-"API interface when you request the generation of a new key. Adding "
-"<code>www</code> at the beginning of the domain name may fix this issue. If "
-"you do not understand what is this then send an email to our support team "
-"requesting the key."
+msgid "API Key"
 msgstr ""
 
 #: src/strings.php:315
-msgid "Recover Via E-mail"
+msgid ""
+"An API key is required to prevent attackers from deleting audit logs that can help you investigate and recover after a "
+"hack, and allows the plugin to display statistics. By generating an API key, you agree that Sucuri will collect and store "
+"anonymous data about your website. We take your privacy seriously."
 msgstr ""
 
 #: src/strings.php:316
-msgid "Manual Activation"
+#, php-format
+msgid ""
+"Your domain <code>%%SUCURI.CleanDomain%%</code> does not seems to have a DNS <code>A</code> record so it will be "
+"considered as <em>invalid</em> by the API interface when you request the generation of a new key. Adding <code>www</code> "
+"at the beginning of the domain name may fix this issue. If you do not understand what is this then send an email to our "
+"support team requesting the key."
 msgstr ""
 
 #: src/strings.php:317
-msgid ""
-"If you do not have access to the administrator email, you can reinstall the "
-"plugin. The API key is generated using an administrator email and the domain "
-"of the website. Click the \"Manual Activation\" button if you already have a "
-"valid API key to authenticate this website with the remote API web service."
+msgid "Recover Via E-mail"
 msgstr ""
 
-#: src/strings.php:322
+#: src/strings.php:318
+msgid "Manual Activation"
+msgstr ""
+
+#: src/strings.php:319
+msgid ""
+"If you do not have access to the administrator email, you can reinstall the plugin. The API key is generated using an "
+"administrator email and the domain of the website. Click the \"Manual Activation\" button if you already have a valid API "
+"key to authenticate this website with the remote API web service."
+msgstr ""
+
+#: src/strings.php:324
 msgid "Data Storage"
 msgstr ""
 
-#: src/strings.php:323
+#: src/strings.php:325
 msgid ""
-"This is the directory where the plugin will store the security logs, the "
-"list of files marked as fixed in the core integrity tool, the cache for the "
-"malware scanner and 3rd-party plugin metadata. The plugin requires write "
-"permissions in this directory as well as the files contained in it. If you "
-"prefer to keep these files in a non-public directory <em>(one level up the "
-"document root)</em> please define a constant in the <em>\"wp-config.php\"</"
-"em> file named <em>\"SUCURI_DATA_STORAGE\"</em> with the absolute path to "
-"the new directory."
+"This is the directory where the plugin will store the security logs, the list of files marked as fixed in the core "
+"integrity tool, the cache for the malware scanner and 3rd-party plugin metadata. The plugin requires write permissions in "
+"this directory as well as the files contained in it. If you prefer to keep these files in a non-public directory <em>(one "
+"level up the document root)</em> please define a constant in the <em>\"wp-config.php\"</em> file named <em>"
+"\"SUCURI_DATA_STORAGE\"</em> with the absolute path to the new directory."
 msgstr ""
 
-#: src/strings.php:332
+#: src/strings.php:334
 msgid "Import &amp; Export Settings"
 msgstr ""
 
-#: src/strings.php:333
+#: src/strings.php:335
 msgid ""
-"Copy the JSON-encoded data from the box below, go to your other websites and "
-"click the <em>\"Import\"</em> button in the settings page. The plugin will "
-"start using the same settings from this website. Notice that some options "
-"are omitted as they contain values specific to this website. To import the "
-"settings from another website into this one, replace the JSON-encoded data "
-"in the box below with the JSON-encoded data exported from the other website, "
-"then click the button <em>\"Import\"</em>. Notice that some options will not "
-"be imported to reduce the security risk of writing arbitrary data into the "
-"disk."
-msgstr ""
-
-#: src/strings.php:338
-msgid "IP Address Discoverer"
-msgstr ""
-
-#: src/strings.php:339
-msgid ""
-"IP address discoverer will use DNS lookups to automatically detect if the "
-"website is behind the <a href=\"https://sucuri.net/website-firewall/\" "
-"target=\"_blank\" rel=\"noopener\">Sucuri Firewall</a>, in which case it "
-"will modify the global server variable <em>Remote-Addr</em> to set the real "
-"IP of the website’s visitors. This check runs on every WordPress init action "
-"and that is why it may slow down your website as some hosting providers rely "
-"on slow DNS servers which makes the operation take more time than it should."
+"Copy the JSON-encoded data from the box below, go to your other websites and click the <em>\"Import\"</em> button in the "
+"settings page. The plugin will start using the same settings from this website. Notice that some options are omitted as "
+"they contain values specific to this website. To import the settings from another website into this one, replace the JSON-"
+"encoded data in the box below with the JSON-encoded data exported from the other website, then click the button <em>"
+"\"Import\"</em>. Notice that some options will not be imported to reduce the security risk of writing arbitrary data into "
+"the disk."
 msgstr ""
 
 #: src/strings.php:340
-msgid "HTTP Header:"
+msgid "IP Address Discoverer"
 msgstr ""
 
 #: src/strings.php:341
-msgid "Proceed"
+msgid ""
+"IP address discoverer will use DNS lookups to automatically detect if the website is behind the <a href=\"https://sucuri."
+"net/website-firewall/\" target=\"_blank\" rel=\"noopener\">Sucuri Firewall</a>, in which case it will modify the global "
+"server variable <em>Remote-Addr</em> to set the real IP of the website’s visitors. This check runs on every WordPress init "
+"action and that is why it may slow down your website as some hosting providers rely on slow DNS servers which makes the "
+"operation take more time than it should."
 msgstr ""
 
 #: src/strings.php:342
-msgid "Sucuri Firewall"
+msgid "HTTP Header:"
+msgstr ""
+
+#: src/strings.php:343
+msgid "Proceed"
 msgstr ""
 
 #: src/strings.php:344
-msgid "Top Level Domain:"
-msgstr ""
-
-#: src/strings.php:345
-msgid "Hostname:"
+msgid "Sucuri Firewall"
 msgstr ""
 
 #: src/strings.php:346
-msgid "IP Address (Hostname):"
+msgid "Top Level Domain:"
 msgstr ""
 
 #: src/strings.php:347
+msgid "Hostname:"
+msgstr ""
+
+#: src/strings.php:348
+msgid "IP Address (Hostname):"
+msgstr ""
+
+#: src/strings.php:349
 msgid "IP Address (Username):"
 msgstr ""
 
-#: src/strings.php:350
+#: src/strings.php:352
 msgid "Reset Security Logs, Hardening and Settings"
 msgstr ""
 
-#: src/strings.php:351
+#: src/strings.php:353
 msgid ""
-"This action will trigger the deactivation / uninstallation process of the "
-"plugin. All local security logs, hardening and settings will be deleted. "
-"Notice that the security logs stored in the API service will not be deleted, "
-"this is to prevent tampering from a malicious user. You can request a new "
-"API key if you want to start from scratch."
+"This action will trigger the deactivation / uninstallation process of the plugin. All local security logs, hardening and "
+"settings will be deleted. Notice that the security logs stored in the API service will not be deleted, this is to prevent "
+"tampering from a malicious user. You can request a new API key if you want to start from scratch."
 msgstr ""
 
-#: src/strings.php:356
+#: src/strings.php:358
 msgid "Reverse Proxy"
 msgstr ""
 
-#: src/strings.php:357
+#: src/strings.php:359
 msgid ""
-"The event monitor uses the API address of the origin of the request to track "
-"the actions. The plugin uses two methods to retrieve this: the main method "
-"uses the global server variable <em>Remote-Addr</em> available in most "
-"modern web servers, and an alternative method uses custom HTTP headers "
-"<em>(which are unsafe by default)</em>. You should not worry about this "
-"option unless you know what a reverse proxy is. Services like the <a href="
-"\"https://sucuri.net/website-firewall/\" target=\"_blank\" rel=\"noopener"
-"\">Sucuri Firewall</a> &mdash; once active &mdash; force the network traffic "
-"to pass through them to filter any security threat that may affect the "
-"original server. A side effect of this is that the real IP address is no "
-"longer available in the global server variable <em>Remote-Addr</em> but in a "
-"custom HTTP header with a name provided by the service."
+"The event monitor uses the API address of the origin of the request to track the actions. The plugin uses two methods to "
+"retrieve this: the main method uses the global server variable <em>Remote-Addr</em> available in most modern web servers, "
+"and an alternative method uses custom HTTP headers <em>(which are unsafe by default)</em>. You should not worry about this "
+"option unless you know what a reverse proxy is. Services like the <a href=\"https://sucuri.net/website-firewall/\" target="
+"\"_blank\" rel=\"noopener\">Sucuri Firewall</a> &mdash; once active &mdash; force the network traffic to pass through them "
+"to filter any security threat that may affect the original server. A side effect of this is that the real IP address is no "
+"longer available in the global server variable <em>Remote-Addr</em> but in a custom HTTP header with a name provided by "
+"the service."
 msgstr ""
 
-#: src/strings.php:360
+#: src/strings.php:362
 msgid "Log Exporter"
 msgstr ""
 
-#: src/strings.php:361
+#: src/strings.php:363
 msgid ""
-"This option allows you to export the WordPress audit logs to a local log "
-"file that can be read by a SIEM or any log analysis software <em>(we "
-"recommend OSSEC)</em>. That will give visibility from within WordPress to "
-"complement your log monitoring infrastructure. <b>NOTE:</b> Do not use a "
-"publicly accessible file, you must use a file at least one level up the "
-"document root to prevent leaks of information."
+"This option allows you to export the WordPress audit logs to a local log file that can be read by a SIEM or any log "
+"analysis software <em>(we recommend OSSEC)</em>. That will give visibility from within WordPress to complement your log "
+"monitoring infrastructure. <b>NOTE:</b> Do not use a publicly accessible file, you must use a file at least one level up "
+"the document root to prevent leaks of information."
 msgstr ""
 
-#: src/strings.php:362 src/strings.php:374
+#: src/strings.php:364 src/strings.php:376
 msgid "File Path:"
 msgstr ""
 
-#: src/strings.php:366
+#: src/strings.php:368
 msgid "Timezone Override"
 msgstr ""
 
-#: src/strings.php:367
+#: src/strings.php:369
 msgid ""
-"This option defines the timezone that will be used through out the entire "
-"plugin to print the dates and times whenever is necessary. This option also "
-"affects the date and time of the logs visible in the audit logs panel which "
-"is data that comes from a remote server configured to use Eastern Daylight "
-"Time (EDT). WordPress offers an option in the general settings page to allow "
-"you to configure the timezone for the entire website, however, if you are "
-"experiencing problems with the time in the audit logs, this option will help "
-"you fix them."
+"This option defines the timezone that will be used through out the entire plugin to print the dates and times whenever is "
+"necessary. This option also affects the date and time of the logs visible in the audit logs panel which is data that comes "
+"from a remote server configured to use Eastern Daylight Time (EDT). WordPress offers an option in the general settings "
+"page to allow you to configure the timezone for the entire website, however, if you are experiencing problems with the "
+"time in the audit logs, this option will help you fix them."
 msgstr ""
 
-#: src/strings.php:368
+#: src/strings.php:370
 msgid "Timezone:"
 msgstr ""
 
-#: src/strings.php:372
+#: src/strings.php:374
 msgid "Whitelist Blocked PHP Files"
 msgstr ""
 
-#: src/strings.php:373
+#: src/strings.php:375
 msgid ""
-"After you apply the hardening in either the includes, content, and/or "
-"uploads directories, the plugin will add a rule in the access control file "
-"to deny access to any PHP file located in these folders. This is a good "
-"precaution in case an attacker is able to upload a shell script. With a few "
-"exceptions the <em>\"index.php\"</em> file is the only one that should be "
-"publicly accessible, however many theme/plugin developers decide to use "
-"these folders to process some operations. In this case applying the "
-"hardening <strong>may break</strong> their functionality."
+"After you apply the hardening in either the includes, content, and/or uploads directories, the plugin will add a rule in "
+"the access control file to deny access to any PHP file located in these folders. This is a good precaution in case an "
+"attacker is able to upload a shell script. With a few exceptions the <em>\"index.php\"</em> file is the only one that "
+"should be publicly accessible, however many theme/plugin developers decide to use these folders to process some "
+"operations. In this case applying the hardening <strong>may break</strong> their functionality."
 msgstr ""
 
-#: src/strings.php:378
+#: src/strings.php:380
 msgid "Directory"
 msgstr ""
 
-#: src/strings.php:379
+#: src/strings.php:381
 msgid "Pattern"
 msgstr ""
 
-#: src/strings.php:384 src/strings.php:392
+#: src/strings.php:386 src/strings.php:394
 msgid ""
-"WordPress has a big user base in the public Internet, which brings interest "
-"to attackers to find vulnerabilities in the code, 3rd-party extensions, and "
-"themes that other companies develop. You should keep every piece of code "
-"installed in your website updated to prevent attacks as soon as disclosed "
-"vulnerabilities are patched."
+"WordPress has a big user base in the public Internet, which brings interest to attackers to find vulnerabilities in the "
+"code, 3rd-party extensions, and themes that other companies develop. You should keep every piece of code installed in your "
+"website updated to prevent attacks as soon as disclosed vulnerabilities are patched."
 msgstr ""
 
-#: src/strings.php:386 src/strings.php:394 src/strings.php:424
+#: src/strings.php:388 src/strings.php:396 src/strings.php:426
 msgid "Version"
 msgstr ""
 
-#: src/strings.php:387 src/strings.php:395
+#: src/strings.php:389 src/strings.php:397
 msgid "Update"
 msgstr ""
 
-#: src/strings.php:388 src/strings.php:396
+#: src/strings.php:390 src/strings.php:398
 msgid "Tested With"
 msgstr ""
 
-#: src/strings.php:391
+#: src/strings.php:393
 msgid "Available Plugin and Theme Updates"
 msgstr ""
 
-#: src/strings.php:400
+#: src/strings.php:402
 msgid "Download"
 msgstr ""
 
-#: src/strings.php:403
+#: src/strings.php:405
 msgid ""
-"WordPress has generated a new (random) password for your account <b>%%SUCURI."
-"ResetPassword.UserName%%</b> at <a target=\"_blank\" href=\"http://%%SUCURI."
-"ResetPassword.Website%%\" rel=\"noopener\">%%SUCURI.ResetPassword.Website%%</"
-"a>. The change has been requested by one of the admins in this website for "
-"security reasons. Your new password is &mdash; <span style=\"font-family:"
-"Menlo, Monaco, monospace, serif;font-weight:700\">%%%SUCURI.ResetPassword."
-"Password%%%</span> &mdash; please change it as soon as possible."
-msgstr ""
-
-#: src/strings.php:406
-msgid "Reset User Password"
+"WordPress has generated a new (random) password for your account <b>%%SUCURI.ResetPassword.UserName%%</b> at <a target="
+"\"_blank\" href=\"http://%%SUCURI.ResetPassword.Website%%\" rel=\"noopener\">%%SUCURI.ResetPassword.Website%%</a>. The "
+"change has been requested by one of the admins in this website for security reasons. Your new password is &mdash; <span "
+"style=\"font-family:Menlo, Monaco, monospace, serif;font-weight:700\">%%%SUCURI.ResetPassword.Password%%%</span> &mdash; "
+"please change it as soon as possible."
 msgstr ""
 
 #: src/strings.php:408
-msgid ""
-"You can generate a new random password for the user accounts that you select "
-"from the list. An email with the new password will be sent to the email "
-"address of each chosen user. If you choose to change the password of your "
-"own user, then your current session will expire immediately. You will need "
-"to log back into the admin panel with the new password that will be sent to "
-"your email."
+msgid "Reset User Password"
 msgstr ""
 
-#: src/strings.php:413
+#: src/strings.php:410
+msgid ""
+"You can generate a new random password for the user accounts that you select from the list. An email with the new password "
+"will be sent to the email address of each chosen user. If you choose to change the password of your own user, then your "
+"current session will expire immediately. You will need to log back into the admin panel with the new password that will be "
+"sent to your email."
+msgstr ""
+
+#: src/strings.php:415
 msgid "Roles"
 msgstr ""
 
-#: src/strings.php:417
-msgid "Reset Installed Plugins"
-msgstr ""
-
 #: src/strings.php:419
-msgid ""
-"In case you suspect having an infection in your site, or after you got rid "
-"of a malicious code, it’s recommended to reinstall all the plugins installed "
-"in your site, including the ones you are not using. Notice that premium "
-"plugins will not be automatically reinstalled to prevent backward "
-"compatibility issues and problems with licenses."
-msgstr ""
-
-#: src/strings.php:420
-#, php-format
-msgid ""
-"The information shown here is cached for %%SUCURI.ResetPlugin.CacheLifeTime"
-"%% seconds. This is necessary to reduce the quantity of HTTP requests sent "
-"to the WordPress servers and the bandwidth of your site. Currently there is "
-"no option to recreate this cache."
+msgid "Reset Installed Plugins"
 msgstr ""
 
 #: src/strings.php:421
 msgid ""
-"<b>WARNING!</b> This procedure can break your website. The reset will not "
-"affect the database nor the settings of each plugin, but depending on how "
-"they were written the reset action might break them. Be sure to create a "
-"backup of the plugins directory before the execution of this tool."
+"In case you suspect having an infection in your site, or after you got rid of a malicious code, it’s recommended to "
+"reinstall all the plugins installed in your site, including the ones you are not using. Notice that premium plugins will "
+"not be automatically reinstalled to prevent backward compatibility issues and problems with licenses."
 msgstr ""
 
-#: src/strings.php:425
+#: src/strings.php:422
+#, php-format
+msgid ""
+"The information shown here is cached for %%SUCURI.ResetPlugin.CacheLifeTime%% seconds. This is necessary to reduce the "
+"quantity of HTTP requests sent to the WordPress servers and the bandwidth of your site. Currently there is no option to "
+"recreate this cache."
+msgstr ""
+
+#: src/strings.php:423
+msgid ""
+"<b>WARNING!</b> This procedure can break your website. The reset will not affect the database nor the settings of each "
+"plugin, but depending on how they were written the reset action might break them. Be sure to create a backup of the "
+"plugins directory before the execution of this tool."
+msgstr ""
+
+#: src/strings.php:427
 msgid "Type"
 msgstr ""
 
-#: src/strings.php:430
+#: src/strings.php:432
 msgid "Update Secret Keys"
 msgstr ""
 
-#: src/strings.php:431
+#: src/strings.php:433
 msgid ""
-"The secret or security keys are a list of constants added to your site to "
-"ensure better encryption of information stored in the user’s cookies. A "
-"secret key makes your site harder to hack by adding random elements to the "
-"password. You do not have to remember the keys, just write a random, "
-"complicated, and long string in the <code>wp-config.php</code> file. You can "
-"change these keys at any point in time. Changing them will invalidate all "
-"existing cookies, forcing all logged in users to login again."
+"The secret or security keys are a list of constants added to your site to ensure better encryption of information stored "
+"in the user’s cookies. A secret key makes your site harder to hack by adding random elements to the password. You do not "
+"have to remember the keys, just write a random, complicated, and long string in the <code>wp-config.php</code> file. You "
+"can change these keys at any point in time. Changing them will invalidate all existing cookies, forcing all logged in "
+"users to login again."
 msgstr ""
 
-#: src/strings.php:432
+#: src/strings.php:434
 msgid "Your current session will expire once the form is submitted."
 msgstr ""
 
-#: src/strings.php:437
+#: src/strings.php:439
 msgid "Generate New Security Keys"
 msgstr ""
 
-#: src/strings.php:440
-msgid "Scheduled Tasks"
-msgstr ""
-
-#: src/strings.php:441
-msgid ""
-"The plugin scans your entire website looking for changes which are later "
-"reported via the API in the audit logs page. By default the scanner runs "
-"daily but you can change the frequency to meet your requirements. Notice "
-"that scanning your project files too frequently may affect the performance "
-"of your website. Be sure to have enough server resources before changing "
-"this option. The memory limit and maximum execution time are two of the PHP "
-"options that your server will set to stop your website from consuming too "
-"much resources."
-msgstr ""
-
 #: src/strings.php:442
-msgid ""
-"The scanner uses the <a href=\"http://php.net/manual/en/class.splfileobject."
-"php\" target=\"_blank\" rel=\"noopener\">PHP SPL library</a> and the <a "
-"target=\"_blank\" href=\"http://php.net/manual/en/class.filesystemiterator."
-"php\" rel=\"noopener\">Filesystem Iterator</a> class to scan the directory "
-"tree where your website is located in the server. This library is only "
-"available on PHP 5 >= 5.3.0 &mdash; OR &mdash; PHP 7; if you have an older "
-"version of PHP the plugin will not work as expected. Please ask your hosting "
-"provider to advise you on this matter."
+msgid "Scheduled Tasks"
 msgstr ""
 
 #: src/strings.php:443
 msgid ""
-"Scheduled tasks are rules registered in your database by a plugin, theme, or "
-"the base system itself; they are used to automatically execute actions "
-"defined in the code every certain amount of time. A good use of these rules "
-"is to generate backup files of your site, execute a security scanner, or "
-"remove unused elements like drafts. <b>Note:</b> Scheduled tasks can be re-"
-"installed by any plugin/theme automatically."
+"The plugin scans your entire website looking for changes which are later reported via the API in the audit logs page. By "
+"default the scanner runs daily but you can change the frequency to meet your requirements. Notice that scanning your "
+"project files too frequently may affect the performance of your website. Be sure to have enough server resources before "
+"changing this option. The memory limit and maximum execution time are two of the PHP options that your server will set to "
+"stop your website from consuming too much resources."
 msgstr ""
 
-#: src/strings.php:446
-msgid "Schedule"
+#: src/strings.php:444
+msgid ""
+"The scanner uses the <a href=\"http://php.net/manual/en/class.splfileobject.php\" target=\"_blank\" rel=\"noopener\">PHP "
+"SPL library</a> and the <a target=\"_blank\" href=\"http://php.net/manual/en/class.filesystemiterator.php\" rel=\"noopener"
+"\">Filesystem Iterator</a> class to scan the directory tree where your website is located in the server. This library is "
+"only available on PHP 5 >= 5.3.0 &mdash; OR &mdash; PHP 7; if you have an older version of PHP the plugin will not work as "
+"expected. Please ask your hosting provider to advise you on this matter."
 msgstr ""
 
-#: src/strings.php:447
-msgid "Next Due"
+#: src/strings.php:445
+msgid ""
+"Scheduled tasks are rules registered in your database by a plugin, theme, or the base system itself; they are used to "
+"automatically execute actions defined in the code every certain amount of time. A good use of these rules is to generate "
+"backup files of your site, execute a security scanner, or remove unused elements like drafts. <b>Note:</b> Scheduled tasks "
+"can be re-installed by any plugin/theme automatically."
 msgstr ""
 
 #: src/strings.php:448
+msgid "Schedule"
+msgstr ""
+
+#: src/strings.php:449
+msgid "Next Due"
+msgstr ""
+
+#: src/strings.php:450
 msgid "Arguments"
 msgstr ""
 
-#: src/strings.php:454
+#: src/strings.php:456
 msgid "Ignore Files And Folders During The Scans"
 msgstr ""
 
-#: src/strings.php:455
+#: src/strings.php:457
 msgid ""
-"Use this tool to select the files and/or folders that are too heavy for the "
-"scanner to process. These are usually folders with images, media files like "
-"videos and audios, backups and &mdash; in general &mdash; anything that is "
-"not code-related. Ignoring these files or folders will reduce the memory "
-"consumption of the PHP script."
+"Use this tool to select the files and/or folders that are too heavy for the scanner to process. These are usually folders "
+"with images, media files like videos and audios, backups and &mdash; in general &mdash; anything that is not code-related. "
+"Ignoring these files or folders will reduce the memory consumption of the PHP script."
 msgstr ""
 
-#: src/strings.php:456
+#: src/strings.php:458
 msgid "Ignore a file or directory:"
 msgstr ""
 
-#: src/strings.php:457
+#: src/strings.php:459
 msgid "e.g. /private/directory/"
 msgstr ""
 
-#: src/strings.php:462
+#: src/strings.php:464
 msgid "Unignore Selected Directories"
 msgstr ""
 
-#: src/strings.php:465
+#: src/strings.php:467
 msgid "WordPress Integrity (False Positives)"
 msgstr ""
 
-#: src/strings.php:466
+#: src/strings.php:468
 msgid ""
-"Since the scanner doesn’t read the files during the execution of the "
-"integrity check, it is possible to find false positives. Files listed here "
-"have been marked as false positives and will be ignored by the scanner in "
-"subsequent scans."
+"Since the scanner doesn’t read the files during the execution of the integrity check, it is possible to find false "
+"positives. Files listed here have been marked as false positives and will be ignored by the scanner in subsequent scans."
 msgstr ""
 
-#: src/strings.php:468
+#: src/strings.php:470
 msgid "Reason"
 msgstr ""
 
-#: src/strings.php:469
+#: src/strings.php:471
 msgid "Ignored At"
 msgstr ""
 
-#: src/strings.php:472
+#: src/strings.php:474
 msgid "Stop Ignoring the Selected Files"
 msgstr ""
 
-#: src/strings.php:476
+#: src/strings.php:478
 msgid ""
-"If your server allows the execution of system commands, you can configure "
-"the plugin to use the <a href=\"https://en.wikipedia.org/wiki/Diff_utility\" "
-"target=\"_blank\" rel=\"noopener\">Unix Diff Utility</a> to compare the "
-"actual content of the file installed in the website and the original file "
-"provided by WordPress. This will show the differences between both files and "
-"then you can act upon the information provided."
+"If your server allows the execution of system commands, you can configure the plugin to use the <a href=\"https://en."
+"wikipedia.org/wiki/Diff_utility\" target=\"_blank\" rel=\"noopener\">Unix Diff Utility</a> to compare the actual content "
+"of the file installed in the website and the original file provided by WordPress. This will show the differences between "
+"both files and then you can act upon the information provided."
 msgstr ""
 
-#: src/strings.php:480
+#: src/strings.php:482
 msgid "Environment Variables"
 msgstr ""
 
-#: src/strings.php:483
-msgid "Access File Integrity"
-msgstr ""
-
-#: src/strings.php:484
-msgid ""
-"The <code>.htaccess</code> file is a distributed configuration file, and is "
-"how the Apache web server handles configuration changes on a per-directory "
-"basis. WordPress uses this file to manipulate how Apache serves files from "
-"its root directory and subdirectories thereof; most notably, it modifies "
-"this file to be able to handle pretty permalinks."
-msgstr ""
-
 #: src/strings.php:485
-msgid "Htaccess file found in"
+msgid "Access File Integrity"
 msgstr ""
 
 #: src/strings.php:486
 msgid ""
-"Your website has no <code>.htaccess</code> file or it was not found in the "
-"default location."
+"The <code>.htaccess</code> file is a distributed configuration file, and is how the Apache web server handles "
+"configuration changes on a per-directory basis. WordPress uses this file to manipulate how Apache serves files from its "
+"root directory and subdirectories thereof; most notably, it modifies this file to be able to handle pretty permalinks."
 msgstr ""
 
 #: src/strings.php:487
-msgid ""
-"The main <code>.htaccess</code> file in your site has the standard rules for "
-"a WordPress installation. You can customize it to improve the performance "
-"and change the behaviour of the redirections for pages and posts in your "
-"site. To get more information visit the official documentation at <a target="
-"\"_blank\" rel=\"noopener\" href=\"https://codex.wordpress.org/"
-"Using_Permalinks#Creating_and_editing_.28.htaccess.29\"> Codex WordPress - "
-"Creating and editing (.htaccess)</a>"
+msgid "Htaccess file found in"
 msgstr ""
 
 #: src/strings.php:488
-msgid "Codex WordPress HTAccess"
+msgid "Your website has no <code>.htaccess</code> file or it was not found in the default location."
+msgstr ""
+
+#: src/strings.php:489
+msgid "Your web server does not support .htaccess files."
+msgstr ""
+
+#: src/strings.php:490
+msgid ""
+"The main <code>.htaccess</code> file in your site has the standard rules for a WordPress installation. You can customize "
+"it to improve the performance and change the behaviour of the redirections for pages and posts in your site. To get more "
+"information visit the official documentation at <a target=\"_blank\" rel=\"noopener\" href=\"https://codex.wordpress.org/"
+"Using_Permalinks#Creating_and_editing_.28.htaccess.29\"> Codex WordPress - Creating and editing (.htaccess)</a>"
 msgstr ""
 
 #: src/strings.php:491
-msgid "General Settings"
-msgstr ""
-
-#: src/strings.php:492
-msgid "Scanner"
+msgid "Codex WordPress HTAccess"
 msgstr ""
 
 #: src/strings.php:493
-msgid "Hardening"
+msgid "General Settings"
 msgstr ""
 
 #: src/strings.php:494
-msgid "Post-Hack"
+msgid "Scanner"
 msgstr ""
 
 #: src/strings.php:495
-msgid "Alerts"
+msgid "Hardening"
+msgstr ""
+
+#: src/strings.php:496
+msgid "Post-Hack"
 msgstr ""
 
 #: src/strings.php:497
+msgid "Alerts"
+msgstr ""
+
+#: src/strings.php:499
 msgid "Website Info"
 msgstr ""
 
-#: src/strings.php:498
+#: src/strings.php:500
 msgid "Hardening Options"
 msgstr ""
 
-#: src/strings.php:501
+#: src/strings.php:503
 #, php-format
 msgid "This information will be updated %%SUCURI.SiteCheck.Lifetime%%"
 msgstr ""
 
-#: src/strings.php:502
+#: src/strings.php:504
 msgid "Refresh Malware Scan"
 msgstr ""
 
-#: src/strings.php:505
+#: src/strings.php:507
 msgid "No malicious JavaScript"
 msgstr ""
 
-#: src/strings.php:506
+#: src/strings.php:508
 msgid "No malicious iFrames"
 msgstr ""
 
-#: src/strings.php:507
+#: src/strings.php:509
 msgid "No suspicious redirections"
 msgstr ""
 
-#: src/strings.php:508
+#: src/strings.php:510
 msgid "No blackhat SEO spam"
 msgstr ""
 
-#: src/strings.php:509
+#: src/strings.php:511
 msgid "No anomaly detection"
 msgstr ""
 
-#: src/strings.php:510
+#: src/strings.php:512
 msgid ""
-"Some types of problems cannot be detected by this scanner. If this scanner "
-"did not detect any issue and you still suspect a problem exists, you can <a "
-"href=\"https://sucuri.net/website-security-platform/signup\" target=\"_blank"
-"\" rel=\"noopener\">sign up with Sucuri</a> for a complete and in-depth scan "
-"+ cleanup (not included in the free checks)."
+"Some types of problems cannot be detected by this scanner. If this scanner did not detect any issue and you still suspect "
+"a problem exists, you can <a href=\"https://sucuri.net/website-security-platform/signup\" target=\"_blank\" rel=\"noopener"
+"\">sign up with Sucuri</a> for a complete and in-depth scan + cleanup (not included in the free checks)."
 msgstr ""
 
-#: src/strings.php:513
+#: src/strings.php:515
 msgid "Hover to see the Payload"
 msgstr ""
 
-#: src/strings.php:516
+#: src/strings.php:518
 msgid "Recommendations"
 msgstr ""
 
-#: src/strings.php:519 src/strings.php:521
+#: src/strings.php:521 src/strings.php:523
 msgid "Malware Scan Target"
 msgstr ""
 
-#: src/strings.php:520
+#: src/strings.php:522
 msgid ""
-"The remote malware scanner provided by the plugin is powered by <a href="
-"\"https://sitecheck.sucuri.net/\" target=\"_blank\" rel=\"noopener\">Sucuri "
-"SiteCheck</a>, a service that takes a publicly accessible URL and scans it "
-"for malicious code. If your website is not visible to the Internet, for "
-"example, if it is hosted in a local development environment or a restricted "
-"network, the scanner will not be able to work on it. Additionally, if the "
-"website was installed in a non-standard directory the scanner will report a "
-"\"404 Not Found\" error. You can use this option to change the URL that will "
+"The remote malware scanner provided by the plugin is powered by <a href=\"https://sitecheck.sucuri.net/\" target=\"_blank"
+"\" rel=\"noopener\">Sucuri SiteCheck</a>, a service that takes a publicly accessible URL and scans it for malicious code. "
+"If your website is not visible to the Internet, for example, if it is hosted in a local development environment or a "
+"restricted network, the scanner will not be able to work on it. Additionally, if the website was installed in a non-"
+"standard directory the scanner will report a \"404 Not Found\" error. You can use this option to change the URL that will "
 "be scanned."
 msgstr ""
 
-#: src/strings.php:522
+#: src/strings.php:524
 msgid "Malware Scan Target:"
 msgstr ""
 
-#: src/strings.php:526
+#: src/strings.php:528
 msgid "WordPress Security Recommendations"
 msgstr ""
 
@@ -3231,21 +2967,131 @@ msgstr ""
 msgid "Invalid template type"
 msgstr ""
 
-#: src/wordpress-recommendations.php:62
+#: src/wordpress-recommendations.lib.php:63
+msgid "Implement an SSL Certificate"
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:63
+msgid ""
+"SSL certificates help protect the integrity of the data in transit between the host (web server or firewall) and the "
+"client (web browser)."
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:75
 msgid "Upgrade PHP to a supported version"
 msgstr ""
 
-#: src/wordpress-recommendations.php:63
-msgid "The PHP version you are using no longer receives security support and could be exposed to unpatched security vulnerabilities."
-msgstr ""
-
-#: src/wordpress-recommendations.php:76
+#: src/wordpress-recommendations.lib.php:75
 msgid ""
-"Your WordPress install is following <a href=\"https://sucuri.net/guides/wordpress-security\" target=\"_blank\" rel=\"noopener\">"
-"the security best practices</a>."
+"The PHP version you are using no longer receives security support and could be exposed to unpatched security "
+"vulnerabilities."
 msgstr ""
 
-#: sucuri.php:316
+#: src/wordpress-recommendations.lib.php:88
+msgid "Missing WordPress Salt & Security Keys"
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:88
+msgid ""
+"Consider using WordPress Salt & Security Keys to add an extra layer of protection to the session cookies and credentials."
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:95
+msgid "WordPress Salt & Security Keys should be updated"
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:95
+msgid ""
+"Updating WordPress Salt & Security Keys after a compromise and on a regular basis, at least once a year, reduces the risks "
+"of session hijacking."
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:108
+msgid "Admin/Administrator username still exists"
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:108
+msgid ""
+"Using a unique username and removing the default admin/administrator account make it more difficult for attackers to brute "
+"force your WordPress."
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:121
+msgid "Use super admin account only when needed"
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:121
+msgid "Create an Editor account instead of always using the super-admin to reduce the damage in case of session hijacking."
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:149
+msgid "Unable to detect a popular 2FA plugin"
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:149
+msgid "Do you have another 2FA solution in place? If not, it's recommended that you add a 2FA plugin to protect your website."
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:167
+msgid "Remove unwanted/unused extensions"
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:167
+msgid "Keeping unwanted themes and plugins increases the chance of a compromise, even if they are disabled."
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:179
+msgid "Decrease the number of plugins"
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:179
+msgid "The greater the number of plugins installed, the greater the risk of infection and performance issues."
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:195
+msgid "Unable to detect a popular backup plugin"
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:195
+msgid "Do you have another backup solution in place? If not, it\'s recommended that you add a backup plugin "
+"to recover your website when needed."
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:207
+msgid "Disable file editing"
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:207
+msgid "Using \"DISALLOW_FILE_EDIT\" helps prevent an attacker from changing your files through WordPress backend."
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:219
+msgid "Disable WordPress debug mode"
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:219
+msgid ""
+"When \"WP_DEBUG\" is set to true, it will cause all PHP errors, notices and warnings to be displayed which can expose "
+"sensitive information."
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:236
+msgid "Prevent PHP direct execution on sensitive directories"
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:236
+msgid ""
+"Directories such as \"wp-content\" and \"wp-includes\" are generally not intended to be accessed by any user, consider "
+"hardening them via Sucuri Security -> Settings -> Hardening."
+msgstr ""
+
+#: src/wordpress-recommendations.lib.php:249
+msgid ""
+"Your WordPress install is following <a href=\"https://sucuri.net/guides/wordpress-security\" target=\"_blank\" rel="
+"\"noopener\">the security best practices</a>."
+msgstr ""
+
+#: sucuri.php:317
 msgid "Sucuri plugin has been uninstalled"
 msgstr ""
 
@@ -3259,12 +3105,10 @@ msgstr ""
 
 #. Description of the plugin/theme
 msgid ""
-"The <a href=\"https://sucuri.net/\" target=\"_blank\">Sucuri</a> plugin "
-"provides the website owner the best Activity Auditing, SiteCheck Remote "
-"Malware Scanning, Effective Security Hardening and Post-Hack features. "
-"SiteCheck will check for malware, spam, blacklisting and other security "
-"issues like .htaccess redirects, hidden eval code, etc. The best thing about "
-"it is it's completely free."
+"The <a href=\"https://sucuri.net/\" target=\"_blank\">Sucuri</a> plugin provides the website owner the best Activity "
+"Auditing, SiteCheck Remote Malware Scanning, Effective Security Hardening and Post-Hack features. SiteCheck will check for "
+"malware, spam, blacklisting and other security issues like .htaccess redirects, hidden eval code, etc. The best thing "
+"about it is it's completely free."
 msgstr ""
 
 #. Author of the plugin/theme

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: dd@sucuri.net
 Donate Link: https://sucuri.net/
 Tags: malware, security, firewall, scan, spam, virus, sucuri, protection, blacklist, detection, hardening, file integrity
 Requires at least: 3.6
-Tested up to: 5.2
-Stable tag: 1.8.21
+Tested up to: 5.2.2
+Stable tag: 1.8.22
 
 The Sucuri WordPress Security plugin is a security toolset for security integrity monitoring, malware detection and security hardening.
 
@@ -189,6 +189,22 @@ We take your privacy seriously. For free plugin users without an API key, no inf
 This version adds an option to refresh the malware scan results on demand, as well as several small bug fixes and improvements.
 
 == Changelog ==
+
+= 1.8.22 =
+* Add "SSL existence check" to WordPress Security Recommendations
+* Add "Salt & Security Keys existence check" to WordPress Security Recommendations
+* Add "Salt & Security Keys age check" to WordPress Security Recommendations
+* Add "Admin account check" to WordPress Security Recommendations
+* Add "Single super-admin check" to WordPress Security Recommendations
+* Add "Use of 2FA plugin login recommendation" to WordPress Security Recommendations
+* Add "Use of backups plugin recommendation" to WordPress Security Recommendations
+* Add "Too much plugin check" to WordPress Security Recommendations
+* Add "File editing check" to WordPress Security Recommendations
+* Add "WordPress debug check" to WordPress Security Recommendations
+* Add "Server Tokens check" to WordPress Security Recommendations
+* Add "Basic hardening check" to WordPress Security Recommendations
+* Update translation file to include new WordPress Security Recommendations checks
+* Remove PHP version check from hardening page
 
 = 1.8.21 =
 * Add WordPress Security Recommendations section in the dashboard

--- a/readme.txt
+++ b/readme.txt
@@ -201,9 +201,11 @@ This version adds an option to refresh the malware scan results on demand, as we
 * Add "Too much plugin check" to WordPress Security Recommendations
 * Add "File editing check" to WordPress Security Recommendations
 * Add "WordPress debug check" to WordPress Security Recommendations
-* Add "Server Tokens check" to WordPress Security Recommendations
 * Add "Basic hardening check" to WordPress Security Recommendations
-* Update translation file to include new WordPress Security Recommendations checks
+* Add a delete button on Last Logins sections
+* Add register of logs removal on Audit Logs
+* Fix display of Access File Integrity on NGINX/IIS servers
+* Update translation file to include new checks and buttons
 * Remove PHP version check from hardening page
 
 = 1.8.21 =

--- a/readme.txt
+++ b/readme.txt
@@ -198,14 +198,13 @@ This version adds an option to refresh the malware scan results on demand, as we
 * Add "Single super-admin check" to WordPress Security Recommendations
 * Add "Use of 2FA plugin login recommendation" to WordPress Security Recommendations
 * Add "Use of backups plugin recommendation" to WordPress Security Recommendations
-* Add "Too much plugin check" to WordPress Security Recommendations
+* Add "Too many plugins check" to WordPress Security Recommendations
 * Add "File editing check" to WordPress Security Recommendations
 * Add "WordPress debug check" to WordPress Security Recommendations
 * Add "Basic hardening check" to WordPress Security Recommendations
 * Add a delete button on Last Logins sections
 * Add register of logs removal on Audit Logs
 * Fix display of Access File Integrity on NGINX/IIS servers
-* Update translation file to include new checks and buttons
 * Remove PHP version check from hardening page
 
 = 1.8.21 =

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: dd@sucuri.net
 Donate Link: https://sucuri.net/
 Tags: malware, security, firewall, scan, spam, virus, sucuri, protection, blacklist, detection, hardening, file integrity
 Requires at least: 3.6
-Tested up to: 5.2.2
+Tested up to: 5.2.3
 Stable tag: 1.8.22
 
 The Sucuri WordPress Security plugin is a security toolset for security integrity monitoring, malware detection and security hardening.

--- a/src/event.lib.php
+++ b/src/event.lib.php
@@ -722,4 +722,54 @@ class SucuriScanEvent extends SucuriScan
 
         return $resp;
     }
+
+    /**
+     * Clear last logins or failed login logs.
+     * 
+     * This can also be done via Sucuri Security -> Settings -> Data Storage,
+     * however to improve the user experience, a button on Last Logins  and on
+     * Failed logins sections was added and it triggers the removal of
+     * sucuri/sucuri-lastlogins.php and sucuri/sucuri-failedlogins.php.
+     * 
+     * @param string $filename Name of the file to be deleted.
+     *
+     * @return HTML Message with the delete action outcome.
+     */
+    public static function clearLastLogs($filename)
+    {
+        // Get the complete path of the file.
+        $filepath = SucuriScan::dataStorePath($filename);
+
+        // Do not proceed if not possible.
+        if (
+            !is_writable(dirname($filepath)) ||
+            !file_exists($filepath) ||
+            is_dir($filepath) ||
+            empty($filepath)
+        ) {
+            return SucuriScanInterface::error(
+                sprintf(
+                    __('%s is empty or can not be deleted.', 'sucuri-scanner'),
+                    $filename
+                )
+            );
+        }
+
+        // Delete $filepath.
+        @unlink($filepath);
+        
+        // Register on audit logs and return result.
+        SucuriScanEvent::reportInfoEvent(
+            sprintf(
+                __('%s was deleted.', 'sucuri-scanner'),
+                $filename
+            )
+        );
+        return SucuriScanInterface::info(
+            sprintf(
+                __('%s was deleted. Please refresh this page.', 'sucuri-scanner'),
+                $filename
+            )
+        );
+    }
 }

--- a/src/event.lib.php
+++ b/src/event.lib.php
@@ -741,15 +741,10 @@ class SucuriScanEvent extends SucuriScan
         $filepath = SucuriScan::dataStorePath($filename);
 
         // Do not proceed if not possible.
-        if (
-            !is_writable(dirname($filepath)) ||
-            !file_exists($filepath) ||
-            is_dir($filepath) ||
-            empty($filepath)
-        ) {
+        if (!is_writable(dirname($filepath)) || is_dir($filepath)) {
             return SucuriScanInterface::error(
                 sprintf(
-                    __('%s is empty or can not be deleted.', 'sucuri-scanner'),
+                    __('%s cannot be deleted.', 'sucuri-scanner'),
                     $filename
                 )
             );
@@ -767,7 +762,7 @@ class SucuriScanEvent extends SucuriScan
         );
         return SucuriScanInterface::info(
             sprintf(
-                __('%s was deleted. Please refresh this page.', 'sucuri-scanner'),
+                __('%s was deleted.', 'sucuri-scanner'),
                 $filename
             )
         );

--- a/src/lastlogins-failed.php
+++ b/src/lastlogins-failed.php
@@ -96,6 +96,11 @@ function sucuriscan_failed_logins_panel()
         $template_variables['FailedLogins.WarningVisibility'] = 'hidden';
     }
 
+    // Clear failed login logins when delete button is pressed.
+    if (SucuriScanInterface::checkNonce() && SucuriScanRequest::post(':delete_failedlogins')) {
+        SucuriScanEvent::clearLastLogs('sucuri-failedlogins.php');
+    }
+
     return SucuriScanTemplate::getSection('lastlogins-failedlogins', $template_variables);
 }
 

--- a/src/lastlogins-failed.php
+++ b/src/lastlogins-failed.php
@@ -45,6 +45,11 @@ function sucuriscan_failed_logins_panel()
     $page_offset = ($page_number - 1) * $max_per_page;
     $page_limit = ($page_offset + $max_per_page);
 
+    // Clear failed login logins when delete button is pressed.
+    if (SucuriScanInterface::checkNonce() && SucuriScanRequest::post(':delete_failedlogins')) {
+            SucuriScanEvent::clearLastLogs('sucuri-failedlogins.php');
+    }
+
     $max_failed_logins = SucuriScanOption::getOption(':maximum_failed_logins');
     $notify_bruteforce_attack = SucuriScanOption::getOption(':notify_bruteforce_attack');
     $failed_logins = sucuriscan_get_all_failed_logins($page_offset, $max_per_page);
@@ -94,11 +99,6 @@ function sucuriscan_failed_logins_panel()
 
     if ($notify_bruteforce_attack == 'enabled') {
         $template_variables['FailedLogins.WarningVisibility'] = 'hidden';
-    }
-
-    // Clear failed login logins when delete button is pressed.
-    if (SucuriScanInterface::checkNonce() && SucuriScanRequest::post(':delete_failedlogins')) {
-        SucuriScanEvent::clearLastLogs('sucuri-failedlogins.php');
     }
 
     return SucuriScanTemplate::getSection('lastlogins-failedlogins', $template_variables);

--- a/src/lastlogins.php
+++ b/src/lastlogins.php
@@ -119,6 +119,11 @@ function sucuriscan_lastlogins_all()
         'UserList.NoItemsVisibility' => 'visible',
     );
 
+    // Clear last login logins when delete button is pressed.
+    if (SucuriScanInterface::checkNonce() && SucuriScanRequest::post(':delete_lastlogins')) {
+        SucuriScanEvent::clearLastLogs('sucuri-lastlogins.php');
+    }
+
     if (!sucuriscan_lastlogins_datastore_is_writable()) {
         $fpath = SucuriScan::escape(sucuriscan_lastlogins_datastore_filepath());
         SucuriScanInterface::error(sprintf(__('Last-logins data file is not writable: <code>%s</code>', 'sucuri-scanner'), $fpath));
@@ -168,11 +173,6 @@ function sucuriscan_lastlogins_all()
             $last_logins['total'],
             $max_per_page
         );
-    }
-
-    // Clear last login logins when delete button is pressed.
-    if (SucuriScanInterface::checkNonce() && SucuriScanRequest::post(':delete_lastlogins')) {
-        SucuriScanEvent::clearLastLogs('sucuri-lastlogins.php');
     }
 
     return SucuriScanTemplate::getSection('lastlogins-all', $params);

--- a/src/lastlogins.php
+++ b/src/lastlogins.php
@@ -170,6 +170,11 @@ function sucuriscan_lastlogins_all()
         );
     }
 
+    // Clear last login logins when delete button is pressed.
+    if (SucuriScanInterface::checkNonce() && SucuriScanRequest::post(':delete_lastlogins')) {
+        SucuriScanEvent::clearLastLogs('sucuri-lastlogins.php');
+    }
+
     return SucuriScanTemplate::getSection('lastlogins-all', $params);
 }
 

--- a/src/pagehandler.php
+++ b/src/pagehandler.php
@@ -52,7 +52,7 @@ function sucuriscan_page()
     $params['SiteCheck.Recommendations'] = '<div id="sucuriscan-recommendations"></div>';
     
     /* load data for the WordPress best practices section */
-    $params['WordPress.Recommendations'] = SucuriWordPressRecomendations::pageWordPressRecommendations();
+    $params['WordPress.Recommendations'] = SucuriWordPressRecommendations::pageWordPressRecommendations();
 
     if (SucuriScanRequest::get(':sitecheck_refresh') !== false) {
         $params['SiteCheck.Refresh'] = 'true';
@@ -147,7 +147,6 @@ function sucuriscan_settings_page()
     /* settings - hardening */
     $params['Settings.Hardening.Firewall'] = SucuriScanHardeningPage::firewall();
     $params['Settings.Hardening.WPVersion'] = SucuriScanHardeningPage::wpversion();
-    $params['Settings.Hardening.PHPVersion'] = SucuriScanHardeningPage::phpversion();
     $params['Settings.Hardening.RemoveGenerator'] = SucuriScanHardeningPage::wpgenerator();
     $params['Settings.Hardening.NginxPHPFPM'] = SucuriScanHardeningPage::nginxphp();
     $params['Settings.Hardening.WPUploads'] = SucuriScanHardeningPage::wpuploads();

--- a/src/settings-general.php
+++ b/src/settings-general.php
@@ -206,9 +206,17 @@ function sucuriscan_settings_general_datastorage($nonce)
                 }
             }
 
+            // Register on audit logs and return result.
+            SucuriScanEvent::reportInfoEvent(
+                sprintf(
+                    __('%s were deleted.', 'sucuri-scanner'),
+                    implode(', ', $filenames)
+                )
+            );
+
             SucuriScanInterface::info(
                 sprintf(
-                    __('%d out of %d files has been deleted', 'sucuri-scanner'),
+                    __('%d out of %d files has been deleted.', 'sucuri-scanner'),
                     $deleted,
                     count($filenames)
                 )

--- a/src/settings-general.php
+++ b/src/settings-general.php
@@ -216,7 +216,7 @@ function sucuriscan_settings_general_datastorage($nonce)
 
             SucuriScanInterface::info(
                 sprintf(
-                    __('%d out of %d files has been deleted.', 'sucuri-scanner'),
+                    __('%d out of %d files have been deleted.', 'sucuri-scanner'),
                     $deleted,
                     count($filenames)
                 )

--- a/src/settings-hardening.php
+++ b/src/settings-hardening.php
@@ -152,49 +152,6 @@ class SucuriScanHardeningPage extends SucuriScan
     }
 
     /**
-     * Checks if the server is using a modern PHP version.
-     *
-     * Each release branch of PHP is fully supported for two years from its
-     * initial stable release. During this period, bugs and security issues that
-     * have been reported are fixed and are released in regular point releases.
-     * After this two year period of active support, each branch is then
-     * supported for an additional year for critical security issues only.
-     * Releases during this period are made on an as-needed basis: there may be
-     * multiple point releases, or none, depending on the number of reports.
-     * Once the three years of support are completed, the branch reaches its end
-     * of life and is no longer supported.
-     *
-     * @see http://php.net/supported-versions.php
-     *
-     * @return HTML with the information about this hardening option.
-     */
-    public static function phpversion()
-    {
-        $params = array();
-
-        if (self::processRequest(__FUNCTION__)) {
-            SucuriScanInterface::error(
-                __('Ask your hosting provider to install an updated version of PHP - <a href="http://php.net/supported-versions.php" target="_blank" rel="noopener">List of PHP Supported Versions</a>', 'sucuri-scanner')
-            );
-        }
-
-        $params['Hardening.FieldName'] = __FUNCTION__;
-        $params['Hardening.Title'] = __('Verify PHP Version', 'sucuri-scanner');
-        $params['Hardening.Description'] = sprintf(__('PHP %s is installed.', 'sucuri-scanner'), PHP_VERSION);
-
-        if (intval(version_compare(PHP_VERSION, '7.1.0') >= 0)) {
-            $params['Hardening.Status'] = 1;
-            $params['Hardening.FieldAttrs'] = 'disabled';
-            $params['Hardening.FieldText'] = __('Revert Hardening', 'sucuri-scanner');
-        } else {
-            $params['Hardening.Status'] = 0;
-            $params['Hardening.FieldText'] = __('Apply Hardening', 'sucuri-scanner');
-        }
-
-        return self::drawSection($params);
-    }
-
-    /**
      * Notify the state of the hardening for the removal of the Generator tag in
      * HTML code printed by WordPress to show the current version number of the
      * installation.

--- a/src/settings-webinfo.php
+++ b/src/settings-webinfo.php
@@ -118,16 +118,13 @@ function sucuriscan_settings_webinfo_details()
 function sucuriscan_settings_webinfo_htaccess()
 {
 
-    if (SucuriScan::isNginxServer() || SucuriScan::isIISServer()) {
-        return ''; /* empty page */
-    }
-
     $htaccess = SucuriScan::getHtaccessPath();
     $params = array(
         'HTAccess.Content' => '',
         'HTAccess.TextareaVisible' => 'hidden',
         'HTAccess.StandardVisible' => 'hidden',
         'HTAccess.NotFoundVisible' => 'hidden',
+        'HTAccess.NotApache' => 'hidden',
         'HTAccess.FoundVisible' => 'hidden',
         'HTAccess.Fpath' => 'unknown',
     );
@@ -144,7 +141,11 @@ function sucuriscan_settings_webinfo_htaccess()
             $params['HTAccess.StandardVisible'] = 'visible';
         }
     } else {
-        $params['HTAccess.NotFoundVisible'] = 'visible';
+        if (SucuriScan::isNginxServer() || SucuriScan::isIISServer()) {
+            $params['HTAccess.NotApache'] = 'visible';
+        } else {
+            $params['HTAccess.NotFoundVisible'] = 'visible';
+        }
     }
 
     return SucuriScanTemplate::getSection('settings-webinfo-htaccess', $params);

--- a/src/settings-webinfo.php
+++ b/src/settings-webinfo.php
@@ -117,6 +117,11 @@ function sucuriscan_settings_webinfo_details()
  */
 function sucuriscan_settings_webinfo_htaccess()
 {
+
+    if (SucuriScan::isNginxServer() || SucuriScan::isIISServer()) {
+        return ''; /* empty page */
+    }
+
     $htaccess = SucuriScan::getHtaccessPath();
     $params = array(
         'HTAccess.Content' => '',

--- a/src/settings-webinfo.php
+++ b/src/settings-webinfo.php
@@ -129,7 +129,10 @@ function sucuriscan_settings_webinfo_htaccess()
         'HTAccess.Fpath' => 'unknown',
     );
 
-    if ($htaccess) {
+    // If it's not Apache, do not based the analysis on htaccess file.
+    if (SucuriScan::isNginxServer() || SucuriScan::isIISServer()) {
+        $params['HTAccess.NotApache'] = 'visible';
+    } elseif ($htaccess) {
         $rules = SucuriScanFileInfo::fileContent($htaccess);
 
         $params['HTAccess.TextareaVisible'] = 'visible';
@@ -141,11 +144,7 @@ function sucuriscan_settings_webinfo_htaccess()
             $params['HTAccess.StandardVisible'] = 'visible';
         }
     } else {
-        if (SucuriScan::isNginxServer() || SucuriScan::isIISServer()) {
-            $params['HTAccess.NotApache'] = 'visible';
-        } else {
-            $params['HTAccess.NotFoundVisible'] = 'visible';
-        }
+        $params['HTAccess.NotFoundVisible'] = 'visible';
     }
 
     return SucuriScanTemplate::getSection('settings-webinfo-htaccess', $params);

--- a/src/strings.php
+++ b/src/strings.php
@@ -146,7 +146,7 @@ __('Loading...', 'sucuri-scanner');
 __('All Users', 'sucuri-scanner');
 __('Admins', 'sucuri-scanner');
 __('Logged-in Users', 'sucuri-scanner');
-__('Failed logins', 'sucuri-scanner');
+__('Failed Logins', 'sucuri-scanner');
 
 // lastlogins-admins.html.tpl
 __('Successful Logins (admins)', 'sucuri-scanner');
@@ -169,6 +169,7 @@ __('IP Address', 'sucuri-scanner');
 __('Hostname', 'sucuri-scanner');
 __('Date/Time', 'sucuri-scanner');
 __('no data available', 'sucuri-scanner');
+__('Delete', 'sucuri-scanner');
 
 // lastlogins-all.snippet.tpl
 __('Edit', 'sucuri-scanner');
@@ -182,6 +183,7 @@ __('Date/Time', 'sucuri-scanner');
 __('Web Browser', 'sucuri-scanner');
 __('no data available', 'sucuri-scanner');
 __('Block', 'sucuri-scanner');
+__('Delete', 'sucuri-scanner');
 
 // lastlogins-loggedin.html.tpl
 __('Logged-in Users}', 'sucuri-scanner');

--- a/src/strings.php
+++ b/src/strings.php
@@ -486,6 +486,7 @@ __('Access File Integrity', 'sucuri-scanner');
 __('The <code>.htaccess</code> file is a distributed configuration file, and is how the Apache web server handles configuration changes on a per-directory basis. WordPress uses this file to manipulate how Apache serves files from its root directory and subdirectories thereof; most notably, it modifies this file to be able to handle pretty permalinks.', 'sucuri-scanner');
 __('Htaccess file found in', 'sucuri-scanner');
 __('Your website has no <code>.htaccess</code> file or it was not found in the default location.', 'sucuri-scanner');
+__('Your web server does not support .htaccess files.', 'sucuri-scanner');
 __('The main <code>.htaccess</code> file in your site has the standard rules for a WordPress installation. You can customize it to improve the performance and change the behaviour of the redirections for pages and posts in your site. To get more information visit the official documentation at <a target="_blank" rel="noopener" href="https://codex.wordpress.org/Using_Permalinks#Creating_and_editing_.28.htaccess.29"> Codex WordPress - Creating and editing (.htaccess)</a>', 'sucuri-scanner');
 __('Codex WordPress HTAccess', 'sucuri-scanner');
 

--- a/src/wordpress-recommendations.lib.php
+++ b/src/wordpress-recommendations.lib.php
@@ -116,7 +116,7 @@ class SucuriWordPressRecommendations
          * @see https://wordpress.org/support/article/editing-wp-config-php/#security-keys
          * @see https://sucuri.net/guides/wordpress-security/#harrec
          */
-        if (defined('AUTH_KEY') || defined('AUTH_SALT')) {
+        if (defined('AUTH_KEY') && defined('AUTH_SALT')) {
             unset($recommendations['wpSaltExistenceChecker']);
         }
         if (file_exists(ABSPATH.'/wp-config.php') &&

--- a/src/wordpress-recommendations.lib.php
+++ b/src/wordpress-recommendations.lib.php
@@ -11,7 +11,7 @@
  * @copyright  2010-2019 Sucuri Inc.
  * @license    https://www.gnu.org/licenses/gpl-2.0.txt GPL2
  *
- * @see       https://wordpress.org/plugins/sucuri-scanner
+ * @see        https://wordpress.org/plugins/sucuri-scanner
  */
 if (!defined('SUCURISCAN_INIT') || SUCURISCAN_INIT !== true) {
     if (!headers_sent()) {
@@ -30,7 +30,7 @@ if (!defined('SUCURISCAN_INIT') || SUCURISCAN_INIT !== true) {
  * @copyright  2010-2019 Sucuri Inc.
  * @license    https://www.gnu.org/licenses/gpl-2.0.txt GPL2
  *
- * @see       https://wordpress.org/plugins/sucuri-scanner
+ * @see        https://wordpress.org/plugins/sucuri-scanner
  * @see        https://sucuri.net/guides/wordpress-security/
  */
 class SucuriWordPressRecommendations
@@ -222,22 +222,15 @@ class SucuriWordPressRecommendations
         }
 
         /*
-         * Check if Server Tokens has too much information.
-         * @see https://www.acunetix.com/blog/articles/configure-web-server-disclose-identity/
-         */
-        if (preg_match('/[0-9]\.[0-9]/', $_SERVER['SERVER_SOFTWARE'])) {
-            // phpcs:disable Generic.Files.LineLength
-            $recommendations['serverTokens'] = array(
-                __('Hide server version', 'sucuri-scanner') => __('Displaying the server or OS version on "Server" HTTP header can help hackers exploit known vulnerabilities, ask your hosting provider to trim the Server Tokens.', 'sucuri-scanner'),
-            );
-            // phpcs:enable
-        }
-
-        /*
-         * Check if Hardening was applied.
+         * Check if Hardening was applied as long as this is not a NGINX/IIS server.
          * @see https://sucuri.net/guides/wordpress-security/#harrec
          */
-        if (!SucuriScanHardening::isHardened(WP_CONTENT_DIR) && !SucuriScanHardening::isHardened(ABSPATH.'/wp-includes')) {
+        if (
+            !SucuriScan::isNginxServer() &&
+            !SucuriScan::isIISServer() &&
+            (!SucuriScanHardening::isHardened(WP_CONTENT_DIR) ||
+            !SucuriScanHardening::isHardened(ABSPATH.'/wp-includes'))
+            ) {
             // phpcs:disable Generic.Files.LineLength
             $recommendations['notHardened'] = array(
                 __('Prevent PHP direct execution on sensitive directories', 'sucuri-scanner') => __('Directories such as "wp-content" and "wp-includes" are generally not intended to be accessed by any user, consider hardening them via Sucuri Security -> Settings -> Hardening.', 'sucuri-scanner'),

--- a/src/wordpress-recommendations.lib.php
+++ b/src/wordpress-recommendations.lib.php
@@ -153,6 +153,8 @@ class SucuriWordPressRecommendations
          * are created by this feature.
          */
         $wpPluginsInstalled = get_plugins();
+        $wpPluginsActivatedName = array();
+        $wpPluginsDeactivatedName = array();
         foreach ($wpPluginsInstalled as $pluginPath => $pluginDetails) {
             $wpPluginsInstalledName[] = $pluginDetails['Name'];
             if (is_plugin_active($pluginPath)) {

--- a/src/wordpress-recommendations.lib.php
+++ b/src/wordpress-recommendations.lib.php
@@ -176,7 +176,7 @@ class SucuriWordPressRecommendations
          * the 2FA plugin check.
          */
         // phpcs:disable Generic.Files.LineLength
-        if ((count(wp_get_themes()) < 2 || count($wpPluginsDeactivatedName) < 1) && !is_multisite() || is_multisite()) {
+        if ((count(wp_get_themes()) < 2 || count($wpPluginsDeactivatedName) < 1) || is_multisite()) {
             unset($recommendations['forgottenExtension']);
         }
         // phpcs:enable
@@ -185,7 +185,7 @@ class SucuriWordPressRecommendations
          * Check for too much plugins.
          * @see https://sucuri.net/guides/wordpress-security/#apt
          */
-        if (count($wpPluginsInstalled) < 50 && !is_multisite() || is_multisite()) {
+        if (count($wpPluginsInstalled) < 50 || is_multisite()) {
             unset($recommendations['tooMuchPlugins']);
         }
 

--- a/src/wordpress-recommendations.lib.php
+++ b/src/wordpress-recommendations.lib.php
@@ -6,14 +6,13 @@
  * PHP version 5
  *
  * @category   Library
- * @package    Sucuri
- * @subpackage SucuriScanner
+ *
  * @author     Northon Torga <northon.torga@sucuri.net>
  * @copyright  2010-2019 Sucuri Inc.
  * @license    https://www.gnu.org/licenses/gpl-2.0.txt GPL2
- * @link       https://wordpress.org/plugins/sucuri-scanner
+ *
+ * @see       https://wordpress.org/plugins/sucuri-scanner
  */
-
 if (!defined('SUCURISCAN_INIT') || SUCURISCAN_INIT !== true) {
     if (!headers_sent()) {
         /* Report invalid access if possible. */
@@ -26,70 +25,251 @@ if (!defined('SUCURISCAN_INIT') || SUCURISCAN_INIT !== true) {
  * Make sure the WordPress install follows security best practices.
  *
  * @category   Library
- * @package    Sucuri
- * @subpackage SucuriScanner
+ *
  * @author     Northon Torga <northon.torga@sucuri.net>
  * @copyright  2010-2019 Sucuri Inc.
  * @license    https://www.gnu.org/licenses/gpl-2.0.txt GPL2
- * @link       https://wordpress.org/plugins/sucuri-scanner
- * @see        https://sitecheck.sucuri.net/
+ *
+ * @see       https://wordpress.org/plugins/sucuri-scanner
+ * @see        https://sucuri.net/guides/wordpress-security/
  */
-class SucuriWordPressRecomendations
+class SucuriWordPressRecommendations
 {
-
     /**
      * Generates the HTML section for the WordPress recommendations section.
      *
-     * @return string HTML code to render the recommendations section.
+     * @return string HTML code to render the recommendations section
      */
     public static function pageWordPressRecommendations()
     {
-
         $params = array();
         $recommendations = array();
         $params['WordPress.Recommendations.Content'] = '';
 
-        /**
-         * BEGIN security checks.
-         * 
+        /*
+         * SECURITY CHECKS
+         *
          * Each check must register a second array inside $recommendations,
          * containing the title and description of the recommendation.
          */
 
-        // Check if php version needs to be upgraded.
-        if (version_compare(phpversion(), '7.1', '<')) {
-            $recommendations['PHPVersionCheck'] = array(
-                __('Upgrade PHP to a supported version', 'sucuri-scanner') =>
-                __('The PHP version you are using no longer receives security support and could be exposed to unpatched security vulnerabilities.', 'sucuri-scanner')
+        /*
+         * Check if WordPress is using a SSL certificate.
+         * @see https://blog.sucuri.net/2019/03/how-to-add-ssl-move-wordpress-from-http-to-https.html
+         */
+        if (!is_ssl()) {
+            // phpcs:disable Generic.Files.LineLength
+            $recommendations['noSSL'] = array(
+                __('Implement a SSL Certificate', 'sucuri-scanner') => __('SSL certificates help protect the integrity of the data in transit between the host (web server or firewall) and the client (web browser).', 'sucuri-scanner'),
             );
+            // phpcs:enable
         }
 
-        /**
-         * BEGIN delivery of results.
-         * 
-         * When recommendations array is empty, delivery an "all is good" message,
-         * otherwise display each item that needs fixing individually.
+        /*
+         * Check if PHP version being used needs to be upgraded.
+         * @see https://www.php.net/supported-versions.php
          */
-        if (count($recommendations) == 0) {
+        if (version_compare(phpversion(), '7.2', '<')) {
+            // phpcs:disable Generic.Files.LineLength
+            $recommendations['PHPVersionCheck'] = array(
+                __('Upgrade PHP to a supported version', 'sucuri-scanner') => __('The PHP version you are using no longer receives security support and could be exposed to unpatched security vulnerabilities.', 'sucuri-scanner'),
+            );
+            // phpcs:enable
+        }
 
-            $params['WordPress.Recommendations.Color'] = 'green';
-            $params['WordPress.Recommendations.Content'] = __('Your WordPress install is following <a href="https://sucuri.net/guides/wordpress-security" target="_blank" rel="noopener">the security best practices</a>.', 'sucuri-scanner');
-        } else {
+        /*
+         * Check if WordPress Salt & Security Keys are set and were updated on the last 6 months.
+         * @see https://wordpress.org/support/article/editing-wp-config-php/#security-keys
+         * @see https://sucuri.net/guides/wordpress-security/#harrec
+         */
+        if (!defined('AUTH_KEY') || !defined('AUTH_SALT')) {
+            // phpcs:disable Generic.Files.LineLength
+            $recommendations['wpSaltExistenceChecker'] = array(
+                __('Missing WordPress Salt & Security Keys', 'sucuri-scanner') => __('Consider using WordPress Salt & Security Keys to add an extra layer of protection to the session cookies and credentials.', 'sucuri-scanner'),
+            );
+        // phpcs:enable
+        } elseif (file_exists(ABSPATH.'/wp-config.php')) {
+            if (filemtime(ABSPATH.'/wp-config.php') < strtotime('-6 months')) {
+                // phpcs:disable Generic.Files.LineLength
+                $recommendations['wpSaltAgeDiscriminator'] = array(
+                    __('WordPress Salt & Security Keys should be updated', 'sucuri-scanner') => __('Updating WordPress Salt & Security Keys after a compromise and on a regular basis, at least once a year, reduces the risks of session hijacking.', 'sucuri-scanner'),
+                );
+                // phpcs:enable
+            }
+        }
 
-            /* set title to blue as not all recommendations have been fullfilled */
+        /*
+         * Check if there is a standard administrator/admin account.
+         * @see https://sucuri.net/guides/wordpress-security/#uac
+         */
+        if (!empty(get_users(array('role' => 'administrator', 'search' => 'admin*')))) {
+            // phpcs:disable Generic.Files.LineLength
+            $recommendations['adminBadUsername'] = array(
+                __('Admin/Administrator username still exists', 'sucuri-scanner') => __('Using an unique username and removing the default admin/administrator account make it more difficult for attackers to brute force your WordPress.', 'sucuri-scanner'),
+            );
+            // phpcs:enable
+        }
+
+        /*
+         * Check if user is using the super-admin for day-to-day operations.
+         * @see https://sucuri.net/guides/wordpress-security/#uac
+         */
+        $wpUsersCount = count_users();
+        if ($wpUsersCount['total_users'] === 1) {
+            // phpcs:disable Generic.Files.LineLength
+            $recommendations['lonelySuperAdmin'] = array(
+                __('Use super admin account only when needed', 'sucuri-scanner') => __('Create an Editor account instead of always using the super-admin to reduce the damage in case of session hijacking.', 'sucuri-scanner'),
+            );
+            // phpcs:enable
+        }
+
+        /*
+         * Check if user a 2FA plugin is being used.
+         * @see https://sucuri.net/guides/wordpress-security/#pwd
+         *
+         * First the script will get the plugins name, then run a regex match to
+         * identify possible 2FA plugins being used.
+         *
+         * NOTE: $wpPluginsInstalledName, $wpPluginsActivatedName, $wpPluginsDeactivatedName
+         * are created by this feature.
+         */
+        $wpPluginsInstalled = get_plugins();
+        foreach ($wpPluginsInstalled as $pluginPath => $pluginDetails) {
+            $wpPluginsInstalledName[] = $pluginDetails['Name'];
+            if (is_plugin_active($pluginPath)) {
+                $wpPluginsActivatedName[] = $pluginDetails['Name'];
+            } else {
+                $wpPluginsDeactivatedName[] = $pluginDetails['Name'];
+            }
+        }
+        // phpcs:disable Generic.Files.LineLength
+        $wp2faPluginsInstalled = preg_grep('/(2FA|2\sFactor|Two\sFactor|Two-Factor|2-Factor|Secure\sLogin|SecSign|Authentication|Wordfence\sSecurity|iThemes\sSecurity\sPro|Limit\sLogin|LDAP)/i', $wpPluginsInstalledName);
+        if (empty($wp2faPluginsInstalled)) {
+            $recommendations['loginUnprotected'] = array(
+                __('Install a 2FA plugin', 'sucuri-scanner') => __('2FA protects your account in the event that someone is able to guess/crack your password.', 'sucuri-scanner'),
+            );
+        }
+        // phpcs:enable
+
+        /*
+         * Check for unwanted extensions.
+         * @see https://sucuri.net/guides/wordpress-security/#apt
+         *
+         * Triggered if there are more than 2 themes or 5 plugins disabled and the
+         * WordPress install is not a multisite.
+         *
+         * NOTE: This check uses $wpPluginsDeactivatedName which is created by
+         * the 2FA plugin check.
+         */
+        if ((count(wp_get_themes()) > 2) || (count($wpPluginsDeactivatedName) > 5) && !is_multisite()) {
+            // phpcs:disable Generic.Files.LineLength
+            $recommendations['forgottenExtensionFestival'] = array(
+                __('Remove unwanted/unused extensions', 'sucuri-scanner') => __('Keeping unwanted themes and plugins increases the chance of a compromise, even if they are disabled.', 'sucuri-scanner'),
+            );
+            // phpcs:enable
+        }
+
+        /*
+         * Check for too much plugins.
+         * @see https://sucuri.net/guides/wordpress-security/#apt
+         */
+        if (count($wpPluginsInstalled) > 50 && !is_multisite()) {
+            // phpcs:disable Generic.Files.LineLength
+            $recommendations['tooMuchPlugins'] = array(
+                __('Decrease the number of plugins', 'sucuri-scanner') => __('The greater the number of plugins installed, the greater the risk of infection and performance issues.', 'sucuri-scanner'),
+            );
+            // phpcs:enable
+        }
+
+        /*
+         * Check for backup plugins.
+         * @see https://sucuri.net/guides/wordpress-security/#bup
+         *
+         * NOTE: This check uses $wpPluginsInstalledName which is created by
+         * the 2FA plugin check.
+         */
+        // phpcs:disable Generic.Files.LineLength
+        $wpBackupsPluginsInstalled = preg_grep('/(Backup|Back-up|Migration|VaultPress|Duplicator|Snapshot|ManageWP|iControlWP|Staging|Updraft|Backwp|Recovery)/i', $wpPluginsInstalledName);
+        if (empty($wpBackupsPluginsInstalled)) {
+            $recommendations['lackOfBackupsPlugins'] = array(
+                __('Install a backup plugin', 'sucuri-scanner') => __('A good set of backups can save your website when absolutely everything else has gone wrong.', 'sucuri-scanner'),
+            );
+        }
+        // phpcs:enable
+
+        /*
+         * Check if File Editing is still possible via wp-admin.
+         * @see https://sucuri.net/guides/wordpress-security/#appconf
+         */
+        if (!defined('DISALLOW_FILE_EDIT')) {
+            // phpcs:disable Generic.Files.LineLength
+            $recommendations['fileEditStillEnabled'] = array(
+                __('Disable file editing', 'sucuri-scanner') => __('Disabling file editing helps preventing an attacker from changing your files through WordPress backend.', 'sucuri-scanner'),
+            );
+            // phpcs:enable
+        }
+
+        /*
+         * Check if WordPress Debug Mode is set.
+         * @see https://wordpress.org/support/article/debugging-in-wordpress/
+         */
+        if (!defined('WP_DEBUG') || WP_DEBUG === true) {
+            // phpcs:disable Generic.Files.LineLength
+            $recommendations['wpDebugOnline'] = array(
+                __('Disable WordPress debug mode', 'sucuri-scanner') => __('The debug mode will cause all PHP errors, notices and warnings to be displayed which can expose sensitive information.', 'sucuri-scanner'),
+            );
+            // phpcs:enable
+        }
+
+        /*
+         * Check if Server Tokens has too much information.
+         * @see https://www.acunetix.com/blog/articles/configure-web-server-disclose-identity/
+         */
+        if (preg_match('/[0-9]\.[0-9]/', $_SERVER['SERVER_SOFTWARE'])) {
+            // phpcs:disable Generic.Files.LineLength
+            $recommendations['serverTokens'] = array(
+                __('Hide server version', 'sucuri-scanner') => __('Displaying the server or OS version on "Server" HTTP header can help hackers exploit known vulnerabilities, ask your hosting provider to trim the Server Tokens.', 'sucuri-scanner'),
+            );
+            // phpcs:enable
+        }
+
+        /*
+         * Check if Hardening was applied.
+         * @see https://sucuri.net/guides/wordpress-security/#harrec
+         */
+        if (!SucuriScanHardening::isHardened(WP_CONTENT_DIR) && !SucuriScanHardening::isHardened(ABSPATH.'/wp-includes')) {
+            // phpcs:disable Generic.Files.LineLength
+            $recommendations['notHardened'] = array(
+                __('Prevent PHP direct execution on sensitive directories', 'sucuri-scanner') => __('Directories such as "wp-content" and "wp-includes" are generally not intended to be accessed by any user, consider hardening them via Sucuri Security -> Settings -> Hardening.', 'sucuri-scanner'),
+            );
+            // phpcs:enable
+        }
+
+        /*
+         * DELIVERY RESULTS
+         *
+         * Delivery an "all is good" message, unless recommendations array has values,
+         * in which case the plugin must display the items that need fixing.
+         */
+        $params['WordPress.Recommendations.Color'] = 'green';
+        // phpcs:disable Generic.Files.LineLength
+        $params['WordPress.Recommendations.Content'] = __('Your WordPress install is following <a href="https://sucuri.net/guides/wordpress-security" target="_blank" rel="noopener">the security best practices</a>.', 'sucuri-scanner');
+        // phpcs:enable
+
+        if (count($recommendations) !== 0) {
+            /* Set title to blue as not there is still recommendations to be followed. */
             $params['WordPress.Recommendations.Color'] = 'blue';
+            $params['WordPress.Recommendations.Content'] = null;
 
-            /* delivery the recommendations using the getSnippet function */
+            /* Delivery the recommendations using the getSnippet function. */
             $recommendation = array_keys($recommendations);
             foreach ($recommendation as $checkid) {
-
                 foreach ($recommendations[$checkid] as $title => $description) {
-
                     $params['WordPress.Recommendations.Content'] .= SucuriScanTemplate::getSnippet(
                         'wordpress-recommendations',
                         array(
                             'WordPress.Recommendations.Title' => $title,
-                            'WordPress.Recommendations.Value' => $description
+                            'WordPress.Recommendations.Value' => $description,
                         )
                     );
                 }

--- a/sucuri.php
+++ b/sucuri.php
@@ -8,7 +8,7 @@
  * Author: Sucuri Inc.
  * Text Domain: sucuri-scanner
  * Domain Path: /lang
- * Version: 1.8.21
+ * Version: 1.8.22
  *
  * PHP version 5
  *
@@ -85,7 +85,7 @@ define('SUCURISCAN', 'sucuriscan');
 /**
  * Current version of the plugin's code.
  */
-define('SUCURISCAN_VERSION', '1.8.21');
+define('SUCURISCAN_VERSION', '1.8.22');
 
 /**
  * Defines the human readable name of the plugin.


### PR DESCRIPTION
* Add new WordPress Security Recommendations
* Update translation file to include new WordPress Security Recommendations checks
* Remove PHP version check from hardening page
* Add a delete button on Last Logins section
* Register logs removal on Audit Logs
* Fix display of Access File Integrity on NGINX/IIS servers

Please, do not review or approve this PR yet, I may still attempt to fix known bugs on this new version.