### PR TITLE
Fix mail error handling

### DIFF
--- a/src/settings-alerts.php
+++ b/src/settings-alerts.php
@@ -91,14 +91,19 @@ function sucuriscan_settings_alerts_recipients($nonce)
         // Debug ability of the plugin to send email alerts correctly.
         if (SucuriScanRequest::post(':debug_email')) {
             $recipients = SucuriScanOption::getOption(':notify_to');
-            SucuriScanMail::sendMail(
+            $mailSentSuccess = SucuriScanMail::sendMail(
                 $recipients,
                 __('Test Email Alert', 'sucuri-scanner'),
                 sprintf(__('Test email alert sent at %s', 'sucuri-scanner'), SucuriScan::datetime()),
                 array('Force' => true)
             );
 
-            SucuriScanInterface::info(__('A test alert was sent to your email, check your inbox', 'sucuri-scanner'));
+            if ($mailSentSuccess) {
+                SucuriScanInterface::info(__('A test alert was sent to your email, check your inbox', 'sucuri-scanner'));
+            }else {
+                SucuriScanInterface::error(__('An error occurred sending email - please check your server mail configuration.', 'sucuri-scanner'));
+            }
+
         }
     }
 


### PR DESCRIPTION
This PR fixes an issue whereby critical failures `PHP Fatal errors` while dispatching email notifications were bubbling up as `500s` and blocking users. 

It also adds a notification shown when the testing email notification fails and a log item for email notification failures.