### PR TITLE
Removed wordpress.sucuri.net API dependency

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,4 +1,7 @@
 {
     "core": null,
-    "plugins": ["."]
+    "plugins": ["."],
+    "config":{
+        "SUCURISCAN_API_URL": "https://sucuri.net"
+    }
 }

--- a/cypress/integration/sucuri-scanner.js
+++ b/cypress/integration/sucuri-scanner.js
@@ -60,7 +60,7 @@ describe( 'Run integration tests', () => {
 	it('can delete datastore files', () => {
 		cy.visit('/wp-admin/admin.php?page=sucuriscan_settings#general');
 
-		cy.get('input[value="sucuri-auditqueue.php"]').click();
+		cy.get('input[value="sucuri-integrity.php"]').click();
 		cy.get('[data-cy=sucuriscan_general_datastore_delete_button]').click();
 		cy.get('.sucuriscan-alert').contains('1 out of 1 files have been deleted.');
 

--- a/inc/css/styles.css
+++ b/inc/css/styles.css
@@ -647,6 +647,12 @@ body.sucuri-security_page_sucuriscan_hardening {
     right: 20px;
     top: 14px;
 }
+.apiservice .sucuriscan-hstatus form {
+    position: relative;
+    right: 0;
+    top: 0;
+    margin-top: 14px;
+}
 .sucuriscan-flag-bar {
     fill: #fff !important;
 }

--- a/inc/tpl/settings-apiservice-status.html.tpl
+++ b/inc/tpl/settings-apiservice-status.html.tpl
@@ -3,12 +3,10 @@
     <h3 class="sucuriscan-title">{{API Service Communication}}</h3>
 
     <div class="inside">
-        <p>{{Once the API key is generate the plugin will communicate with a remote API service that will act as a safe data storage for the audit logs generated when the website triggers certain events that the plugin monitors. If the website is hacked the attacker will not have access to these logs and that way you can investigate what was modified <em>(for malware infaction)</em> and/or how the malicious person was able to gain access to the website.}}</p>
-
+        <p>{{Once the API key is generated and the SUCURISCAN_API_URL configuration value is set, the plugin will communicate with your remote API service that will act as a safe data storage for the audit logs generated when the website triggers certain events that the plugin monitors. If the website is hacked the attacker will not have access to these logs and that way you can investigate what was modified <em>(for malware infaction)</em> and/or how the malicious person was able to gain access to the website.}}</p>
         <div class="sucuriscan-inline-alert-error sucuriscan-%%SUCURI.ApiStatus.ErrorVisibility%%">
-            <p>{{Disabling the API service communication will stop the event monitoring, consider to enable the <a href="%%SUCURI.URL.Settings%%#general">Log Exporter</a> to keep the monitoring working while the HTTP requests are ignored, otherwise an attacker may execute an action that will not be registered in the security logs and you will not have a way to investigate the attack in the future.}}</p>
+            <p>{{The API service is disabled consider enabling the <a href="%%SUCURI.URL.Settings%%#general">Log Exporter</a> to keep the monitoring working while the HTTP requests are ignored, otherwise an attacker may execute an action that will not be registered in the security logs and you will not have a way to investigate the attack in the future.}}</p>
         </div>
-
         <div class="sucuriscan-hstatus sucuriscan-hstatus-%%SUCURI.ApiStatus.StatusNum%%">
             <span>{{API Service Communication}} &mdash; %%SUCURI.ApiStatus.Status%% &mdash;</span>
             <span class="sucuriscan-monospace">%%SUCURI.ApiStatus.ServiceURL%%</span>
@@ -17,14 +15,6 @@
                 <input type="hidden" name="sucuriscan_api_service" value="%%SUCURI.ApiStatus.SwitchValue%%" />
                 <button type="submit" class="button button-primary" data-cy="sucuriscan_api_status_toggle">%%SUCURI.ApiStatus.SwitchText%%</button>
             </form>
-        </div>
-
-        <p>
-            {{<strong>Are you a developer?</strong> You may be interested in our API. Feel free to use the URL shown below to access the latest 50 entries in your security log, change the value for the parameter <code>l=N</code> if you need more. Be aware that the API doesn't provides an offset parameter, so if you have the intension to query specific sections of the log you will need to wrap the HTTP request around your own cache mechanism. We <strong>DO NOT</strong> take feature requests for the API, this is a semi-private service tailored for the specific needs of the plugin and not intended to be used by 3rd-party apps, we may change the behavior of each API endpoint without previous notice, use it at your own risk.}}
-        </p>
-
-        <div class="sucuriscan-hstatus sucuriscan-hstatus-2 sucuriscan-monospace">
-            <span>curl -s "https://wordpress.sucuri.net/api/?k=%%SUCURI.ApiStatus.ApiKey%%&a=get_logs&l=50" | python -m json.tool</span>
         </div>
     </div>
 </div>

--- a/inc/tpl/settings-apiservice-status.html.tpl
+++ b/inc/tpl/settings-apiservice-status.html.tpl
@@ -1,11 +1,11 @@
 
-<div class="sucuriscan-panel">
+<div class="sucuriscan-panel apiservice">
     <h3 class="sucuriscan-title">{{API Service Communication}}</h3>
 
     <div class="inside">
         <p>{{Once the API key is generated and the SUCURISCAN_API_URL configuration value is set, the plugin will communicate with your remote API service that will act as a safe data storage for the audit logs generated when the website triggers certain events that the plugin monitors. If the website is hacked the attacker will not have access to these logs and that way you can investigate what was modified <em>(for malware infaction)</em> and/or how the malicious person was able to gain access to the website.}}</p>
         <div class="sucuriscan-inline-alert-error sucuriscan-%%SUCURI.ApiStatus.ErrorVisibility%%">
-            <p>{{The API service is disabled. Consider enabling the <a href="%%SUCURI.URL.Settings%%#general">Log Exporter</a> to keep the monitoring working while the HTTP requests are ignored, otherwise an attacker may execute an action that will not be registered in the security logs and you will not have a way to investigate the attack in the future.}}</p>
+            <p>{{The API service is disabled. Consider enabling the <a href="%%SUCURI.URL.Settings%%#general">Log Exporter</a> to keep the monitoring working otherwise, an attacker may execute an action that will not be registered in the security logs and you will not have a way to identify such an event while investigating the incident.}}</p>
         </div>
         <div class="sucuriscan-hstatus sucuriscan-hstatus-%%SUCURI.ApiStatus.StatusNum%%">
             <span>{{API Service Communication}} &mdash; %%SUCURI.ApiStatus.Status%% &mdash;</span>

--- a/inc/tpl/settings-apiservice-status.html.tpl
+++ b/inc/tpl/settings-apiservice-status.html.tpl
@@ -5,7 +5,7 @@
     <div class="inside">
         <p>{{Once the API key is generated and the SUCURISCAN_API_URL configuration value is set, the plugin will communicate with your remote API service that will act as a safe data storage for the audit logs generated when the website triggers certain events that the plugin monitors. If the website is hacked the attacker will not have access to these logs and that way you can investigate what was modified <em>(for malware infaction)</em> and/or how the malicious person was able to gain access to the website.}}</p>
         <div class="sucuriscan-inline-alert-error sucuriscan-%%SUCURI.ApiStatus.ErrorVisibility%%">
-            <p>{{The API service is disabled consider enabling the <a href="%%SUCURI.URL.Settings%%#general">Log Exporter</a> to keep the monitoring working while the HTTP requests are ignored, otherwise an attacker may execute an action that will not be registered in the security logs and you will not have a way to investigate the attack in the future.}}</p>
+            <p>{{The API service is disabled. Consider enabling the <a href="%%SUCURI.URL.Settings%%#general">Log Exporter</a> to keep the monitoring working while the HTTP requests are ignored, otherwise an attacker may execute an action that will not be registered in the security logs and you will not have a way to investigate the attack in the future.}}</p>
         </div>
         <div class="sucuriscan-hstatus sucuriscan-hstatus-%%SUCURI.ApiStatus.StatusNum%%">
             <span>{{API Service Communication}} &mdash; %%SUCURI.ApiStatus.Status%% &mdash;</span>

--- a/src/event.lib.php
+++ b/src/event.lib.php
@@ -384,7 +384,7 @@ class SucuriScanEvent extends SucuriScan
      */
     public static function sendLogsFromQueue()
     {
-        if (SucuriScanOption::isDisabled(':api_service') || !defined('SUCURISCAN_API_URL')) {
+        if (SucuriScanOption::isDisabled(':api_service') || !defined('SUCURISCAN_API_URL') || empty(SUCURISCAN_API_URL)) {
             return false;
         }
 

--- a/src/event.lib.php
+++ b/src/event.lib.php
@@ -280,7 +280,7 @@ class SucuriScanEvent extends SucuriScan
      * Sends information of a security event to the API.
      *
      * If the website owner has enabled the security log exporter, this method
-     * will also write the information about the security event to taht file.
+     * will also write the information about the security event to that file.
      * This allows to integrate with different monitoring systems like OSSEC or
      * OpenVAS.
      *
@@ -384,7 +384,7 @@ class SucuriScanEvent extends SucuriScan
      */
     public static function sendLogsFromQueue()
     {
-        if (SucuriScanOption::isDisabled(':api_service')) {
+        if (SucuriScanOption::isDisabled(':api_service') || !defined('SUCURISCAN_API_URL')) {
             return false;
         }
 

--- a/src/event.lib.php
+++ b/src/event.lib.php
@@ -740,7 +740,7 @@ class SucuriScanEvent extends SucuriScan
             return false;
         }
 
-        $reset_password_url = network_site_url("wp-login.php?action=rp&key=$key&login=" . rawurlencode($user_login), 'login' );
+        $reset_password_url = network_site_url("wp-login.php?action=rp&key=$key&login=" . rawurlencode($user_login), 'https' );
 
         $message = SucuriScanTemplate::getSection(
             'settings-posthack-reset-password-alert',

--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -66,7 +66,7 @@ class SucuriScanOption extends SucuriScanRequest
             'sucuriscan_addr_header' => 'HTTP_X_SUCURI_CLIENTIP',
             'sucuriscan_api_key' => false,
             'sucuriscan_api_protocol' => 'https',
-            'sucuriscan_api_service' => 'enabled',
+            'sucuriscan_api_service' => 'disabled',
             'sucuriscan_auto_clear_cache' => 'disabled',
             'sucuriscan_checksum_api' => '',
             'sucuriscan_cloudproxy_apikey' => '',

--- a/src/settings-apiservice.php
+++ b/src/settings-apiservice.php
@@ -30,27 +30,27 @@ if (!defined('SUCURISCAN_INIT') || SUCURISCAN_INIT !== true) {
  */
 function sucuriscan_settings_apiservice_status($nonce)
 {
-    $api_url_is_set = defined('SUCURISCAN_API_URL');
+    $api_url_is_set = defined('SUCURISCAN_API_URL') && !empty(SUCURISCAN_API_URL);
 
     $params = array();
 
     if ($nonce) {
-            // Enable or disable the API service communication.
-            $api_service = SucuriScanRequest::post(':api_service', '(en|dis)able');
+        // Enable or disable the API service communication.
+        $api_service = SucuriScanRequest::post(':api_service', '(en|dis)able');
 
-            if ($api_service) {
-                if (!$api_url_is_set) {
-                    SucuriScanInterface::error(__('The status of the API service could not be enabled because the required SUCURISCAN_API_URL configuration was not found.', 'sucuri-scanner'));
-                } else {
-                    $action_d = $api_service . 'd';
-                    $message = sprintf(__('API service communication was <code>%s</code>', 'sucuri-scanner'), $action_d);
+        if ($api_service) {
+            if (!$api_url_is_set) {
+                SucuriScanInterface::error(__('The status of the API service could not be enabled because the required SUCURISCAN_API_URL configuration was not found.', 'sucuri-scanner'));
+            } else {
+                $action_d = $api_service . 'd';
+                $message = sprintf(__('API service communication was <code>%s</code>', 'sucuri-scanner'), $action_d);
 
-                    SucuriScanEvent::reportInfoEvent($message);
-                    SucuriScanEvent::notifyEvent('plugin_change', $message);
-                    SucuriScanOption::updateOption(':api_service', $action_d);
-                    SucuriScanInterface::info(__('The status of the API service has been changed', 'sucuri-scanner'));
-                }
+                SucuriScanEvent::reportInfoEvent($message);
+                SucuriScanEvent::notifyEvent('plugin_change', $message);
+                SucuriScanOption::updateOption(':api_service', $action_d);
+                SucuriScanInterface::info(__('The status of the API service has been changed', 'sucuri-scanner'));
             }
+        }
     }
 
     $api_service_option = SucuriScanOption::getOption(':api_service');

--- a/src/settings-apiservice.php
+++ b/src/settings-apiservice.php
@@ -62,7 +62,7 @@ function sucuriscan_settings_apiservice_status($nonce)
         $params['ApiStatus.SwitchValue'] = 'enable';
         $params['ApiStatus.WarningVisibility'] = 'hidden';
         $params['ApiStatus.ErrorVisibility'] = 'visible';
-        $params['ApiStatus.ServiceURL'] = 'Service API URL not set. To enable the API service add your API service url as the SUCURISCAN_API_URL constant value to the main configuration file (wp-config.php).';
+        $params['ApiStatus.ServiceURL'] = 'Service API URL not set. To enable the API service, add your API service URL as the SUCURISCAN_API_URL constant value to the main configuration file (wp-config.php).';
     } else {
         $params['ApiStatus.StatusNum'] = '1';
         $params['ApiStatus.Status'] = __('Enabled', 'sucuri-scanner');

--- a/src/settings-apiservice.php
+++ b/src/settings-apiservice.php
@@ -30,41 +30,48 @@ if (!defined('SUCURISCAN_INIT') || SUCURISCAN_INIT !== true) {
  */
 function sucuriscan_settings_apiservice_status($nonce)
 {
+    $api_url_is_set = defined('SUCURISCAN_API_URL');
+
     $params = array();
 
-    $params['ApiStatus.StatusNum'] = '1';
-    $params['ApiStatus.Status'] = __('Enabled', 'sucuri-scanner');
-    $params['ApiStatus.SwitchText'] = __('Disable', 'sucuri-scanner');
-    $params['ApiStatus.SwitchValue'] = 'disable';
-    $params['ApiStatus.WarningVisibility'] = 'visible';
-    $params['ApiStatus.ErrorVisibility'] = 'hidden';
-    $params['ApiStatus.ServiceURL'] = SUCURISCAN_API_URL;
-    $params['ApiStatus.ApiKey'] = '';
-
     if ($nonce) {
-        // Enable or disable the API service communication.
-        $api_service = SucuriScanRequest::post(':api_service', '(en|dis)able');
+            // Enable or disable the API service communication.
+            $api_service = SucuriScanRequest::post(':api_service', '(en|dis)able');
 
-        if ($api_service) {
-            $action_d = $api_service . 'd';
-            $message = sprintf(__('API service communication was <code>%s</code>', 'sucuri-scanner'), $action_d);
+            if ($api_service) {
+                if (!$api_url_is_set) {
+                    SucuriScanInterface::error(__('The status of the API service could not be enabled because the required SUCURISCAN_API_URL configuration was not found.', 'sucuri-scanner'));
+                } else {
+                    $action_d = $api_service . 'd';
+                    $message = sprintf(__('API service communication was <code>%s</code>', 'sucuri-scanner'), $action_d);
 
-            SucuriScanEvent::reportInfoEvent($message);
-            SucuriScanEvent::notifyEvent('plugin_change', $message);
-            SucuriScanOption::updateOption(':api_service', $action_d);
-            SucuriScanInterface::info(__('The status of the API service has been changed', 'sucuri-scanner'));
-        }
+                    SucuriScanEvent::reportInfoEvent($message);
+                    SucuriScanEvent::notifyEvent('plugin_change', $message);
+                    SucuriScanOption::updateOption(':api_service', $action_d);
+                    SucuriScanInterface::info(__('The status of the API service has been changed', 'sucuri-scanner'));
+                }
+            }
     }
 
-    $api_service = SucuriScanOption::getOption(':api_service');
+    $api_service_option = SucuriScanOption::getOption(':api_service');
 
-    if ($api_service === 'disabled') {
+    if ($api_service_option === 'disabled' || !$api_url_is_set) {
         $params['ApiStatus.StatusNum'] = '0';
         $params['ApiStatus.Status'] = __('Disabled', 'sucuri-scanner');
         $params['ApiStatus.SwitchText'] = __('Enable', 'sucuri-scanner');
         $params['ApiStatus.SwitchValue'] = 'enable';
         $params['ApiStatus.WarningVisibility'] = 'hidden';
         $params['ApiStatus.ErrorVisibility'] = 'visible';
+        $params['ApiStatus.ServiceURL'] = 'Service API URL not set. To enable the API service add your API service url as the SUCURISCAN_API_URL constant value to the main configuration file (wp-config.php).';
+    } else {
+        $params['ApiStatus.StatusNum'] = '1';
+        $params['ApiStatus.Status'] = __('Enabled', 'sucuri-scanner');
+        $params['ApiStatus.SwitchText'] = __('Disable', 'sucuri-scanner');
+        $params['ApiStatus.SwitchValue'] = 'disable';
+        $params['ApiStatus.WarningVisibility'] = 'visible';
+        $params['ApiStatus.ErrorVisibility'] = 'hidden';
+        $params['ApiStatus.ServiceURL'] = SUCURISCAN_API_URL;
+        $params['ApiStatus.ApiKey'] = '';
     }
 
     $api_key = SucuriScanAPI::getPluginKey();

--- a/sucuri.php
+++ b/sucuri.php
@@ -8,7 +8,7 @@
  * Author: Sucuri Inc.
  * Text Domain: sucuri-scanner
  * Domain Path: /lang
- * Version: 1.8.37
+ * Version: 1.8.36
  *
  * PHP version 7
  *

--- a/sucuri.php
+++ b/sucuri.php
@@ -8,7 +8,7 @@
  * Author: Sucuri Inc.
  * Text Domain: sucuri-scanner
  * Domain Path: /lang
- * Version: 1.8.36
+ * Version: 1.8.37
  *
  * PHP version 7
  *
@@ -112,18 +112,6 @@ define('SUCURISCAN_PLUGIN_PATH', WP_PLUGIN_DIR . '/' . SUCURISCAN_PLUGIN_FOLDER)
  * The local URL where the plugin's files and assets are served.
  */
 define('SUCURISCAN_URL', rtrim(plugin_dir_url(__FILE__), '/'));
-
-/**
- * Remote URL where the public Sucuri API service is running.
- *
- * We will check if the constant was already set to allow developers to use
- * their own API service. This is useful both for the execution of the tests
- * as well as for website owners who do not want to send data to the Sucuri
- * servers.
- */
-if (!defined('SUCURISCAN_API_URL')) {
-    define('SUCURISCAN_API_URL', 'https://wordpress.sucuri.net/api/');
-}
 
 /**
  * Latest version of the public Sucuri API.


### PR DESCRIPTION
This PR removes the `https://wordpress.sucuri.net/api/` dependency, since this service has been discontinued until further notice. User who have their custom API to use in place of `https://wordpress.sucuri.net/api/` can still use the functionality by  adding the API endpoint as `SUCURISCAN_API_URL` on the `wp-config.php` file.

