### PR TITLE
Make getDatastoreInfo() only read information on datastore files

### DIFF
--- a/src/cache.lib.php
+++ b/src/cache.lib.php
@@ -286,18 +286,22 @@ class SucuriScanCache extends SucuriScan
                 continue;
             }
 
-            if(strpos($line, "exit(0);\n") === 0) {
+            if(strpos($line, "exit(0);") !== false) {
                 break; /* No more info */
             }
         }
 
         fclose($datastore_handle);
 
-        if (empty($finfo)) {
-            return false;
+        $finfo['fpath'] = $this->datastore_path;
+
+        if (!isset($finfo['created_on'])) {
+            $finfo['created_on'] = time();
         }
 
-        $finfo['fpath'] = $this->datastore_path;
+        if (!isset($finfo['updated_on'])) {
+            $finfo['updated_on'] = time();
+        }   
 
         return $finfo;
     }


### PR DESCRIPTION
As @yaelcampo noticed, the `getDatastoreInfo()` function was iterating over the whole datastore files instead of only going through the information.

This PR solves that.

Zip file: [sucuri-scanner.zip](https://github.com/Sucuri/sucuri-wordpress-plugin/files/4115497/sucuri-scanner.zip)

