### PR TITLE
Fixed API service messaging

### DIFF
--- a/inc/css/styles.css
+++ b/inc/css/styles.css
@@ -1117,3 +1117,7 @@ body.sucuri-security_page_sucuriscan_hardening {
 h3.lead {
     margin: .5em 0;
 }
+
+.sucuriscan-hstatus-2 .btn-enable-api-s {
+    display: none;
+}

--- a/inc/tpl/settings-apiservice-status.html.tpl
+++ b/inc/tpl/settings-apiservice-status.html.tpl
@@ -4,16 +4,16 @@
 
     <div class="inside">
         <p>{{Once the API key is generated and the SUCURISCAN_API_URL configuration value is set, the plugin will communicate with your remote API service that will act as a safe data storage for the audit logs generated when the website triggers certain events that the plugin monitors. If the website is hacked the attacker will not have access to these logs and that way you can investigate what was modified <em>(for malware infaction)</em> and/or how the malicious person was able to gain access to the website.}}</p>
-        <div class="sucuriscan-inline-alert-error sucuriscan-%%SUCURI.ApiStatus.ErrorVisibility%%">
-            <p>{{The API service is disabled. Consider enabling the <a href="%%SUCURI.URL.Settings%%#general">Log Exporter</a> to keep the monitoring working otherwise, an attacker may execute an action that will not be registered in the security logs and you will not have a way to identify such an event while investigating the incident.}}</p>
+        <div class="sucuriscan-inline-alert-info sucuriscan-%%SUCURI.ApiStatus.ErrorVisibility%%">
+            <p>{{The API service is disabled. Consider enabling the <a href="%%SUCURI.URL.Settings%%#general">Log Exporter</a> to keep the monitoring working. Otherwise, an attacker may execute an action that will not be registered in the security logs and you will not have a way to identify such an event while investigating the incident.}}</p>
         </div>
         <div class="sucuriscan-hstatus sucuriscan-hstatus-%%SUCURI.ApiStatus.StatusNum%%">
-            <span>{{API Service Communication}} &mdash; %%SUCURI.ApiStatus.Status%% &mdash;</span>
-            <span class="sucuriscan-monospace">%%SUCURI.ApiStatus.ServiceURL%%</span>
+            <span>{{API Service Communication}} &mdash; %%SUCURI.ApiStatus.Status%%</span>
+            <span class="sucuriscan-monospace">&mdash; %%SUCURI.ApiStatus.ServiceURL%%</span>
             <form action="%%SUCURI.URL.Settings%%#apiservice" method="post">
                 <input type="hidden" name="sucuriscan_page_nonce" value="%%SUCURI.PageNonce%%" />
                 <input type="hidden" name="sucuriscan_api_service" value="%%SUCURI.ApiStatus.SwitchValue%%" />
-                <button type="submit" class="button button-primary" data-cy="sucuriscan_api_status_toggle">%%SUCURI.ApiStatus.SwitchText%%</button>
+                <button type="submit" class="button button-primary btn-enable-api-s" data-cy="sucuriscan_api_status_toggle">%%SUCURI.ApiStatus.SwitchText%%</button>
             </form>
         </div>
     </div>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate Link: https://sucuri.net/
 Tags: malware, security, firewall, scan, spam, virus, sucuri, protection, blocklist, detection, hardening, file integrity
 Requires at least: 3.6
 Tested up to: 6.2
-Stable tag: 1.8.38
+Stable tag: 1.8.39
 
 The Sucuri WordPress Security plugin is a security toolset for security integrity monitoring, malware detection and security hardening.
 
@@ -198,8 +198,11 @@ This version adds an option to refresh the malware scan results on demand, as we
 Daniel is no longer maintaining the Sucuri plugin at GoDaddy. We have transferred it to a dedicated team to maintain and improve it.
 
 == Changelog ==
+= 1.8.39 =
+* Fixed API service messaging
+
 = 1.8.38 =
-* Fixed API service handling when the SUCURISCAN_PLUGIN_PATH config value is not defined
+* Fixed API service handling when the SUCURISCAN_API_URL config value is not defined
 * Fixed API service UI messaging
 
 = 1.8.37 =

--- a/src/interface.lib.php
+++ b/src/interface.lib.php
@@ -228,19 +228,6 @@ class SucuriScanInterface
         SucuriScanOption::updateOption(':plugin_version', SUCURISCAN_VERSION);
 
         /**
-         * Suggest re-activation of the API communication.
-         *
-         * Check if the API communication has been disabled due to issues with
-         * the previous version of the code, in this case we will display a
-         * message at the top of the admin dashboard suggesting the user to
-         * enable it once again expecting to see have a better performance with
-         * the new code.
-         */
-        if (SucuriScanOption::isDisabled(':api_service')) {
-            self::info(__('API service communication is disabled, if you just updated the plugin this might be a good opportunity to test this feature once again with the new code. Enable it again from the "API Service" panel located in the settings page.', 'sucuri-scanner'));
-        }
-
-        /**
          * Invite website owner to subscribe to our security newsletter.
          *
          * For every fresh installation of the plugin we will send a one-time

--- a/src/settings-apiservice.php
+++ b/src/settings-apiservice.php
@@ -55,23 +55,29 @@ function sucuriscan_settings_apiservice_status($nonce)
 
     $api_service_option = SucuriScanOption::getOption(':api_service');
 
-    if ($api_service_option === 'disabled' || !$api_url_is_set) {
-        $params['ApiStatus.StatusNum'] = '0';
-        $params['ApiStatus.Status'] = __('Disabled', 'sucuri-scanner');
-        $params['ApiStatus.SwitchText'] = __('Enable', 'sucuri-scanner');
-        $params['ApiStatus.SwitchValue'] = 'enable';
-        $params['ApiStatus.WarningVisibility'] = 'hidden';
-        $params['ApiStatus.ErrorVisibility'] = 'visible';
-        $params['ApiStatus.ServiceURL'] = 'Service API URL not set. To enable the API service, add your API service URL as the SUCURISCAN_API_URL constant value to the main configuration file (wp-config.php).';
-    } else {
+    if ($api_service_option === 'enabled') {
         $params['ApiStatus.StatusNum'] = '1';
         $params['ApiStatus.Status'] = __('Enabled', 'sucuri-scanner');
         $params['ApiStatus.SwitchText'] = __('Disable', 'sucuri-scanner');
         $params['ApiStatus.SwitchValue'] = 'disable';
         $params['ApiStatus.WarningVisibility'] = 'visible';
         $params['ApiStatus.ErrorVisibility'] = 'hidden';
-        $params['ApiStatus.ServiceURL'] = SUCURISCAN_API_URL;
     }
+
+    if ($api_service_option === 'disabled' || !$api_url_is_set) {
+        $params['ApiStatus.StatusNum'] = '2';
+        $params['ApiStatus.Status'] = __('Disabled', 'sucuri-scanner');
+        $params['ApiStatus.SwitchText'] = __('Enable', 'sucuri-scanner');
+        $params['ApiStatus.SwitchValue'] = 'enable';
+        $params['ApiStatus.WarningVisibility'] = 'hidden';
+        $params['ApiStatus.ErrorVisibility'] = 'visible';
+    }
+
+    if ($api_service_option === 'disabled' && $api_url_is_set) {
+        $params['ApiStatus.StatusNum'] = '0';
+    }
+
+    $params['ApiStatus.ServiceURL'] = !$api_url_is_set ? __('Service API URL not set. To enable the API service, add your custom API service URL as the SUCURISCAN_API_URL constant value to the main configuration file (wp-config.php). If you do not have a custom API to store the audit logs, the plugin will still store these logs on your hosting environment.') : __('Service API URL: '). SUCURISCAN_API_URL;
 
     $api_key = SucuriScanAPI::getPluginKey();
     $params['ApiStatus.ApiKey'] = $api_key ? $api_key : __('NONE', 'sucuri-scanner');

--- a/sucuri.php
+++ b/sucuri.php
@@ -8,7 +8,7 @@
  * Author: Sucuri Inc.
  * Text Domain: sucuri-scanner
  * Domain Path: /lang
- * Version: 1.8.38
+ * Version: 1.8.39
  *
  * PHP version 7
  *
@@ -85,7 +85,7 @@ define('SUCURISCAN', 'sucuriscan');
 /**
  * Current version of the plugin's code.
  */
-define('SUCURISCAN_VERSION', '1.8.38');
+define('SUCURISCAN_VERSION', '1.8.39');
 
 /**
  * Defines the human readable name of the plugin.


### PR DESCRIPTION
This PR brings in more fixes for the API service functionality so as to provide more elaborate errors and alerts messaging for all of the API service status. 

## Screenshots:
### API URL is set and service is enabled
<img width="1749" alt="Screenshot 2023-04-12 at 21 02 09" src="https://user-images.githubusercontent.com/4721523/231576582-dd0342e6-ad5d-425a-879e-ec14a3569fbf.png">

### API URL is set but service is disabled
<img width="1738" alt="Screenshot 2023-04-12 at 21 01 58" src="https://user-images.githubusercontent.com/4721523/231576656-600dfca7-81c5-4bab-a2c1-b51f744f531d.png">

### API URL is not set
<img width="1706" alt="Screenshot 2023-04-12 at 21 20 46" src="https://user-images.githubusercontent.com/4721523/231576751-6703826d-0232-4868-a572-80db07363b05.png">

