### PR TITLE
WS-8855 Cross-Site Request Forgery (CSRF) on WordPress Plugin

### DIFF
--- a/src/globals.php
+++ b/src/globals.php
@@ -175,9 +175,9 @@ if (defined('SUCURISCAN')) {
         add_action('xmlrpc_publish_post', 'SucuriScanHook::hookPublishPostXMLRPC', 50, 5);
 
         if (SucuriScan::runAdminInit()) {
-            add_action('admin_init', 'SucuriScanHook::hookCoreUpdate');
+            add_action('_core_updated_successfully', 'SucuriScanHook::hookCoreUpdate');
             add_action('admin_init', 'SucuriScanHook::hookOptionsManagement');
-            add_action('admin_init', 'SucuriScanHook::hookPluginDelete');
+            add_action('deleted_plugin', 'SucuriScanHook::hookPluginDelete');
             add_action('admin_init', 'SucuriScanHook::hookPluginEditor');
             add_action('admin_init', 'SucuriScanHook::hookPluginInstall');
             add_action('admin_init', 'SucuriScanHook::hookPluginUpdate');


### PR DESCRIPTION
This PR adds check_ajax_referer for the admin hooks and changes the core update hook to use the inbuilt WordPress hook.