### PR TITLE
Ensure wp_get_current_user exists before calling

### DIFF
--- a/src/mail.lib.php
+++ b/src/mail.lib.php
@@ -169,7 +169,12 @@ class SucuriScanMail extends SucuriScanOption
         $params = array();
         $display_name = '';
         $prettify_type = 'simple';
-        $user = wp_get_current_user();
+        
+        // Check if the WordPress function wp_get_current_user is available
+        if (!function_exists('wp_get_current_user')) {
+            include(ABSPATH . "wp-includes/pluggable.php");
+        }
+        
         $website = self::getDomain();
 
         if (isset($data_set['PrettifyType'])) {


### PR DESCRIPTION
Updated the code to check if the `wp_get_current_user` function exists before calling it. This prevents errors in scenarios where WordPress hasn't fully loaded all functions. The update includes the `pluggable.php` file when necessary.

```
Fatal error: Uncaught Error: Call to undefined function p_get_current _user in /wp-content/plugins/sucuri-
scanner/src/mail.lib.php:172 Stack trace: #0
/wp-content/plugins/sucuri-scanner/src/mail.lib.php(85): SucuriScanMail:prettifyMail'Plugin Deactiva…', 'Plugin
deactiva..', Array) #1 /wp-content/plugins/sucuri-scanner/src/event.lib.php(629):
SucuriScanMail::sendMail(robertstanly100.., 'Plugin Deactiva…', 'Plugin deactiva…',
Array) #2 /wp-content/plugins/sucuri-scanner/src/hook.lib.php(424):
SucuriScanEvent.:notifyEvent'plugin deactiva.., 'Plugin deactiva…) #3
/wp-content/plugins/sucuri-scanner/src/hook.lib.php(436): SucuriScanHook::hookPluginChanges('deactivated', 'wp-
sms-two-way…', false) #4/home/customer/www/ce in/wp-
content/plugins/sucuri-scanner/src/mail.lib.php on line 172
```

Best