### PR TITLE
Force Sitecheck to re-scan the site if the user clicks on "Refresh Malware Scan"

### DIFF
--- a/src/sitecheck.lib.php
+++ b/src/sitecheck.lib.php
@@ -129,7 +129,7 @@ class SucuriScanSiteCheck extends SucuriScanAPI
         $cache->delete('scan_results');
 
         /* send HTTP request to SiteCheck's API service. */
-        $results = self::runMalwareScan();
+        $results = self::runMalwareScan(true);
 
         /* check for error in the request's response. */
         if (is_string($results) || isset($results['SYSTEM']['ERROR'])) {


### PR DESCRIPTION
Basically we'll ask Sitecheck to re-scan the site if:

1. Local cache is invalid
2. User requested it with the "Refresh Malware Scan" link