### PR TITLE
Remove unnecessary code slowing down retrieval of auditlogs

### DIFF
--- a/src/auditlogs.lib.php
+++ b/src/auditlogs.lib.php
@@ -254,10 +254,7 @@ class SucuriScanAuditLogs
             }
         }
 
-        $cache = new SucuriScanCache('auditqueue');
-        $finfo = $cache->getDatastoreInfo();
-        $events = $cache->getAll();
-        $response['queueSize'] = count($events);
+        $response['queueSize'] = $auditlogs['total_entries'];
 
         wp_send_json($response, 200);
     }


### PR DESCRIPTION
The total entries of the logs is already available through the `$auditlogs` variable.

Lines 258 and 259 were causing reading and parsing of the file twice, making it three in total.

Zip file with these changes: [sucuri-scanner.zip](https://github.com/Sucuri/sucuri-wordpress-plugin/files/4062827/sucuri-scanner.zip)
