### PR TITLE
Fix directory hardening recommendation

### DIFF
--- a/src/wordpress-recommendations.lib.php
+++ b/src/wordpress-recommendations.lib.php
@@ -243,7 +243,7 @@ class SucuriWordPressRecommendations
          * @see https://sucuri.net/guides/wordpress-security/#harrec
          */
         // phpcs:disable Generic.Files.LineLength
-        if (SucuriScan::isNginxServer() || SucuriScan::isIISServer() || (SucuriScanHardening::isHardened(WP_CONTENT_DIR) && SucuriScanHardening::isHardened(ABSPATH.'/wp-includes'))) {
+        if (SucuriScan::isNginxServer() || SucuriScan::isIISServer() || SucuriScan::isBehindFirewall() || (SucuriScanHardening::isHardened(WP_CONTENT_DIR) && SucuriScanHardening::isHardened(ABSPATH.'/wp-includes'))) {
             unset($recommendations['notHardened']);
         }
         // phpcs:enable


### PR DESCRIPTION
The directory hardening recommendation was shown even if the site was behind the firewall, causing different information between the recommendation box and the hardening settings page. This PR fixes that.