### PR TITLE
Fix wrong path to .htaccess

### DIFF
--- a/src/hardening.lib.php
+++ b/src/hardening.lib.php
@@ -190,6 +190,9 @@ class SucuriScanHardening extends SucuriScan
      */
     private static function htaccess($folder = '')
     {
+        if (!function_exists('get_home_path')) {
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+        }
         $folder = str_replace(get_home_path(), '', $folder);
         $bpath = rtrim(get_home_path(), DIRECTORY_SEPARATOR);
 

--- a/src/hardening.lib.php
+++ b/src/hardening.lib.php
@@ -190,8 +190,8 @@ class SucuriScanHardening extends SucuriScan
      */
     private static function htaccess($folder = '')
     {
-        $folder = str_replace(ABSPATH, '', $folder);
-        $bpath = rtrim(ABSPATH, DIRECTORY_SEPARATOR);
+        $folder = str_replace(get_home_path(), '', $folder);
+        $bpath = rtrim(get_home_path(), DIRECTORY_SEPARATOR);
 
         return $bpath . '/' . $folder . '/.htaccess';
     }


### PR DESCRIPTION
Hello,

If Wordpress Core files are located in a subdirectory, the path to .htaccess file is incorrect.
Sucuri should not use `ABSPATH` to locate files but the [get_home_path()](https://developer.wordpress.org/reference/functions/get_home_path/) function 

I think this fix should also fix issue #119 