### PR TITLE
Fix "Path cannot be empty" error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cypress.json
 .phpunit.result.cache
 .vscode/launch.json
 .vscode/settings.json
+.idea/

--- a/src/cache.lib.php
+++ b/src/cache.lib.php
@@ -402,6 +402,9 @@ class SucuriScanCache extends SucuriScan
         }
 
         $finfo = $this->getDatastoreInfo();
+        if (empty($finfo['fpath'])) {
+            return false;
+        }
         $line = sprintf("%s:%s\n", $key, json_encode($data));
 
         return (bool) @file_put_contents($finfo['fpath'], $line, FILE_APPEND);

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -21,4 +21,24 @@ final class CacheTest extends TestCase
         $entries = $cache->getAll();
         $this->assertSame(20, count($entries));
     }
+
+    public function testDatastoreAddToMissingFile()
+    {
+        $cache = new SucuriScanCache('test-datastore', false);
+        $ok = $cache->add('1234567890_0000', 'value');
+        $this->assertFalse($ok);
+    }
+
+    public function testDatastoreAddToReadOnlyFile()
+    {
+        $datastore = 'test-datastore';
+        $datastoreFullpath = SUCURI_DATA_STORAGE . "/sucuri-$datastore.php";
+        $cache = new SucuriScanCache($datastore, true);
+        chmod($datastoreFullpath, 000);
+
+        $ok = $cache->add('1234567890_0000', 'value');
+        unlink($datastoreFullpath);
+
+        $this->assertFalse($ok);
+    }
 }


### PR DESCRIPTION
This commit fixes the `PHP Fatal error Uncaught ValueError: Path cannot be empty in src/cache.lib.php:407` error.