### PR TITLE
Fix required parameter follows optional parameter issue

### DIFF
--- a/src/hook.lib.php
+++ b/src/hook.lib.php
@@ -996,7 +996,7 @@ class SucuriScanHook extends SucuriScanEvent
      * @param int $id The identifier of the edited user account
      * @param object $old_user_data Object containing user's data prior to update.
      */
-    public static function hookProfileUpdate($id = 0, $old_user_data)
+    public static function hookProfileUpdate($id = 0, $old_user_data = false)
     {
         $title = __('unknown', 'sucuri-scanner');
         $email = __('user@domain.com', 'sucuri-scanner');


### PR DESCRIPTION
Resolves an issue in PHP8 where a required parameter follows an optional parameter in a function declaration. #104

```
PHP Deprecated:  Required parameter $old_user_data follows optional parameter $id in /sucuri-scanner/src/hook.lib.php on line 999
```