### PR TITLE
Use Plugins path or Must use plugins

### DIFF
--- a/sucuri.php
+++ b/sucuri.php
@@ -106,7 +106,14 @@ define('SUCURISCAN_PLUGIN_FOLDER', basename(dirname(__FILE__)));
 /**
  * The fullpath where the plugin's files will be located.
  */
-define('SUCURISCAN_PLUGIN_PATH', WP_PLUGIN_DIR . '/' . SUCURISCAN_PLUGIN_FOLDER);
+ $sucuriscanPluginPath = WP_PLUGIN_DIR . '/' . SUCURISCAN_PLUGIN_FOLDER;
+ if (!is_dir($sucuriscanPluginPath) && is_dir(WPMU_PLUGIN_DIR . '/' . SUCURISCAN_PLUGIN_FOLDER)) {
+    $sucuriscanPluginPath = WPMU_PLUGIN_DIR . '/' . SUCURISCAN_PLUGIN_FOLDER;
+ } else {
+     throw new \RuntimeException('Sucuri scan plugin cannot be found in plugins or must-use plugins.');
+ }
+
+define('SUCURISCAN_PLUGIN_PATH', $sucuriscanPluginPath);
 
 /**
  * The local URL where the plugin's files and assets are served.


### PR DESCRIPTION
Use Plugins path or Must use plugins depending on where the plugin is located.

I tried to install this plugin as a [Must use plugin](https://docs.roots.io/bedrock/master/mu-plugin-autoloader/) but it didn't worked. I finally figured out why, here is a little PR to fix that.