### PR TITLE
Fix admin/administrator username lookup for WordPress versions prior 4.7

### DIFF
--- a/src/wordpress-recommendations.lib.php
+++ b/src/wordpress-recommendations.lib.php
@@ -128,10 +128,27 @@ class SucuriWordPressRecommendations
          * Check for standard administrator/admin account.
          * @see https://sucuri.net/guides/wordpress-security/#uac
          */
-        $usersWithAdminLogin = get_users(array(
-            'role' => 'administrator',
-            'login__in' => array('admin', 'administrator'),
-        ));
+        $usersWithAdminLogin = array();
+        $adminUsernames = array('admin', 'administrator');
+
+        if (version_compare(SucuriScan::siteVersion(), '4.7', '>=')) {
+            $usersWithAdminLogin = get_users(array(
+                'role' => 'administrator',
+                'login__in' => $adminUsernames,
+            ));
+        } else {
+            $allUsers = get_users(array(
+                'role' => 'administrator',
+                'fields' => array('user_login'),
+            ));
+        
+            foreach($allUsers as $user) {
+                if (in_array($user->user_login, $adminUsernames)) {
+                    $usersWithAdminLogin[] = $user->user_login;
+                }
+            }
+        }
+
         if (empty($usersWithAdminLogin)) {
             unset($recommendations['adminBadUsername']);
         }


### PR DESCRIPTION
I noticed that the admin/administrator lookup was not working as expected prior WordPress 4.7. This was because the `login` param wasn't added until 4.7 (https://github.com/WordPress/WordPress/commit/e96c617c03a17e1de11c64488a394d225d7a4a0f#diff-a11b398dd46cc2d79f3f2072ede871c0).

This PR fixes the lookup!