### PR TITLE
Update styles.css

### DIFF
--- a/inc/css/styles.css
+++ b/inc/css/styles.css
@@ -3,7 +3,7 @@ body.sucuri-security_page_sucuriscan_settings,
 body.sucuri-security_page_sucuriscan_firewall,
 body.sucuri-security_page_sucuriscan_hardening {
     background: #E9E7E7;
-    font-family: 'Open Sans', serif;
+    font-family: 'Open Sans', sans-serif;
     font-size: 14px;
     line-height: 1.5rem;
     color: #1A272C;


### PR DESCRIPTION
The fallback should be sans-serif like the first choice font. Otherwise when Google Fonts are unavailable it looks like this: 

<img width="819" alt="image" src="https://user-images.githubusercontent.com/152804/209431048-a739a4b2-b15b-4f22-a178-4e8169b62fe3.png">
