### PR TITLE
Fixed typos in the event.lib.php file

### DIFF
--- a/src/event.lib.php
+++ b/src/event.lib.php
@@ -505,7 +505,7 @@ class SucuriScanEvent extends SucuriScan
     /**
      * Reports a debug event on the website.
      *
-     * @param string $message Text witht the explanation of the event or action performed.
+     * @param string $message Text with the explanation of the event or action performed.
      * @return bool            Either true or false depending on the success of the operation.
      */
     public static function reportDebugEvent($message = '')
@@ -516,7 +516,7 @@ class SucuriScanEvent extends SucuriScan
     /**
      * Reports a notice event on the website.
      *
-     * @param string $message Text witht the explanation of the event or action performed.
+     * @param string $message Text with the explanation of the event or action performed.
      * @return bool            Either true or false depending on the success of the operation.
      */
     public static function reportNoticeEvent($message = '')
@@ -527,7 +527,7 @@ class SucuriScanEvent extends SucuriScan
     /**
      * Reports a info event on the website.
      *
-     * @param string $message Text witht the explanation of the event or action performed.
+     * @param string $message Text with the explanation of the event or action performed.
      * @return bool            Either true or false depending on the success of the operation.
      */
     public static function reportInfoEvent($message = '')
@@ -538,7 +538,7 @@ class SucuriScanEvent extends SucuriScan
     /**
      * Reports a warning event on the website.
      *
-     * @param string $message Text witht the explanation of the event or action performed.
+     * @param string $message Text with the explanation of the event or action performed.
      * @return bool            Either true or false depending on the success of the operation.
      */
     public static function reportWarningEvent($message = '')
@@ -549,7 +549,7 @@ class SucuriScanEvent extends SucuriScan
     /**
      * Reports a error event on the website.
      *
-     * @param string $message Text witht the explanation of the event or action performed.
+     * @param string $message Text with the explanation of the event or action performed.
      * @return bool            Either true or false depending on the success of the operation.
      */
     public static function reportErrorEvent($message = '')
@@ -560,7 +560,7 @@ class SucuriScanEvent extends SucuriScan
     /**
      * Reports a critical event on the website.
      *
-     * @param string $message Text witht the explanation of the event or action performed.
+     * @param string $message Text with the explanation of the event or action performed.
      * @return bool            Either true or false depending on the success of the operation.
      */
     public static function reportCriticalEvent($message = '')


### PR DESCRIPTION
In the block comments for various event reporting functions there was a typo `Text witht the explanation` that should be `Text with the explanation`. This simple PR fixes those 6 typos.