### PR TITLE
Added option to clear cache by path

### DIFF
--- a/cypress/integration/sucuri-scanner-firewall.js
+++ b/cypress/integration/sucuri-scanner-firewall.js
@@ -54,6 +54,18 @@ describe( '', () => {
 
     cy.get( '#firewall-clear-cache-response' ).contains( /The cache for the domain ".*" is being cleared. Note that it may take up to two minutes for it to be fully flushed./g );
   } );
+  
+  it( 'can clear cache by path', () => {
+    cy.visit( '/wp-admin/admin.php?page=sucuriscan_firewall#clearcache' );
+
+    cy.get( '[data-cy=firewall-clear-cache-path-input]').type('blog');
+
+    cy.get( '[data-cy=sucuriscan-clear-cache-path]' ).click();
+
+    cy.wait( 2000 );
+
+    cy.get( '#firewall-clear-cache-response' ).contains( /The cache for ".*" is being cleared. Note that it may take up to two minutes for it to be fully flushed./g );
+  } );
 
   it( 'can delete api key', () => {
     cy.visit( '/wp-admin/admin.php?page=sucuriscan#auditlogs' );

--- a/inc/css/styles.css
+++ b/inc/css/styles.css
@@ -50,6 +50,7 @@ body.sucuri-security_page_sucuriscan_hardening {
     margin: 0;
     padding: 0 7px;
     line-height: 28px;
+    font-weight: 400;
 }
 .sucuriscan-container fieldset {
     margin-bottom: 10px;
@@ -942,4 +943,37 @@ body.sucuri-security_page_sucuriscan_hardening {
 .rtl .wrap .sucuriscan-alert > .close {
     right: initial;
     left: 20px;
+}
+
+.firewall-clear-cache-path {
+    margin-top: 20px;
+    margin-bottom: 20px;
+}
+
+.firewall-clear-cache-path fieldset {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-end;
+} 
+
+.firewall-clear-cache-path fieldset input {
+    min-width: 300px;
+}
+
+.firewall-clear-cache-path fieldset label{
+    display: flex;
+    flex-direction: column;
+    margin: 0;
+}
+
+.ml-0 {
+    margin-left: 0 !important;
+}
+
+.mt-2 {
+    margin-top: 2em !important;
+}
+
+h3.lead {
+    margin: .5em 0;
 }

--- a/inc/tpl/firewall-clearcache.html.tpl
+++ b/inc/tpl/firewall-clearcache.html.tpl
@@ -20,6 +20,30 @@ jQuery(document).ready(function ($) {
             $('#firewall-clear-cache-response').html(data);
         });
     });
+    
+    $('#firewall-clear-cache-path-button').on('click', function (event) {
+        event.preventDefault();
+
+        var button = $(this),
+            pathEl = $('input[name="path"]'),
+            path = $(pathEl).val();
+
+        if (!path) return;
+
+        button.attr('disabled', true);
+        button.html('{{Loading...}}');
+        $('#firewall-clear-cache-response').html('');
+
+        $.post('%%SUCURI.AjaxURL.Firewall%%', {
+            action: 'sucuriscan_ajax',
+            sucuriscan_page_nonce: '%%SUCURI.PageNonce%%',
+            form_action: 'firewall_clear_cache',
+            path
+        }, function (data) {
+            $('#firewall-clear-cache-response').html(data);
+            button.html('{{Clear Cache}}');
+        });
+    });
 
     $('#firewall-clear-cache-auto').on('change', 'input:checkbox', function () {
         var checked = $(this).is(':checked');
@@ -34,6 +58,13 @@ jQuery(document).ready(function ($) {
         }, function () {
             $('#firewall-clear-cache-auto span').html('{{Clear cache when a post or page is updated}}');
         });
+    });
+    
+    $('#firewall-clear-cache-path-input').on('keyup', function () {
+        var input = $(this),
+            button = $("#firewall-clear-cache-path-button");
+
+        button.attr('disabled', $(input).val().length === 0);
     });
 });
 </script>
@@ -50,14 +81,32 @@ jQuery(document).ready(function ($) {
 
         <p>{{A web cache (or HTTP cache) is an information technology for the temporary storage (caching) of web documents, such as HTML pages and images, to reduce bandwidth usage, server load, and perceived lag. A web cache system stores copies of documents passing through it; subsequent requests may be satisfied from the cache if certain conditions are met. A web cache system can refer either to an appliance, or to a computer program. &mdash; <a href="https://en.wikipedia.org/wiki/Web_cache" target="_blank" rel="noopener">WikiPedia - Web Cache</a>}}</p>
 
-        <div id="firewall-clear-cache-auto">
+        <div class="firewall-clear-cache-path">
+            <form action="%%SUCURI.URL.Firewall%%" method="post" class="sucuriscan-%%SUCURI.Firewall.APIKeyFormVisibility%%">
+                <input type="hidden" name="sucuriscan_page_nonce" value="%%SUCURI.PageNonce%%" />
+                <h3 class="lead">Clear Cache by Path</h3>
+                <p>This option allows you to clear the cache for an individual page, post, or other path. Enter the URL you wish to clear and then click the Clear Cache button. </p>
+                <p>This functionality will not clear static content. (i.e. .jpg or .css)</p>
+                <fieldset class="sucuriscan-clearfix">
+                    <label>
+                        <span class="ml-0">{{Path:}}</span>
+                        <input type="text" name="path" id="firewall-clear-cache-path-input" data-cy="firewall-clear-cache-path-input" placeholder="e.g. security/how-to-clear-a-path" class="ml-0" />
+                    </label>
+                    <button type="submit" class="button button-primary" id="firewall-clear-cache-path-button" disabled data-cy="sucuriscan-clear-cache-path">{{Clear Cache}}</button>
+                </fieldset>
+            </form>
+        </div>
+        <div id="firewall-clear-cache-auto" class="mt-2">
+            <h3 class="lead">Clear Cache Globally</h3>
+            <p>This option allows you to purge all of your page and files cache at once.</p>
+            <p>You can select the checkbox below to clear your website cache globally every time a save is made on your WordPress website.</p>
             <label>
                 <input type="checkbox" name="sucuriscan_auto_clear_cache" value="true" %%SUCURI.FirewallAutoClearCache%% />
-                <span>{{Clear cache when a post or page is updated}}</span>
+                <span>{{Clear cache whenever a post or page is updated}}</span>
             </label>
         </div>
+        <button id="firewall-clear-cache-button" class="button button-primary">{{Clear Global Cache}}</button>
 
-        <div id="firewall-clear-cache-response"></div>
-        <button id="firewall-clear-cache-button" class="button button-primary">{{Clear Cache}}</button>
+        <div id="firewall-clear-cache-response" class="mt-2"></div>
     </div>
 </div>

--- a/src/firewall.lib.php
+++ b/src/firewall.lib.php
@@ -665,9 +665,14 @@ class SucuriScanFirewall extends SucuriScanAPI
      * @param  array|bool $api_key The firewall API key.
      * @return string|bool         Message explaining the result of the operation.
      */
-    public static function clearCache($api_key = false)
+    public static function clearCache($api_key = false, $path = '')
     {
         $params = array('a' => 'clear_cache');
+        $path = ltrim(trim($path), '/');
+
+        if ($path) {
+            $params['file'] = $path;
+        }
 
         if (is_array($api_key)) {
             $params = array_merge($params, $api_key);
@@ -737,7 +742,8 @@ class SucuriScanFirewall extends SucuriScanAPI
         $api_key = self::getKey();
 
         if ($api_key) {
-            $res = self::clearCache($api_key);
+            $path = SucuriScanRequest::post('path');
+            $res = self::clearCache($api_key, $path);
 
             if (is_array($res) && isset($res['messages'])) {
                 $response = sprintf(


### PR DESCRIPTION
This PR adds an option to clear cache by path. It also updates the clear cache page description text to make it easier to understand the differences between the available options.

Default View
<img width="1396" alt="default" src="https://user-images.githubusercontent.com/4721523/181500209-354c5c4e-c3ef-4024-8816-3357fb5c6670.png">

After Cache Cleared
<img width="1372" alt="after clear cache" src="https://user-images.githubusercontent.com/4721523/181500247-581f3979-6731-4ef4-95bb-82e841e57427.png">
