### PR TITLE
Silence fopen warning

### DIFF
--- a/src/cache.lib.php
+++ b/src/cache.lib.php
@@ -238,7 +238,7 @@ class SucuriScanCache extends SucuriScan
         $object['info'] = array();
         $object['entries'] = array();
 
-        if (($fh = fopen($this->datastore_path, 'r')) === false) {
+        if (($fh = @fopen($this->datastore_path, 'r')) === false) {
             return $object;
         }
 


### PR DESCRIPTION
This commit silences the warning [fopen](https://www.php.net/manual/en/function.fopen.php) emits upon failure (e.g. the file requested does not exist).