### PR TITLE
Add Cypress e2e tests for Firewall tab

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -78,10 +78,16 @@ jobs:
       - name: Docker debug information
         run: docker -v
 
-      - name: Run E2E tests
+      - name: Run Sucuri Scanner tests (E2E)
         run: |
           cp cypress.json.example cypress.json
-          npx cypress run
+          npx cypress run --spec cypress/integration/sucuri-scanner.js
+
+      - name: Run Firewall tests (E2E)
+        if: env.cypress_waf_api_key
+        env:
+          cypress_waf_api_key: ${{ secrets.WAF_API_KEY }}
+        run: npx cypress run --spec cypress/integration/sucuri-scanner-firewall.js
           
       - name: Upload Cypress tests on failure
         uses: actions/upload-artifact@v2.2.1

--- a/cypress/integration/sucuri-scanner-firewall.js
+++ b/cypress/integration/sucuri-scanner-firewall.js
@@ -1,0 +1,69 @@
+describe( '', () => {
+  beforeEach( function() {
+		cy.login();
+	}	);
+
+  it( 'can activate api key', () => {
+    cy.visit( '/wp-admin/admin.php?page=sucuriscan#auditlogs' );
+
+    cy.contains( 'Firewall (WAF)' ).click();
+
+    cy.contains( 'Firewall Settings' );
+
+    cy.get( 'input[name=sucuriscan_cloudproxy_apikey]' ).type( Cypress.env( 'waf_api_key' ), { log: false } );
+    cy.get( 'button[data-cy=sucuriscan-save-wafkey]').click();
+
+    cy.get( '.sucuriscan-alert-updated' ).contains( 'SUCURI: Firewall API key was successfully saved' );
+    cy.get( '.sucuriscan-alert-updated' ).contains( 'SUCURI: Reverse proxy support was set to enabled' );
+    cy.get( '.sucuriscan-alert-updated' ).contains( 'SUCURI: HTTP header was set to HTTP_X_SUCURI_CLIENTIP' );
+  } );
+
+  it( 'can try to load audit logs', () => {
+    cy.visit( '/wp-admin/admin.php?page=sucuriscan_firewall#auditlogs' );
+
+    // We either see the message "no data available", or we get at least an entry with the Target field on it.
+    cy.get( '.sucuriscan-firewall-auditlogs' ).contains( /no data available.|Target:.*/g );
+  } );
+
+  it( 'can try to add ip address to the blocklist', () => {
+    const ipAddress = '82.165.185.18'; // known attacker IP
+
+    cy.visit( '/wp-admin/admin.php?page=sucuriscan_firewall#settings' );
+
+    cy.contains( 'IP Access' ).click();
+
+    cy.get( '[data-cy=sucuriscan_ip_access_input]' ).type( ipAddress );
+    cy.get( '[data-cy=sucuriscan_ip_access_submit]' ).click();
+
+    cy.wait( 7000 );
+
+    cy.get( '#sucuriscan-ipaccess-response' ).contains( 'IP address 82.165.185.18' ); // Can connect to the WAF API
+  } );
+
+  it( 'can clear cache when post/page is updated', () => {
+    cy.visit( '/wp-admin/admin.php?page=sucuriscan#auditlogs' );
+
+    cy.get( '[data-cy=sucuriscan-main-nav-firewall]').click();
+    cy.contains( 'Clear Cache' ).click();
+
+    cy.get( 'input[name=sucuriscan_auto_clear_cache]').check();
+
+    cy.get( '#firewall-clear-cache-button' ).click();
+
+    cy.wait( 2000 );
+
+    cy.get( '#firewall-clear-cache-response' ).contains( /The cache for the domain ".*" is being cleared. Note that it may take up to two minutes for it to be fully flushed./g );
+  } );
+
+  it( 'can delete api key', () => {
+    cy.visit( '/wp-admin/admin.php?page=sucuriscan#auditlogs' );
+
+    cy.contains( 'Firewall (WAF)' ).click();
+
+    cy.get( 'button[data-cy=sucuriscan-delete-wafkey] ').click();
+
+    cy.get( '.sucuriscan-alert-updated' ).contains( 'SUCURI: Firewall API key was successfully removed' );
+    cy.get( '.sucuriscan-alert-updated' ).contains( 'SUCURI: Reverse proxy support was set to disabled' );
+    cy.get( '.sucuriscan-alert-updated' ).contains( 'SUCURI: HTTP header was set to REMOTE_ADDR' );
+  } );
+} );

--- a/inc/tpl/base.html.tpl
+++ b/inc/tpl/base.html.tpl
@@ -26,7 +26,7 @@
 
                 <li><a href="%%SUCURI.URL.Dashboard%%" class="button button-primary">{{Dashboard}}</a></li>
 
-                <li><a href="%%SUCURI.URL.Firewall%%" class="button button-primary">{{Firewall (WAF)}}</a></li>
+                <li><a href="%%SUCURI.URL.Firewall%%" class="button button-primary" data-cy="sucuriscan-main-nav-firewall">{{Firewall (WAF)}}</a></li>
 
                 <li><a href="%%SUCURI.URL.Settings%%" class="button button-primary">{{Settings}}</a></li>
             </ul>

--- a/inc/tpl/firewall-ipaccess.html.tpl
+++ b/inc/tpl/firewall-ipaccess.html.tpl
@@ -19,6 +19,7 @@ jQuery(document).ready(function ($) {
                 $('.sucuriscan-ipaccess-table tbody').append('<tr>' +
                 '<td><span class="sucuriscan-monospace">' + data.blocklist[i] + '</span></td>' +
                 '<td><button class="button button-primary sucuriscan-deblocklist" ' +
+                'data-cy="' + data.blocklist[i] + '" ' +
                 'ip="' + data.blocklist[i] + '">{{Delete}}</button></td>' +
                 '</tr>');
             }
@@ -98,8 +99,8 @@ jQuery(document).ready(function ($) {
             <input type="hidden" name="sucuriscan_blocklist_ip" value="true" />
             <fieldset class="sucuriscan-clearfix">
                 <label>{{Add IP to the Blocklist:}}</label>
-                <input type="text" name="sucuriscan_ip" placeholder="{{e.g. 192.168.1.54}}" />
-                <button class="button button-primary sucuriscan-ipaccess-button">{{Submit}}</button>
+                <input type="text" name="sucuriscan_ip" data-cy="sucuriscan_ip_access_input" placeholder="{{e.g. 192.168.1.54}}" />
+                <button class="button button-primary sucuriscan-ipaccess-button" data-cy="sucuriscan_ip_access_submit">{{Submit}}</button>
             </fieldset>
         </form>
 

--- a/inc/tpl/firewall-settings.html.tpl
+++ b/inc/tpl/firewall-settings.html.tpl
@@ -45,7 +45,7 @@ jQuery(document).ready(function ($) {
             <span class="sucuriscan-monospace">%%SUCURI.Firewall.APIKey%%</span>
             <form action="%%SUCURI.URL.Firewall%%" method="post">
                 <input type="hidden" name="sucuriscan_page_nonce" value="%%SUCURI.PageNonce%%" />
-                <button type="submit" name="sucuriscan_delete_wafkey" class="button button-primary">{{Delete}}</button>
+                <button type="submit" name="sucuriscan_delete_wafkey" data-cy="sucuriscan-delete-wafkey" class="button button-primary">{{Delete}}</button>
             </form>
         </div>
 
@@ -54,7 +54,7 @@ jQuery(document).ready(function ($) {
             <fieldset class="sucuriscan-clearfix">
                 <label>{{Firewall API Key:}}</label>
                 <input type="text" name="sucuriscan_cloudproxy_apikey" />
-                <button type="submit" class="button button-primary">{{Save}}</button>
+                <button type="submit" class="button button-primary" data-cy="sucuriscan-save-wafkey">{{Save}}</button>
             </fieldset>
             <br>
         </form>


### PR DESCRIPTION
This PR adds a new test suite that evaluates whether the plugin can connect or not to Sucuri's API to register a WAF API key, see audit logs from the plugin, add a new IP address to the blocklist and clear cache when a post/page is created or updated.

The only tricky part about this is that we require a real API key to make this work, so this test suite requires the secret `WAF_API_KEY` to be set, and if not, this test suite will be skipped.

PS. Our e2e tests are failing because of an issue with the `@wordpress/env` package: https://github.com/WordPress/gutenberg/issues/29752