### PR TITLE
Replace SucuriScan::implode for json_encode, update humanTime functio…

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate Link: https://sucuri.net/
 Tags: malware, security, firewall, scan, spam, virus, sucuri, protection, blacklist, detection, hardening, file integrity
 Requires at least: 3.6
 Tested up to: 5.3.2
-Stable tag: 1.8.23
+Stable tag: 1.8.24
 
 The Sucuri WordPress Security plugin is a security toolset for security integrity monitoring, malware detection and security hardening.
 
@@ -189,6 +189,10 @@ We take your privacy seriously. For free plugin users without an API key, no inf
 This version adds an option to refresh the malware scan results on demand, as well as several small bug fixes and improvements.
 
 == Changelog ==
+
+= 1.8.24 =
+* Fix warning caused by humanTime function
+* Fix fatal error caused by cron jobs with nested arguments
 
 = 1.8.23 =
 * Add Automatic Secret Keys Updater

--- a/src/base.lib.php
+++ b/src/base.lib.php
@@ -183,6 +183,10 @@ class SucuriScan
      */
     public static function humanTime($time = 0)
     {
+        if (!is_numeric($time)) {
+            return 'N/A';
+        }
+
         $now = time();
 
         if ($time === $now) {

--- a/src/event.lib.php
+++ b/src/event.lib.php
@@ -120,7 +120,7 @@ class SucuriScanEvent extends SucuriScan
                         'schedule' => $event['schedule'],
                         'nextTime' => SucuriScan::datetime($timestamp),
                         'nextTimeHuman' => SucuriScan::humanTime($timestamp),
-                        'arguments' => SucuriScan::implode(', ', $event['args']),
+                        'arguments' => json_encode($event['args']),
                     );
                 }
             }

--- a/src/globals.php
+++ b/src/globals.php
@@ -75,21 +75,9 @@ if (defined('SUCURISCAN')) {
     add_filter('cron_schedules', 'SucuriScanEvent::additionalSchedulesFrequencies');
 
     /**
-     * Add cronjob hooks methods.
-     *
-     * This is necessary because using add_action inside the feature class/method
-     * will not be persistent. The hooks must be declared on every page load.
+     * Hook the sucuriscan_autoseckeyupdater cron job.
      */
-    foreach (SucuriScanEvent::activeSchedules() as $hook => $details) {
-        if (substr($hook, 0, strlen('sucuriscan_')) === 'sucuriscan_') {
-            if (!has_action($hook)) {
-                $methodLocation = array('SucuriScanCrons', $hook);
-                if (method_exists($methodLocation[0], $methodLocation[1])) {
-                    add_action($hook, $methodLocation);
-                }
-            }
-        }
-    }
+    add_action('sucuriscan_autoseckeyupdater', 'SucuriScanCrons::sucuriscan_autoseckeyupdater');
 
     /**
      * List an associative array with the sub-pages of this plugin.

--- a/src/settings-posthack.php
+++ b/src/settings-posthack.php
@@ -168,9 +168,9 @@ class SucuriScanSettingsPosthack extends SucuriScanSettings
 
                 if ( isset($activeSchedules[$cronName]) && isset($activeSchedules[$cronName]['schedule'])) {
                     $currentCronFrequency = $activeSchedules[$cronName]['schedule'];
-                }
 
-                $params['SecurityKeys.Schedules'] = str_replace('option value="'.$currentCronFrequency.'"', 'option value="'.$currentCronFrequency.'" selected', $params['SecurityKeys.Schedules']);
+                    $params['SecurityKeys.Schedules'] = str_replace('option value="'.$currentCronFrequency.'"', 'option value="'.$currentCronFrequency.'" selected', $params['SecurityKeys.Schedules']);
+                }
             }
         }
 

--- a/src/settings-posthack.php
+++ b/src/settings-posthack.php
@@ -164,7 +164,12 @@ class SucuriScanSettingsPosthack extends SucuriScanSettings
         } else {
             // Re-order selection box with the current cron frequency
             if (wp_next_scheduled($cronName)) {
-                $currentCronFrequency = SucuriScanEvent::activeSchedules()[$cronName]['schedule'];
+                $activeSchedules = SucuriScanEvent::activeSchedules();
+
+                if ( isset($activeSchedules[$cronName]) && isset($activeSchedules[$cronName]['schedule'])) {
+                    $currentCronFrequency = $activeSchedules[$cronName]['schedule'];
+                }
+
                 $params['SecurityKeys.Schedules'] = str_replace('option value="'.$currentCronFrequency.'"', 'option value="'.$currentCronFrequency.'" selected', $params['SecurityKeys.Schedules']);
             }
         }

--- a/src/settings-scanner.php
+++ b/src/settings-scanner.php
@@ -168,7 +168,7 @@ class SucuriScanSettingsScanner extends SucuriScanSettings
                             'Cronjob.Schedule' => $event['schedule'],
                             'Cronjob.NextTime' => SucuriScan::datetime($timestamp),
                             'Cronjob.NextTimeHuman' => SucuriScan::humanTime($timestamp),
-                            'Cronjob.Arguments' => SucuriScan::implode(', ', $event['args']),
+                            'Cronjob.Arguments' => json_encode($event['args']),
                         )
                     );
                 }

--- a/sucuri.php
+++ b/sucuri.php
@@ -8,7 +8,7 @@
  * Author: Sucuri Inc.
  * Text Domain: sucuri-scanner
  * Domain Path: /lang
- * Version: 1.8.23
+ * Version: 1.8.24
  *
  * PHP version 5
  *
@@ -85,7 +85,7 @@ define('SUCURISCAN', 'sucuriscan');
 /**
  * Current version of the plugin's code.
  */
-define('SUCURISCAN_VERSION', '1.8.23');
+define('SUCURISCAN_VERSION', '1.8.24');
 
 /**
  * Defines the human readable name of the plugin.


### PR DESCRIPTION
This PR:

- Updates `humanTime` to check whether the variable passed is numeric
- Replaces the use of `SucuriScan::implode` for `json_encode`
- Gets rid of the `foreach` in globals in favor of calling `add_action` directly
- Bumps versions to 1.8.24