### PR TITLE
Fix notice caused by lack of MONTH_IN_SECONDS constant

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -193,6 +193,7 @@ This version adds an option to refresh the malware scan results on demand, as we
 = 1.8.24 =
 * Fix warning caused by humanTime function
 * Fix fatal error caused by cron jobs with nested arguments
+* Fix notice caused by lack of MONTH_IN_SECONDS constant introduced only on WP 4.4
 
 = 1.8.23 =
 * Add Automatic Secret Keys Updater

--- a/readme.txt
+++ b/readme.txt
@@ -193,7 +193,7 @@ This version adds an option to refresh the malware scan results on demand, as we
 = 1.8.24 =
 * Fix warning caused by humanTime function
 * Fix fatal error caused by cron jobs with nested arguments
-* Fix notice caused by lack of MONTH_IN_SECONDS constant introduced only on WP 4.4
+* Fix notice about MONTH_IN_SECONDS in WP < 4.4
 
 = 1.8.23 =
 * Add Automatic Secret Keys Updater

--- a/src/event.lib.php
+++ b/src/event.lib.php
@@ -139,6 +139,9 @@ class SucuriScanEvent extends SucuriScan
      */
     public static function additionalSchedulesFrequencies($schedules)
     {
+        if (!defined('MONTH_IN_SECONDS')) {
+            define('MONTH_IN_SECONDS', 30 * DAY_IN_SECONDS);
+        }
         if (!isset($schedules['weekly'])) {
             $schedules['weekly'] = array(
                 'display' => __('Weekly', 'sucuriscan'),


### PR DESCRIPTION
That constant was introduced only on WP 4.4.0:
https://developer.wordpress.org/reference/functions/wp_initial_constants/