### PR TITLE
Update how we store API key

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Run WAF migration tests (E2E)
         run: |
-          npx wp-env run tests-cli bash wp-content/plugins/sucuri-scanner/tests/e2e-seed-waf-migration.sh
+          npx wp-env run tests-cli bash /var/www/html/wp-content/plugins/sucuri-scanner/tests/e2e-seed-waf-migration.sh
           npx cypress run --spec cypress/e2e/sucuri-scanner-waf-migration.cy.js
 
       - name: Run Firewall tests (E2E)

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -98,7 +98,9 @@ jobs:
           make e2e-scanner
 
       - name: Run WAF migration tests (E2E)
-        run: npx cypress run --spec cypress/e2e/sucuri-scanner-waf-migration.cy.js
+        run: |
+          npx wp-env run tests-cli bash wp-content/plugins/sucuri-scanner/tests/e2e-seed-waf-migration.sh
+          npx cypress run --spec cypress/e2e/sucuri-scanner-waf-migration.cy.js
 
       - name: Run Firewall tests (E2E)
         if: env.cypress_waf_api_key

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -1,7 +1,7 @@
 name: End-to-end tests
 
 # Triggers the workflow on push or pull request events
-on: [ push, pull_request ]
+on: [push, pull_request]
 
 jobs:
   # Runs the end-to-end test suite.
@@ -56,7 +56,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 25
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install Dependencies
         run: npm ci
@@ -97,6 +97,9 @@ jobs:
           cp cypress.config.js.example cypress.config.js
           make e2e-scanner
 
+      - name: Run WAF migration tests (E2E)
+        run: npx cypress run --spec cypress/e2e/sucuri-scanner-waf-migration.cy.js
+
       - name: Run Firewall tests (E2E)
         if: env.cypress_waf_api_key
         env:
@@ -111,4 +114,3 @@ jobs:
           path: |
             cypress/videos
             cypress/screenshots
-        

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -98,9 +98,7 @@ jobs:
           make e2e-scanner
 
       - name: Run WAF migration tests (E2E)
-        run: |
-          npx wp-env run tests-cli bash /var/www/html/wp-content/plugins/sucuri-scanner/tests/e2e-seed-waf-migration.sh
-          npx cypress run --spec cypress/e2e/sucuri-scanner-waf-migration.cy.js
+        run: make e2e-waf-migration
 
       - name: Run Firewall tests (E2E)
         if: env.cypress_waf_api_key

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-.PHONY: e2e e2e-prepare e2e-scanner e2e-firewall unit-test update-translations
+.PHONY: e2e e2e-prepare e2e-scanner e2e-firewall e2e-waf-migration-prepare e2e-waf-migration unit-test update-translations
 
 e2e: e2e-prepare e2e-scanner e2e-firewall
 
@@ -15,6 +15,13 @@ e2e-scanner:
 
 e2e-firewall:
 	npx cypress run --spec cypress/e2e/sucuri-scanner-firewall.cy.js
+
+e2e-waf-migration-prepare:
+	chmod +x tests/e2e-seed-waf-migration.sh
+	npx wp-env run tests-cli bash wp-content/plugins/$(notdir $(CURDIR))/tests/e2e-seed-waf-migration.sh
+
+e2e-waf-migration: e2e-waf-migration-prepare
+	npx cypress run --spec cypress/e2e/sucuri-scanner-waf-migration.cy.js
 
 unit-test:
 	./vendor/bin/phpunit

--- a/cypress/e2e/sucuri-scanner-waf-migration.cy.js
+++ b/cypress/e2e/sucuri-scanner-waf-migration.cy.js
@@ -1,0 +1,108 @@
+const legacyWafKey =
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const settingsFilePath = "wp-content/uploads/sucuri/sucuri-settings.php";
+
+function runWpCli(command) {
+  return cy.task("exec", `npx wp-env run tests-cli ${command}`);
+}
+
+function readSettingsFileJson() {
+  const php = `php -r '${
+    `\$path=${JSON.stringify(settingsFilePath)};` +
+    "$content=@file_get_contents($path);" +
+    'if($content===false){echo "";exit(0);} ' +
+    '$lines=explode("\\n",$content,2);' +
+    'if(count($lines)<2){echo "";exit(0);} ' +
+    "$json=trim($lines[1]);" +
+    "echo $json;"
+  }'`;
+
+  return runWpCli(php).then((output) => {
+    if (!output) {
+      return {};
+    }
+    return JSON.parse(output);
+  });
+}
+
+function seedLegacyWafKey() {
+  const php = `php -r '${
+    `\$path=${JSON.stringify(settingsFilePath)};` +
+    "$dir=dirname($path);" +
+    "if(!is_dir($dir)){mkdir($dir,0755,true);} " +
+    "$data=array(" +
+    `"sucuriscan_cloudproxy_apikey"=>"${legacyWafKey}",` +
+    '"sucuriscan_addr_header"=>"REMOTE_ADDR",' +
+    '"sucuriscan_notify_to"=>"alerts@example.com"' +
+    ");" +
+    "$json=json_encode($data);" +
+    '$content="<?php exit(0); ?>\\n".$json."\\n";' +
+    "file_put_contents($path,$content);"
+  }'`;
+
+  return runWpCli(php)
+    .then(() =>
+      runWpCli(
+        "wp option delete sucuriscan_secret_cloudproxy_apikey_enc || true",
+      ),
+    )
+    .then(() =>
+      runWpCli("wp option delete sucuriscan_secret_cloudproxy_apikey || true"),
+    );
+}
+
+beforeEach(() => {
+  cy.session("Login to WordPress", () => {
+    cy.login();
+  });
+});
+
+describe("Run e2e WAF migration tests", () => {
+  it("migrates legacy WAF key to encrypted DB option", () => {
+    return seedLegacyWafKey().then(() => {
+      readSettingsFileJson().then((settings) => {
+        expect(settings.sucuriscan_cloudproxy_apikey).to.eq(legacyWafKey);
+        expect(settings.sucuriscan_addr_header).to.eq("REMOTE_ADDR");
+      });
+
+      cy.intercept(
+        "POST",
+        "/wp-admin/admin-ajax.php?page=sucuriscan",
+        (req) => {
+          if (req.body.includes("get_firewall_settings")) {
+            req.reply({
+              status: 1,
+              output: {
+                cache_level: "full",
+                status: "active",
+              },
+            });
+          }
+        },
+      );
+
+      cy.visit("/wp-admin/admin.php?page=sucuriscan_firewall");
+
+      readSettingsFileJson().then((settings) => {
+        expect(settings).not.to.have.property("sucuriscan_cloudproxy_apikey");
+        expect(settings.sucuriscan_addr_header).to.eq("REMOTE_ADDR");
+      });
+
+      runWpCli(
+        "wp option get sucuriscan_secret_cloudproxy_apikey_enc --format=json",
+      ).then((output) => {
+        const payload = JSON.parse(output);
+        expect(payload).to.have.property("alg", "aes-256-gcm");
+        expect(payload).to.have.property("iv");
+        expect(payload).to.have.property("tag");
+        expect(payload).to.have.property("ct");
+      });
+
+      runWpCli(
+        "wp option get sucuriscan_secret_cloudproxy_apikey || true",
+      ).then((output) => {
+        expect(output).to.eq("");
+      });
+    });
+  });
+});

--- a/cypress/e2e/sucuri-scanner-waf-migration.cy.js
+++ b/cypress/e2e/sucuri-scanner-waf-migration.cy.js
@@ -44,6 +44,41 @@ function seedLegacyWafKey() {
   });
 }
 
+function ensureLegacyWafKey() {
+  return seedLegacyWafKey().then((settings) => {
+    if (settings.sucuriscan_cloudproxy_apikey) {
+      return settings;
+    }
+
+    const php = `php -r '${
+      `\$path=${JSON.stringify(settingsFilePath)};` +
+      "$dir=dirname($path);" +
+      "if(!is_dir($dir)){mkdir($dir,0755,true);} " +
+      "$data=array(" +
+      `"sucuriscan_cloudproxy_apikey"=>"${legacyWafKey}",` +
+      '"sucuriscan_addr_header"=>"REMOTE_ADDR",' +
+      '"sucuriscan_notify_to"=>"alerts@example.com"' +
+      ");" +
+      "$json=json_encode($data);" +
+      '$content="<?php exit(0); ?>\\n".$json."\\n";' +
+      "file_put_contents($path,$content);"
+    }'`;
+
+    return runWpCli(php)
+      .then(() =>
+        runWpCli(
+          "wp option delete sucuriscan_secret_cloudproxy_apikey_enc || true",
+        ),
+      )
+      .then(() =>
+        runWpCli(
+          "wp option delete sucuriscan_secret_cloudproxy_apikey || true",
+        ),
+      )
+      .then(() => readSettingsFileJson());
+  });
+}
+
 beforeEach(() => {
   cy.session("Login to WordPress", () => {
     cy.login();
@@ -52,7 +87,7 @@ beforeEach(() => {
 
 describe("Run e2e WAF migration tests", () => {
   it("migrates legacy WAF key to encrypted DB option", () => {
-    return seedLegacyWafKey().then((settings) => {
+    return ensureLegacyWafKey().then((settings) => {
       expect(settings.sucuriscan_cloudproxy_apikey).to.eq(legacyWafKey);
       expect(settings.sucuriscan_addr_header).to.eq("REMOTE_ADDR");
 

--- a/cypress/e2e/sucuri-scanner-waf-migration.cy.js
+++ b/cypress/e2e/sucuri-scanner-waf-migration.cy.js
@@ -25,27 +25,8 @@ function readSettingsFileJson() {
   });
 }
 
-function seedLegacyWafKey() {
-  const php = `php -r '${
-    `\$path=${JSON.stringify(settingsFilePath)};` +
-    "$content=@file_get_contents($path);" +
-    'if($content===false){echo "";exit(0);} ' +
-    '$lines=explode("\\n",$content,2);' +
-    'if(count($lines)<2){echo "";exit(0);} ' +
-    "$json=trim($lines[1]);" +
-    "echo $json;"
-  }'`;
-
-  return runWpCli(php).then((output) => {
-    if (!output) {
-      return {};
-    }
-    return JSON.parse(output);
-  });
-}
-
 function ensureLegacyWafKey() {
-  return seedLegacyWafKey().then((settings) => {
+  return readSettingsFileJson().then((settings) => {
     if (settings.sucuriscan_cloudproxy_apikey) {
       return settings;
     }

--- a/cypress/e2e/sucuri-scanner-waf-migration.cy.js
+++ b/cypress/e2e/sucuri-scanner-waf-migration.cy.js
@@ -28,27 +28,20 @@ function readSettingsFileJson() {
 function seedLegacyWafKey() {
   const php = `php -r '${
     `\$path=${JSON.stringify(settingsFilePath)};` +
-    "$dir=dirname($path);" +
-    "if(!is_dir($dir)){mkdir($dir,0755,true);} " +
-    "$data=array(" +
-    `"sucuriscan_cloudproxy_apikey"=>"${legacyWafKey}",` +
-    '"sucuriscan_addr_header"=>"REMOTE_ADDR",' +
-    '"sucuriscan_notify_to"=>"alerts@example.com"' +
-    ");" +
-    "$json=json_encode($data);" +
-    '$content="<?php exit(0); ?>\\n".$json."\\n";' +
-    "file_put_contents($path,$content);"
+    "$content=@file_get_contents($path);" +
+    'if($content===false){echo "";exit(0);} ' +
+    '$lines=explode("\\n",$content,2);' +
+    'if(count($lines)<2){echo "";exit(0);} ' +
+    "$json=trim($lines[1]);" +
+    "echo $json;"
   }'`;
 
-  return runWpCli(php)
-    .then(() =>
-      runWpCli(
-        "wp option delete sucuriscan_secret_cloudproxy_apikey_enc || true",
-      ),
-    )
-    .then(() =>
-      runWpCli("wp option delete sucuriscan_secret_cloudproxy_apikey || true"),
-    );
+  return runWpCli(php).then((output) => {
+    if (!output) {
+      return {};
+    }
+    return JSON.parse(output);
+  });
 }
 
 beforeEach(() => {
@@ -59,11 +52,9 @@ beforeEach(() => {
 
 describe("Run e2e WAF migration tests", () => {
   it("migrates legacy WAF key to encrypted DB option", () => {
-    return seedLegacyWafKey().then(() => {
-      readSettingsFileJson().then((settings) => {
-        expect(settings.sucuriscan_cloudproxy_apikey).to.eq(legacyWafKey);
-        expect(settings.sucuriscan_addr_header).to.eq("REMOTE_ADDR");
-      });
+    return seedLegacyWafKey().then((settings) => {
+      expect(settings.sucuriscan_cloudproxy_apikey).to.eq(legacyWafKey);
+      expect(settings.sucuriscan_addr_header).to.eq("REMOTE_ADDR");
 
       cy.intercept(
         "POST",

--- a/cypress/e2e/sucuri-scanner.cy.js
+++ b/cypress/e2e/sucuri-scanner.cy.js
@@ -100,7 +100,7 @@ beforeEach(() => {
 });
 
 describe("Run e2e tests", () => {
-    it("WAF API Key modal appears only on Dashboard, dismisses once, and CTA navigates to WAF", () => {
+    it.skip("WAF API Key modal appears only on Dashboard, dismisses once, and CTA navigates to WAF", () => {
         const wafModalSelector = '.sucuriscan-activate-your-waf-key-modal-modal';
 
         cy.clearCookies();

--- a/cypress/e2e/sucuri-scanner.cy.js
+++ b/cypress/e2e/sucuri-scanner.cy.js
@@ -100,7 +100,7 @@ beforeEach(() => {
 });
 
 describe("Run e2e tests", () => {
-    it.skip("WAF API Key modal appears only on Dashboard, dismisses once, and CTA navigates to WAF", () => {
+    it("WAF API Key modal appears only on Dashboard, dismisses once, and CTA navigates to WAF", () => {
         const wafModalSelector = '.sucuriscan-activate-your-waf-key-modal-modal';
 
         cy.clearCookies();

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -15,21 +15,22 @@
 /**
  * @type {Cypress.PluginConfig}
  */
-const crypto = require('crypto');
+const crypto = require("crypto");
+const { exec } = require("child_process");
 
 function base32ToBuffer(base32) {
-  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 
-  const cleaned = (base32 || '').toUpperCase().replace(/=+$/, '');
+  const cleaned = (base32 || "").toUpperCase().replace(/=+$/, "");
 
-  let bits = '';
+  let bits = "";
 
   for (let i = 0; i < cleaned.length; i++) {
     const val = alphabet.indexOf(cleaned[i]);
 
-    if (val === -1) throw new Error('Invalid base32 character');
+    if (val === -1) throw new Error("Invalid base32 character");
 
-    bits += val.toString(2).padStart(5, '0');
+    bits += val.toString(2).padStart(5, "0");
   }
 
   const bytes = [];
@@ -49,11 +50,15 @@ function totpNow(secret, stepSeconds = 30, digits = 6) {
   msg.writeUInt32BE(0, 0);
   msg.writeUInt32BE(counter, 4);
 
-  const hmac = crypto.createHmac('sha1', key).update(msg).digest();
+  const hmac = crypto.createHmac("sha1", key).update(msg).digest();
 
   const offset = hmac[19] & 0x0f;
-  const code = ((hmac[offset] & 0x7f) << 24) | (hmac[offset + 1] << 16) | (hmac[offset + 2] << 8) | (hmac[offset + 3]);
-  const num = (code % Math.pow(10, digits)).toString().padStart(digits, '0');
+  const code =
+    ((hmac[offset] & 0x7f) << 24) |
+    (hmac[offset + 1] << 16) |
+    (hmac[offset + 2] << 8) |
+    hmac[offset + 3];
+  const num = (code % Math.pow(10, digits)).toString().padStart(digits, "0");
 
   return num;
 }
@@ -61,13 +66,23 @@ function totpNow(secret, stepSeconds = 30, digits = 6) {
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
-  on('task', {
+  on("task", {
     totp({ secret, step = 30, digits = 6 }) {
       try {
         return totpNow(secret, step, digits);
       } catch (e) {
         return null;
       }
-    }
+    },
+    exec(command) {
+      return new Promise((resolve, reject) => {
+        exec(command, { maxBuffer: 1024 * 1024 }, (error, stdout, stderr) => {
+          if (error) {
+            return reject(stderr || error.message);
+          }
+          resolve(stdout.trim());
+        });
+      });
+    },
   });
-}
+};

--- a/lang/sucuri-scanner.pot
+++ b/lang/sucuri-scanner.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Sucuri Security - Auditing, Malware Scanner and Hardening 2.6\n"
+"Project-Id-Version: Sucuri Security - Auditing, Malware Scanner and Hardening 2.7\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/sucuri-scanner\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-01-07T04:06:07+00:00\n"
+"POT-Creation-Date: 2026-03-06T14:41:08+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.11.0\n"
+"X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: sucuri-scanner\n"
 
 #. Plugin Name of the plugin
@@ -51,155 +51,161 @@ msgstr ""
 msgid "Invalid API key format"
 msgstr ""
 
-#: src/api.lib.php:189
+#. translators: %s: API key
+#: src/api.lib.php:190
+#, php-format
 msgid "API key was successfully set: %s"
 msgstr ""
 
-#: src/api.lib.php:285
+#: src/api.lib.php:286
 msgid "Unknown error, there is no information"
 msgstr ""
 
-#: src/api.lib.php:325
+#: src/api.lib.php:326
 msgid "Invalid email format or the host is missing MX records."
 msgstr ""
 
-#: src/api.lib.php:360
+#: src/api.lib.php:361
 msgid "API key was generated and set"
 msgstr ""
 
-#: src/api.lib.php:362
+#: src/api.lib.php:363
 msgid "API key successfully generated and saved."
 msgstr ""
 
-#: src/api.lib.php:390
+#. translators: %s: domain name
+#: src/api.lib.php:392
+#, php-format
 msgid "API key recovery for domain: %s"
 msgstr ""
 
-#: src/api.lib.php:494
+#: src/api.lib.php:496
 msgid "All Time"
 msgstr ""
 
-#: src/api.lib.php:498
-#: src/auditlogs.lib.php:384
+#: src/api.lib.php:500
+#: src/auditlogs.lib.php:385
 msgid "Today"
 msgstr ""
 
-#: src/api.lib.php:502
+#: src/api.lib.php:504
 msgid "Yesterday"
 msgstr ""
 
-#: src/api.lib.php:506
+#: src/api.lib.php:508
 msgid "This Week"
 msgstr ""
 
-#: src/api.lib.php:510
+#: src/api.lib.php:512
 msgid "Last 7 Days"
 msgstr ""
 
-#: src/api.lib.php:514
+#: src/api.lib.php:516
 msgid "Last Week"
 msgstr ""
 
-#: src/api.lib.php:518
+#: src/api.lib.php:520
 msgid "Last 14 Days"
 msgstr ""
 
-#: src/api.lib.php:522
+#: src/api.lib.php:524
 msgid "This Month"
 msgstr ""
 
-#: src/api.lib.php:526
+#: src/api.lib.php:528
 msgid "Last 30 Days"
 msgstr ""
 
-#: src/api.lib.php:530
+#: src/api.lib.php:532
 msgid "Last Month"
 msgstr ""
 
-#: src/api.lib.php:534
+#: src/api.lib.php:536
 msgid "This Year"
 msgstr ""
 
-#: src/api.lib.php:538
+#: src/api.lib.php:540
 msgid "Last Year"
 msgstr ""
 
-#: src/api.lib.php:542
+#: src/api.lib.php:544
 msgid "Custom"
 msgstr ""
 
-#: src/api.lib.php:550
+#: src/api.lib.php:552
 msgid "All Posts"
 msgstr ""
 
-#: src/api.lib.php:554
-#: src/api.lib.php:586
+#: src/api.lib.php:556
+#: src/api.lib.php:588
 msgid "Created"
 msgstr ""
 
-#: src/api.lib.php:558
+#: src/api.lib.php:560
 msgid "Updated"
 msgstr ""
 
-#: src/api.lib.php:562
-#: src/api.lib.php:594
+#: src/api.lib.php:564
+#: src/api.lib.php:596
 msgid "Deleted"
 msgstr ""
 
-#: src/api.lib.php:568
+#: src/api.lib.php:570
 msgid "All Logins"
 msgstr ""
 
-#: src/api.lib.php:572
+#: src/api.lib.php:574
 msgid "Failed"
 msgstr ""
 
-#: src/api.lib.php:576
+#: src/api.lib.php:578
 msgid "Succeeded"
 msgstr ""
 
-#: src/api.lib.php:582
+#: src/api.lib.php:584
 #: src/strings.php:205
 msgid "All Users"
 msgstr ""
 
-#: src/api.lib.php:590
+#: src/api.lib.php:592
 msgid "Edited"
 msgstr ""
 
-#: src/api.lib.php:600
+#: src/api.lib.php:602
 msgid "All Plugins"
 msgstr ""
 
-#: src/api.lib.php:604
+#: src/api.lib.php:606
 msgid "Installed"
 msgstr ""
 
-#: src/api.lib.php:608
+#: src/api.lib.php:610
 #: src/topt.lib.php:1370
 msgid "Activated"
 msgstr ""
 
-#: src/api.lib.php:612
+#: src/api.lib.php:614
 #: src/topt.lib.php:1370
 #: src/topt.lib.php:1402
 msgid "Deactivated"
 msgstr ""
 
-#: src/api.lib.php:618
+#: src/api.lib.php:620
 msgid "All Files"
 msgstr ""
 
-#: src/api.lib.php:622
+#: src/api.lib.php:624
 msgid "Added"
 msgstr ""
 
-#: src/api.lib.php:942
-msgid "WP Engine PHP Compatibility Checker: %s (created post #%d as cache)"
+#. translators: %1$s: plugin or theme name, %2$d: unique post or page identifier
+#: src/api.lib.php:945
+#, php-format
+msgid "WP Engine PHP Compatibility Checker: %1$s (created post #%2$d as cache)"
 msgstr ""
 
-#: src/api.lib.php:1285
-#: src/api.lib.php:1290
+#: src/api.lib.php:1288
+#: src/api.lib.php:1293
 msgid "WordPress version is not supported anymore"
 msgstr ""
 
@@ -207,15 +213,17 @@ msgstr ""
 msgid "API is not available; using local queue"
 msgstr ""
 
-#: src/auditlogs.lib.php:193
+#. translators: %s: number of seconds
+#: src/auditlogs.lib.php:194
+#, php-format
 msgid "API %s secs"
 msgstr ""
 
-#: src/auditlogs.lib.php:239
+#: src/auditlogs.lib.php:240
 msgid "There are no logs."
 msgstr ""
 
-#: src/auditlogs.lib.php:295
+#: src/auditlogs.lib.php:296
 msgid "status has been changed"
 msgstr ""
 
@@ -246,61 +254,79 @@ msgstr ""
 msgid "Automatic update of security keys failed. Something went wrong!"
 msgstr ""
 
-#: src/event.lib.php:89
-msgid "%s (every %d seconds)"
+#. translators: %1$s: display name, %2$d: time interval
+#: src/event.lib.php:90
+#, php-format
+msgid "%1$s (every %2$d seconds)"
 msgstr ""
 
-#: src/event.lib.php:95
+#: src/event.lib.php:96
 msgid "Never (no execution)"
 msgstr ""
 
-#: src/event.lib.php:214
-#: src/event.lib.php:264
+#: src/event.lib.php:148
+msgid "Weekly"
+msgstr ""
+
+#: src/event.lib.php:154
+msgid "Monthly"
+msgstr ""
+
+#: src/event.lib.php:160
+msgid "Quarterly"
+msgstr ""
+
+#: src/event.lib.php:215
+#: src/event.lib.php:266
 msgid "API key is not available"
 msgstr ""
 
-#: src/event.lib.php:222
+#: src/event.lib.php:223
 msgid "WordPress version was already reported"
 msgstr ""
 
-#: src/event.lib.php:225
+#. translators: %s: WordPress version
+#: src/event.lib.php:227
+#, php-format
 msgid "WordPress version detected %s"
 msgstr ""
 
-#: src/event.lib.php:268
+#: src/event.lib.php:270
 msgid "Scanner ran a couple of minutes ago"
 msgstr ""
 
-#: src/event.lib.php:300
+#: src/event.lib.php:302
 msgid "Event identifier cannot be empty"
 msgstr ""
 
-#: src/event.lib.php:468
-#: src/event.lib.php:475
+#: src/event.lib.php:470
+#: src/event.lib.php:477
 msgid "Info"
 msgstr ""
 
-#: src/event.lib.php:471
+#: src/event.lib.php:473
 msgid "Debug"
 msgstr ""
 
-#: src/event.lib.php:473
+#: src/event.lib.php:475
 msgid "Notice"
 msgstr ""
 
-#: src/event.lib.php:477
+#: src/event.lib.php:479
 msgid "Warning"
 msgstr ""
 
-#: src/event.lib.php:479
+#: src/event.lib.php:481
 msgid "Error"
 msgstr ""
 
-#: src/event.lib.php:481
+#: src/event.lib.php:483
 msgid "Critical"
 msgstr ""
 
-#: src/event.lib.php:611
+#. translators: %1$s: settings url, %2$s: settings url
+#: src/event.lib.php:614
+#, php-format
 msgid ""
 "<br><br>\n"
 "\n"
@@ -312,19 +338,25 @@ msgid ""
 ""
 msgstr ""
 
-#: src/event.lib.php:759
+#: src/event.lib.php:763
 msgid "Password Change"
 msgstr ""
 
-#: src/event.lib.php:934
+#. translators: %s: file path
+#: src/event.lib.php:939
+#, php-format
 msgid "%s cannot be deleted."
 msgstr ""
 
-#: src/event.lib.php:945
+#. translators: %s: comma-separated list of filenames
+#: src/event.lib.php:951
+#, php-format
 msgid "%s log files were deleted."
 msgstr ""
 
-#: src/event.lib.php:946
+#. translators: %s: filename
+#: src/event.lib.php:953
+#, php-format
 msgid "%s log file was deleted."
 msgstr ""
 
@@ -372,8 +404,8 @@ msgstr ""
 #: src/firewall.lib.php:349
 #: src/firewall.lib.php:567
 #: src/firewall.lib.php:602
-#: src/firewall.lib.php:643
-#: src/firewall.lib.php:748
+#: src/firewall.lib.php:644
+#: src/firewall.lib.php:750
 msgid "Firewall API key was not found."
 msgstr ""
 
@@ -437,19 +469,23 @@ msgstr ""
 msgid "Failure connecting to the API service; try again."
 msgstr ""
 
-#: src/firewall.lib.php:617
+#. translators: %s: IP address
+#: src/firewall.lib.php:618
+#, php-format
 msgid "IP has been added to the blocklist: %s"
 msgstr ""
 
-#: src/firewall.lib.php:656
+#. translators: %s: IP address
+#: src/firewall.lib.php:658
+#, php-format
 msgid "IP has been removed from the blocklist: %s"
 msgstr ""
 
-#: src/firewall.lib.php:751
+#: src/firewall.lib.php:753
 msgid "Invalid firewall API key format. Please verify the key is in the form k/s."
 msgstr ""
 
-#: src/firewall.lib.php:779
+#: src/firewall.lib.php:781
 msgid "Failure connecting to the Firewall API service; try again."
 msgstr ""
 
@@ -528,239 +564,305 @@ msgstr ""
 msgid "Cannot remove file from the allowlist; no permissions."
 msgstr ""
 
-#: src/hook.lib.php:68
-msgid "Media file added; ID: %s; name: %s; type: %s"
+#. translators: %1$s: media id, %2$s: media title, %3$s: mime type
+#: src/hook.lib.php:69
+#, php-format
+msgid "Media file added; ID: %1$s; name: %2$s; type: %3$s"
 msgstr ""
 
-#: src/hook.lib.php:82
-#: src/hook.lib.php:110
-#: src/hook.lib.php:196
-#: src/hook.lib.php:1022
-#: src/hook.lib.php:1033
-#: src/hook.lib.php:1064
-#: src/settings-general.php:315
-#: src/settings-general.php:316
-#: src/settings-general.php:317
-#: src/settings-general.php:318
-#: src/settings-general.php:319
+#: src/hook.lib.php:83
+#: src/hook.lib.php:112
+#: src/hook.lib.php:202
+#: src/hook.lib.php:1054
+#: src/hook.lib.php:1065
+#: src/hook.lib.php:1097
+#: src/settings-general.php:320
+#: src/settings-general.php:321
+#: src/settings-general.php:322
+#: src/settings-general.php:323
+#: src/settings-general.php:324
 #: src/settings-webinfo.php:40
 msgid "unknown"
 msgstr ""
 
-#: src/hook.lib.php:83
-#: src/hook.lib.php:111
-#: src/hook.lib.php:1023
-#: src/hook.lib.php:1034
-#: src/hook.lib.php:1065
+#: src/hook.lib.php:84
+#: src/hook.lib.php:113
+#: src/hook.lib.php:1055
+#: src/hook.lib.php:1066
+#: src/hook.lib.php:1098
 msgid "user@domain.com"
 msgstr ""
 
-#: src/hook.lib.php:92
-msgid "User added to website; user_id: %s; role: %s; blog_id: %s; name: %s; email: %s"
+#. translators: %1$s: user_id, %2$s: role, %3$s: blog_id, %4$s: name, %5$s: email
+#: src/hook.lib.php:94
+#, php-format
+msgid "User added to website; user_id: %1$s; role: %2$s; blog_id: %3$s; name: %4$s; email: %5$s"
 msgstr ""
 
-#: src/hook.lib.php:120
-msgid "User removed from website; user_id: %s; blog_id: %s; name: %s; email: %s"
+#. translators: %1$s: user_id, %2$s: blog_id, %3$s: name, %4$s: email
+#: src/hook.lib.php:123
+#, php-format
+msgid "User removed from website; user_id: %1$s; blog_id: %2$s; name: %3$s; email: %4$s"
 msgstr ""
 
-#: src/hook.lib.php:137
-#: src/hook.lib.php:228
-#: src/hook.lib.php:295
-#: src/hook.lib.php:407
-#: src/hook.lib.php:537
-#: src/hook.lib.php:757
-#: src/hook.lib.php:783
-#: src/hook.lib.php:885
-#: src/hook.lib.php:931
+#: src/hook.lib.php:140
+#: src/hook.lib.php:236
+#: src/hook.lib.php:305
+#: src/hook.lib.php:425
+#: src/hook.lib.php:554
+#: src/hook.lib.php:781
+#: src/hook.lib.php:808
+#: src/hook.lib.php:912
+#: src/hook.lib.php:960
 #: src/lastlogins-failed.php:251
 msgid "Unknown"
 msgstr ""
 
-#: src/hook.lib.php:139
-msgid "Category created; ID: %s; name: %s"
+#. translators: %1$s: category ID, %2$s: category name
+#: src/hook.lib.php:143
+#, php-format
+msgid "Category created; ID: %1$s; name: %2$s"
 msgstr ""
 
-#: src/hook.lib.php:153
+#. translators: %s: WordPress version
+#: src/hook.lib.php:158
+#, php-format
 msgid "WordPress updated to version: %s"
 msgstr ""
 
-#: src/hook.lib.php:178
-msgid "Bookmark link added; ID: %s; name: %s; url: %s; target: %s"
+#. translators: %1$s: link ID, %2$s: name, %3$s: url, %4$s: target
+#: src/hook.lib.php:184
+#, php-format
+msgid "Bookmark link added; ID: %1$s; name: %2$s; url: %3$s; target: %4$s"
 msgstr ""
 
-#: src/hook.lib.php:208
-msgid "Bookmark link edited; ID: %s; name: %s; url: %s; target: %s"
+#. translators: %1$s: link ID, %2$s: name, %3$s: url, %4$s: target
+#: src/hook.lib.php:215
+#, php-format
+msgid "Bookmark link edited; ID: %1$s; name: %2$s; url: %3$s; target: %4$s"
 msgstr ""
 
-#: src/hook.lib.php:229
+#. translators: %s: username
+#: src/hook.lib.php:238
+#, php-format
 msgid "User authentication failed: %s"
 msgstr ""
 
-#: src/hook.lib.php:282
+#: src/hook.lib.php:292
 msgid "Attempt to reset password by attacking WP/2.8.3 bug"
 msgstr ""
 
-#: src/hook.lib.php:296
+#. translators: %s: username
+#: src/hook.lib.php:307
+#, php-format
 msgid "User authentication succeeded: %s"
 msgstr ""
 
-#: src/hook.lib.php:325
+#. translators: %1$s: option name, %2$s: old value, %3$s: new value
+#: src/hook.lib.php:339
+#, php-format
 msgid ""
-"The value of the option <b>%s</b> was changed from <b>'%s'</b> to <b>'%s'</b>.<br>\n"
+"The value of the option <b>%1$s</b> was changed from <b>'%2$s'</b> to <b>'%3$s'</b>.<br>\n"
 ""
 msgstr ""
 
-#: src/hook.lib.php:331
-msgid "%s: from '%s' to '%s',"
+#. translators: %1$s: option name, %2$s: old value, %3$s: new value
+#: src/hook.lib.php:346
+#, php-format
+msgid "%1$s: from '%2$s' to '%3$s',"
 msgstr ""
 
-#: src/hook.lib.php:340
+#: src/hook.lib.php:356
 msgid "Common"
 msgstr ""
 
-#: src/hook.lib.php:344
+#: src/hook.lib.php:360
 msgid "Global"
 msgstr ""
 
-#: src/hook.lib.php:358
+#. translators: %s: name of the settings page
+#: src/hook.lib.php:375
+#, php-format
 msgid "%s settings changed"
 msgstr ""
 
-#: src/hook.lib.php:361
-msgid "%s: (multiple entries): %s"
+#. translators: %1$s: message, %2$s: list of changed options
+#: src/hook.lib.php:379
+#, php-format
+msgid "%1$s: (multiple entries): %2$s"
 msgstr ""
 
-#: src/hook.lib.php:419
-msgid "Plugin %s: %s (v%s; %s%s)"
+#. translators: %1$s: action (activated/deactivated), %2$s: plugin name, %3$s: version, %4$s: plugin path, %5$s: network status
+#: src/hook.lib.php:438
+#, php-format
+msgid "Plugin %1$s: %2$s (v%3$s; %4$s%5$s)"
 msgstr ""
 
-#: src/hook.lib.php:483
+#: src/hook.lib.php:501
 msgid "Plugins deleted: (multiple entries):"
 msgstr ""
 
-#: src/hook.lib.php:485
+#: src/hook.lib.php:503
 msgid "Plugin deleted:"
 msgstr ""
 
-#: src/hook.lib.php:512
+#. translators: %s: filename of the edited plugin
+#: src/hook.lib.php:530
+#, php-format
 msgid "Plugin editor used in: %s"
 msgstr ""
 
-#: src/hook.lib.php:538
+#. translators: %s: name of the installed plugin
+#: src/hook.lib.php:556
+#, php-format
 msgid "Plugin installed: %s"
 msgstr ""
 
-#: src/hook.lib.php:602
+#: src/hook.lib.php:620
 msgid "Plugins updated: (multiple entries):"
 msgstr ""
 
-#: src/hook.lib.php:604
+#: src/hook.lib.php:622
 msgid "Plugin updated:"
 msgstr ""
 
-#: src/hook.lib.php:673
+#. translators: %s: list of post details
+#: src/hook.lib.php:692
+#, php-format
 msgid "Post deleted: (multiple entries): %s"
 msgstr ""
 
-#: src/hook.lib.php:687
+#: src/hook.lib.php:706
 msgid "Ignore corrupted post data"
 msgstr ""
 
-#: src/hook.lib.php:692
+#: src/hook.lib.php:711
 msgid "Skip events for equal transitions"
 msgstr ""
 
-#: src/hook.lib.php:716
+#: src/hook.lib.php:735
 msgid "Skip events for postman-smtp alerts"
 msgstr ""
 
-#: src/hook.lib.php:721
+#: src/hook.lib.php:740
 msgid "Skip events for ignored post-types"
 msgstr ""
 
-#: src/hook.lib.php:727
+#: src/hook.lib.php:746
 msgid "Skip events for ignored post transitions"
 msgstr ""
 
-#: src/hook.lib.php:733
+#. translators: %s: ID of the post
+#: src/hook.lib.php:753
+#, php-format
 msgid "ID: %s"
 msgstr ""
 
-#: src/hook.lib.php:734
+#. translators: %s: old status of the post
+#: src/hook.lib.php:755
+#, php-format
 msgid "Old status: %s"
 msgstr ""
 
-#: src/hook.lib.php:735
+#. translators: %s: new status of the post
+#: src/hook.lib.php:757
+#, php-format
 msgid "New status: %s"
 msgstr ""
 
-#: src/hook.lib.php:738
+#. translators: %s: title of the post
+#: src/hook.lib.php:761
+#, php-format
 msgid "Title: %s"
 msgstr ""
 
-#: src/hook.lib.php:741
+#. translators: %s: type of the post (e.g. Post, Page)
+#: src/hook.lib.php:765
+#, php-format
 msgid "%s status has been changed"
 msgstr ""
 
-#: src/hook.lib.php:767
-msgid "Post moved to trash; ID: %s; name: %s; status: %s"
+#. translators: %1$s: ID of the post, %2$s: title of the post, %3$s: status of the post
+#: src/hook.lib.php:792
+#, php-format
+msgid "Post moved to trash; ID: %1$s; name: %2$s; status: %3$s"
 msgstr ""
 
-#: src/hook.lib.php:784
+#: src/hook.lib.php:809
 msgid "Publication"
 msgstr ""
 
-#: src/hook.lib.php:802
-msgid "%s was %s; ID: %s; name: %s"
+#. translators: %1$s: post type, %2$s: action (created/updated), %3$s: post ID, %4$s: post title
+#: src/hook.lib.php:828
+#, php-format
+msgid "%1$s was %2$s; ID: %3$s; name: %4$s"
 msgstr ""
 
-#: src/hook.lib.php:867
+#. translators: %s: username or email of the account
+#: src/hook.lib.php:894
+#, php-format
 msgid "Password retrieval attempt: %s"
 msgstr ""
 
-#: src/hook.lib.php:887
+#. translators: %s: name of the deleted theme
+#: src/hook.lib.php:915
+#, php-format
 msgid "Theme deleted: %s"
 msgstr ""
 
-#: src/hook.lib.php:911
-msgid "Theme editor used in: %s/%s"
+#. translators: %1$s: theme name, %2$s: filename
+#: src/hook.lib.php:940
+#, php-format
+msgid "Theme editor used in: %1$s/%2$s"
 msgstr ""
 
-#: src/hook.lib.php:933
+#. translators: %s: name of the installed theme
+#: src/hook.lib.php:963
+#, php-format
 msgid "Theme installed: %s"
 msgstr ""
 
-#: src/hook.lib.php:948
+#. translators: %s: name of the new theme
+#: src/hook.lib.php:979
+#, php-format
 msgid "Theme activated: %s"
 msgstr ""
 
-#: src/hook.lib.php:991
+#: src/hook.lib.php:1022
 msgid "Themes updated: (multiple entries):"
 msgstr ""
 
-#: src/hook.lib.php:993
+#: src/hook.lib.php:1024
 msgid "Theme updated:"
 msgstr ""
 
-#: src/hook.lib.php:1012
+#. translators: %d: ID of the deleted user user
+#: src/hook.lib.php:1044
+#, php-format
 msgid "User account deleted; ID: %d"
 msgstr ""
 
-#: src/hook.lib.php:1044
-msgid "User account edited; ID: %s; name: %s; old_name: %s; email: %s; old_email: %s; roles: %s; old_roles: %s"
+#. translators: %1$s: ID, %2$s: name, %3$s: old name, %4$s: email, %5$s: old email, %6$s: roles, %7$s: old roles
+#: src/hook.lib.php:1077
+#, php-format
+msgid "User account edited; ID: %1$s; name: %2$s; old_name: %3$s; email: %4$s; old_email: %5$s; roles: %6$s; old_roles: %7$s"
 msgstr ""
 
-#: src/hook.lib.php:1076
-msgid "User account created; ID: %s; name: %s; email: %s; roles: %s"
+#. translators: %1$s: ID, %2$s: name, %3$s: email, %4$s: roles
+#: src/hook.lib.php:1110
+#, php-format
+msgid "User account created; ID: %1$s; name: %2$s; email: %3$s; roles: %4$s"
 msgstr ""
 
-#: src/hook.lib.php:1120
-msgid "Widget %s (%s) %s %s (#%d; size %dx%d)"
+#. translators: %1$s: base ID, %2$s: widget ID, %3$s: action (added to/deleted from), %4$s: sidebar ID, %5$d: widget number, %6$d: width, %7$d: height
+#: src/hook.lib.php:1155
+#, php-format
+msgid "Widget %1$s (%2$s) %3$s %4$s (#%5$d; size %6$dx%7$d)"
 msgstr ""
 
 #: src/integrity.lib.php:113
 #: src/settings-general.php:46
-#: src/settings-general.php:501
+#: src/settings-general.php:507
 #: src/settings-posthack.php:59
 msgid "You need to confirm that you understand the risk of this operation."
 msgstr ""
@@ -789,57 +891,65 @@ msgstr ""
 msgid "Server is not fast enough to process this action; maximum execution time reached"
 msgstr ""
 
-#: src/integrity.lib.php:240
-msgid "Only <b>%d</b> out of <b>%d</b> files were processed."
+#. translators: %1$d: number of processed files, %2$d: total number of files
+#: src/integrity.lib.php:241
+#, php-format
+msgid "Only <b>%1$d</b> out of <b>%2$d</b> files were processed."
 msgstr ""
 
-#: src/integrity.lib.php:249
-msgid "<b>%d</b> out of <b>%d</b> files were successfully processed."
+#. translators: %1$d: number of processed files, %2$d: total number of files
+#: src/integrity.lib.php:251
+#, php-format
+msgid "<b>%1$d</b> out of <b>%2$d</b> files were successfully processed."
 msgstr ""
 
-#: src/integrity.lib.php:396
+#: src/integrity.lib.php:400
 msgid "The plugin has no permission to delete this file because it was created by a different system user who has more privileges than your account. Please use FTP to delete it."
 msgstr ""
 
-#: src/integrity.lib.php:401
+#: src/integrity.lib.php:405
 msgid "The plugin has no permission to restore this file because it was modified by a different system user who has more privileges than your account. Please use FTP to restore it."
 msgstr ""
 
-#: src/integrity.lib.php:406
+#: src/integrity.lib.php:410
 msgid "The plugin has no permission to restore this file because its directory is owned by a different system user who has more privileges than your account. Please use FTP to restore it."
 msgstr ""
 
-#: src/integrity.lib.php:509
+#: src/integrity.lib.php:513
 #: src/strings.php:662
 #: src/strings.php:667
 msgid "WordPress Integrity Diff Utility"
 msgstr ""
 
-#: src/interface.lib.php:209
+#: src/interface.lib.php:210
 msgid "The plugin requires PHP 5 >= 5.3.0 - OR - PHP 7"
 msgstr ""
 
-#: src/interface.lib.php:217
+#. translators: %s: absolute path of the settings file
+#: src/interface.lib.php:219
+#, php-format
 msgid "Storage is not writable: <code>%s</code>"
 msgstr ""
 
-#: src/interface.lib.php:259
+#: src/interface.lib.php:261
 msgid "Do you want to get vulnerability disclosures? Subscribe to our newsletter <a href=\"http://sucuri.hs-sites.com/subscribe-to-security\" target=\"_blank\" rel=\"noopener\">here</a>"
 msgstr ""
 
-#: src/interface.lib.php:272
+#: src/interface.lib.php:274
 msgid "Access denied; cannot manage options"
 msgstr ""
 
-#: src/interface.lib.php:273
+#. translators: %s: Plugin name
+#: src/interface.lib.php:276
+#, php-format
 msgid "Access denied by %s"
 msgstr ""
 
-#: src/interface.lib.php:293
+#: src/interface.lib.php:298
 msgid "Nonce is invalid"
 msgstr ""
 
-#: src/interface.lib.php:294
+#: src/interface.lib.php:299
 msgid "WordPress CSRF verification failed. The submitted form is missing an important unique code that prevents the execution of automated malicious scanners. Go back and try again. If you did not submit a form, this error message could be an indication of an incompatibility between this plugin and another add-on; one of them is inserting data into the global POST variable when the HTTP request is coming via GET. Disable them one by one (while reloading this page) to find the culprit."
 msgstr ""
 
@@ -879,31 +989,37 @@ msgstr ""
 msgid "Attempt Date/Time"
 msgstr ""
 
-#: src/lastlogins.php:130
+#. translators: %s: file path
+#: src/lastlogins.php:131
+#, php-format
 msgid "Last-logins data file is not writable: <code>%s</code>"
 msgstr ""
 
-#: src/lastlogins.php:306
+#: src/lastlogins.php:307
 msgid "Invalid last-logins storage file"
 msgstr ""
 
-#: src/lastlogins.php:313
+#: src/lastlogins.php:314
 msgid "No last-logins data is available"
 msgstr ""
 
-#: src/lastlogins.php:460
-msgid "Last login was at <b>%s</b> from <b>%s</b> <em>(%s)</em> <a href=\"%s\" target=\"_self\">view all logs</a>"
+#. translators: %1$s: date and time, %2$s: IP address, %3$s: hostname, %4$s: page url
+#: src/lastlogins.php:462
+#, php-format
+msgid "Last login was at <b>%1$s</b> from <b>%2$s</b> <em>(%3$s)</em> <a href=\"%4$s\" target=\"_self\">view all logs</a>"
 msgstr ""
 
 #: src/mail.lib.php:80
 msgid "Maximum number of emails per hour reached"
 msgstr ""
 
-#: src/mail.lib.php:189
-msgid "User: %s (%s)"
+#. translators: %1$s: User display name, %2$s: User login
+#: src/mail.lib.php:190
+#, php-format
+msgid "User: %1$s (%2$s)"
 msgstr ""
 
-#: src/mail.lib.php:215
+#: src/mail.lib.php:216
 msgid "Sucuri Alert"
 msgstr ""
 
@@ -1268,28 +1384,41 @@ msgstr ""
 msgid "Specifies how long the results of a preflight request can be cached."
 msgstr ""
 
-#: src/option.lib.php:685
-#: src/settings-alerts.php:214
-#: src/settings-alerts.php:215
-#: src/settings-alerts.php:216
-msgid "Sucuri Alert, %s, %s, %s"
+#. translators: %s: error message
+#: src/option.lib.php:881
+#, php-format
+msgid "Firewall API key decryption failed: %s"
 msgstr ""
 
-#: src/pagehandler.php:167
-msgid "iFrames"
+#: src/option.lib.php:934
+msgid "The Sucuri WAF API key could not be decrypted. Please re-save the key in the Firewall settings to restore functionality."
+msgstr ""
+
+#. translators: %1$s: domain, %2$s: event, %3$s: remote address
+#. translators: %1$s: specific info like domain, event, etc
+#: src/option.lib.php:1138
+#: src/settings-alerts.php:243
+#: src/settings-alerts.php:245
+#: src/settings-alerts.php:247
+#, php-format
+msgid "Sucuri Alert, %1$s, %2$s, %3$s"
 msgstr ""
 
 #: src/pagehandler.php:168
-msgid "Links"
+msgid "iFrames"
 msgstr ""
 
 #: src/pagehandler.php:169
-msgid "Scripts"
+msgid "Links"
 msgstr ""
 
 #: src/pagehandler.php:170
+msgid "Scripts"
+msgstr ""
+
 #: src/pagehandler.php:171
 #: src/pagehandler.php:172
+#: src/pagehandler.php:173
 #: src/strings.php:26
 #: src/strings.php:57
 #: src/strings.php:69
@@ -1303,303 +1432,333 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: src/pagehandler.php:355
+#: src/pagehandler.php:357
 msgid "Last-Logins logs were successfully reset."
 msgstr ""
 
-#: src/pagehandler.php:357
+#: src/pagehandler.php:359
 msgid "Could not reset the last-logins data file."
 msgstr ""
 
-#: src/settings-alerts.php:56
+#. translators: %s: email address
+#: src/settings-alerts.php:60
+#, php-format
 msgid "The email alerts will be sent to: <code>%s</code>"
 msgstr ""
 
-#: src/settings-alerts.php:59
+#. translators: %s: email address
+#: src/settings-alerts.php:67
+#, php-format
 msgid "The email alerts will be sent to: %s"
 msgstr ""
 
-#: src/settings-alerts.php:63
+#: src/settings-alerts.php:73
 msgid "Email format not supported."
 msgstr ""
 
-#: src/settings-alerts.php:82
+#. translators: %s: list of email addresses
+#: src/settings-alerts.php:94
+#, php-format
 msgid "These emails will stop receiving alerts: <code>%s</code>"
 msgstr ""
 
-#: src/settings-alerts.php:85
+#. translators: %s: list of email addresses
+#: src/settings-alerts.php:101
+#, php-format
 msgid "These emails will stop receiving alerts: %s"
 msgstr ""
 
-#: src/settings-alerts.php:96
+#: src/settings-alerts.php:114
 msgid "Test Email Alert"
 msgstr ""
 
-#: src/settings-alerts.php:97
+#. translators: %s: time of the event
+#: src/settings-alerts.php:116
+#, php-format
 msgid "Test email alert sent at %s"
 msgstr ""
 
-#: src/settings-alerts.php:102
+#: src/settings-alerts.php:121
 msgid "A test alert was sent to your email, check your inbox"
 msgstr ""
 
-#: src/settings-alerts.php:104
+#: src/settings-alerts.php:123
 msgid "An error occurred sending email - please check your server mail configuration."
 msgstr ""
 
-#: src/settings-alerts.php:151
+#: src/settings-alerts.php:170
 msgid "The IP specified address was already added."
 msgstr ""
 
-#: src/settings-alerts.php:153
+#. translators: %s: IP address
+#: src/settings-alerts.php:174
+#, php-format
 msgid "IP has been trusted: %s"
 msgstr ""
 
-#: src/settings-alerts.php:154
+#. translators: %s: IP address
+#: src/settings-alerts.php:179
+#, php-format
 msgid "Events generated from this IP will be ignored: <code>%s</code>"
 msgstr ""
 
-#: src/settings-alerts.php:156
+#: src/settings-alerts.php:183
 msgid "The IP address could not be added to the trusted list"
 msgstr ""
 
-#: src/settings-alerts.php:169
+#: src/settings-alerts.php:196
 msgid "The selected IP addresses were successfully deleted."
 msgstr ""
 
-#: src/settings-alerts.php:178
+#: src/settings-alerts.php:205
 msgid "n/a"
 msgstr ""
 
-#: src/settings-alerts.php:213
-#: src/settings-alerts.php:217
-#: src/settings-alerts.php:218
-msgid "Sucuri Alert, %s, %s"
+#. translators: %1$s: specific info like domain, event, etc
+#: src/settings-alerts.php:241
+#: src/settings-alerts.php:249
+#: src/settings-alerts.php:251
+#, php-format
+msgid "Sucuri Alert, %1$s, %2$s"
 msgstr ""
 
-#: src/settings-alerts.php:219
+#. translators: %s: event name
+#: src/settings-alerts.php:253
+#, php-format
 msgid "Sucuri Alert, %s"
 msgstr ""
 
-#: src/settings-alerts.php:247
+#: src/settings-alerts.php:281
 msgid "Invalid characters in the email subject."
 msgstr ""
 
-#: src/settings-alerts.php:255
+#. translators: %s: email subject
+#: src/settings-alerts.php:291
+#, php-format
 msgid "Email subject set to <code>%s</code>"
 msgstr ""
 
-#: src/settings-alerts.php:260
+#: src/settings-alerts.php:298
 msgid "The email subject has been successfully updated"
 msgstr ""
 
-#: src/settings-alerts.php:309
+#: src/settings-alerts.php:347
 msgid "Maximum 5 per hour"
 msgstr ""
 
-#: src/settings-alerts.php:310
+#: src/settings-alerts.php:348
 msgid "Maximum 10 per hour"
 msgstr ""
 
-#: src/settings-alerts.php:311
+#: src/settings-alerts.php:349
 msgid "Maximum 20 per hour"
 msgstr ""
 
-#: src/settings-alerts.php:312
+#: src/settings-alerts.php:350
 msgid "Maximum 40 per hour"
 msgstr ""
 
-#: src/settings-alerts.php:313
+#: src/settings-alerts.php:351
 msgid "Maximum 80 per hour"
 msgstr ""
 
-#: src/settings-alerts.php:314
+#: src/settings-alerts.php:352
 msgid "Maximum 160 per hour"
 msgstr ""
 
-#: src/settings-alerts.php:315
+#: src/settings-alerts.php:353
 msgid "Unlimited alerts per hour"
 msgstr ""
 
-#: src/settings-alerts.php:325
+#. translators: %s: maximum number
+#: src/settings-alerts.php:365
+#, php-format
 msgid "Maximum alerts per hour set to <code>%s</code>"
 msgstr ""
 
-#: src/settings-alerts.php:330
+#: src/settings-alerts.php:372
 msgid "The maximum number of alerts per hour has been updated"
 msgstr ""
 
-#: src/settings-alerts.php:332
+#: src/settings-alerts.php:374
 msgid "Error updating the maximum number of alerts per hour"
 msgstr ""
 
-#: src/settings-alerts.php:356
+#: src/settings-alerts.php:398
 msgid "30 failed logins per hour"
 msgstr ""
 
-#: src/settings-alerts.php:357
+#: src/settings-alerts.php:399
 msgid "60 failed logins per hour"
 msgstr ""
 
-#: src/settings-alerts.php:358
+#: src/settings-alerts.php:400
 msgid "120 failed logins per hour"
 msgstr ""
 
-#: src/settings-alerts.php:359
+#: src/settings-alerts.php:401
 msgid "240 failed logins per hour"
 msgstr ""
 
-#: src/settings-alerts.php:360
+#: src/settings-alerts.php:402
 msgid "480 failed logins per hour"
 msgstr ""
 
-#: src/settings-alerts.php:369
+#. translators: %s: number of failed logins
+#: src/settings-alerts.php:413
+#, php-format
 msgid "Consider brute-force attack after <code>%s</code> failed logins per hour"
 msgstr ""
 
-#: src/settings-alerts.php:374
+#. translators: %s: number of failed logins
+#: src/settings-alerts.php:422
+#, php-format
 msgid "The plugin will assume that your website is under a brute-force attack after %s failed logins are detected during the same hour"
 msgstr ""
 
-#: src/settings-alerts.php:376
+#: src/settings-alerts.php:426
 msgid "Invalid number of failed logins per hour"
 msgstr ""
 
-#: src/settings-alerts.php:401
+#: src/settings-alerts.php:451
 msgid "Receive email alerts for changes in the settings of the plugin"
 msgstr ""
 
-#: src/settings-alerts.php:402
+#: src/settings-alerts.php:452
 msgid "Receive email alerts in HTML <em>(there may be issues with some mail services)</em>"
 msgstr ""
 
-#: src/settings-alerts.php:403
+#: src/settings-alerts.php:453
 msgid "Use WordPress functions to send mails <em>(uncheck to use native PHP functions)</em>"
 msgstr ""
 
-#: src/settings-alerts.php:404
+#: src/settings-alerts.php:454
 msgid "Allow redirection after login to report the last-login information"
 msgstr ""
 
-#: src/settings-alerts.php:405
+#: src/settings-alerts.php:455
 msgid "Receive email alerts for core integrity checks"
 msgstr ""
 
-#: src/settings-alerts.php:406
+#: src/settings-alerts.php:456
 msgid "Receive email alerts for available updates"
 msgstr ""
 
-#: src/settings-alerts.php:407
+#: src/settings-alerts.php:457
 msgid "Receive email alerts for new user registration"
 msgstr ""
 
-#: src/settings-alerts.php:408
+#: src/settings-alerts.php:458
 msgid "Receive email alerts for successful login attempts"
 msgstr ""
 
-#: src/settings-alerts.php:409
+#: src/settings-alerts.php:459
 msgid "Receive email alerts for failed login attempts <em>(you may receive tons of emails)</em>"
 msgstr ""
 
-#: src/settings-alerts.php:410
+#: src/settings-alerts.php:460
 msgid "Receive email alerts for password guessing attacks <em>(summary of failed logins per hour)</em>"
 msgstr ""
 
-#: src/settings-alerts.php:411
+#: src/settings-alerts.php:461
 msgid "Receive email alerts for changes in the post status <em>(configure from Ignore Posts Changes)</em>"
 msgstr ""
 
-#: src/settings-alerts.php:412
+#: src/settings-alerts.php:462
 msgid "Receive email alerts when the WordPress version is updated"
 msgstr ""
 
-#: src/settings-alerts.php:413
+#: src/settings-alerts.php:463
 msgid "Receive email alerts when your website settings are updated"
 msgstr ""
 
-#: src/settings-alerts.php:414
+#: src/settings-alerts.php:464
 msgid "Receive email alerts when a file is modified with theme/plugin editor"
 msgstr ""
 
-#: src/settings-alerts.php:415
+#: src/settings-alerts.php:465
 msgid "Receive email alerts when a <b>plugin is installed</b>"
 msgstr ""
 
-#: src/settings-alerts.php:416
+#: src/settings-alerts.php:466
 msgid "Receive email alerts when a <b>plugin is activated</b>"
 msgstr ""
 
-#: src/settings-alerts.php:417
+#: src/settings-alerts.php:467
 msgid "Receive email alerts when a <b>plugin is deactivated</b>"
 msgstr ""
 
-#: src/settings-alerts.php:418
+#: src/settings-alerts.php:468
 msgid "Receive email alerts when a <b>plugin is updated</b>"
 msgstr ""
 
-#: src/settings-alerts.php:419
+#: src/settings-alerts.php:469
 msgid "Receive email alerts when a <b>plugin is deleted</b>"
 msgstr ""
 
-#: src/settings-alerts.php:420
+#: src/settings-alerts.php:470
 msgid "Receive email alerts when a <b>widget is added</b> to a sidebar"
 msgstr ""
 
-#: src/settings-alerts.php:421
+#: src/settings-alerts.php:471
 msgid "Receive email alerts when a <b>widget is deleted</b> from a sidebar"
 msgstr ""
 
-#: src/settings-alerts.php:422
+#: src/settings-alerts.php:472
 msgid "Receive email alerts when a <b>theme is installed</b>"
 msgstr ""
 
-#: src/settings-alerts.php:423
+#: src/settings-alerts.php:473
 msgid "Receive email alerts when a <b>theme is activated</b>"
 msgstr ""
 
-#: src/settings-alerts.php:424
+#: src/settings-alerts.php:474
 msgid "Receive email alerts when a <b>theme is updated</b>"
 msgstr ""
 
-#: src/settings-alerts.php:425
+#: src/settings-alerts.php:475
 msgid "Receive email alerts when a <b>theme is deleted</b>"
 msgstr ""
 
-#: src/settings-alerts.php:469
+#. translators: %s: number of events
+#: src/settings-alerts.php:521
+#, php-format
 msgid "A total of %s alert events were changed"
 msgstr ""
 
-#: src/settings-alerts.php:473
+#: src/settings-alerts.php:527
 msgid "The alert settings have been updated"
 msgstr ""
 
-#: src/settings-alerts.php:547
+#: src/settings-alerts.php:601
 msgid "Only lowercase letters, numbers, underscores and hyphens are allowed. Post Types cannot exceed 20 characters as well."
 msgstr ""
 
-#: src/settings-alerts.php:549
+#: src/settings-alerts.php:603
 msgid "The post-type is already being ignored (duplicate)."
 msgstr ""
 
-#: src/settings-alerts.php:553
+#: src/settings-alerts.php:607
 msgid "Post-type has been successfully ignored."
 msgstr ""
 
-#: src/settings-alerts.php:555
+#. translators: %s: post or page type (e.g. post, page, attachment)
+#: src/settings-alerts.php:610
+#, php-format
 msgid "Changes in <code>%s</code> post-type will be ignored"
 msgstr ""
 
-#: src/settings-alerts.php:570
+#: src/settings-alerts.php:625
 msgid "List of monitored post-types has been updated."
 msgstr ""
 
-#: src/settings-alerts.php:572
+#: src/settings-alerts.php:627
 msgid "List of monitored post-types has been updated"
 msgstr ""
 
-#: src/settings-alerts.php:579
-#: src/settings-scanner.php:179
-#: src/settings-scanner.php:239
+#: src/settings-alerts.php:634
+#: src/settings-scanner.php:187
+#: src/settings-scanner.php:248
 #: src/strings.php:47
 #: src/strings.php:218
 #: src/strings.php:230
@@ -1610,71 +1769,83 @@ msgstr ""
 msgid "no data available"
 msgstr ""
 
-#: src/settings-apiservice.php:43
+#: src/settings-apiservice.php:44
 msgid "The status of the API service could not be enabled because the required SUCURISCAN_API_URL configuration was not found."
 msgstr ""
 
-#: src/settings-apiservice.php:46
+#. translators: %s: status of the API (enabled/disabled)
+#: src/settings-apiservice.php:48
+#, php-format
 msgid "API service communication was <code>%s</code>"
 msgstr ""
 
-#: src/settings-apiservice.php:51
+#: src/settings-apiservice.php:53
 msgid "The status of the API service has been changed"
 msgstr ""
 
-#: src/settings-apiservice.php:60
-#: src/settings-general.php:211
-#: src/settings-general.php:277
-#: src/settings-general.php:324
-#: src/settings-headers.php:137
-#: src/settings-headers.php:393
-#: src/settings-headers.php:436
-#: src/settings-integrity.php:80
+#: src/settings-apiservice.php:62
+#: src/settings-general.php:216
+#: src/settings-general.php:282
+#: src/settings-general.php:329
+#: src/settings-headers.php:139
+#: src/settings-headers.php:396
+#: src/settings-headers.php:439
+#: src/settings-integrity.php:82
 #: src/strings.php:772
 #: src/topt.lib.php:1067
 msgid "Enabled"
 msgstr ""
 
-#: src/settings-apiservice.php:61
-#: src/settings-general.php:212
-#: src/settings-general.php:278
-#: src/settings-general.php:325
-#: src/settings-integrity.php:81
+#: src/settings-apiservice.php:63
+#: src/settings-general.php:217
+#: src/settings-general.php:283
+#: src/settings-general.php:330
+#: src/settings-integrity.php:83
 msgid "Disable"
 msgstr ""
 
-#: src/settings-apiservice.php:69
-#: src/settings-general.php:254
-#: src/settings-general.php:298
-#: src/settings-general.php:359
-#: src/settings-headers.php:137
-#: src/settings-headers.php:314
-#: src/settings-headers.php:358
-#: src/settings-headers.php:392
-#: src/settings-headers.php:436
+#: src/settings-apiservice.php:71
+#: src/settings-general.php:259
+#: src/settings-general.php:303
+#: src/settings-general.php:365
+#: src/settings-headers.php:139
+#: src/settings-headers.php:317
+#: src/settings-headers.php:361
+#: src/settings-headers.php:395
+#: src/settings-headers.php:439
 #: src/strings.php:773
 #: src/topt.lib.php:1068
 msgid "Disabled"
 msgstr ""
 
-#: src/settings-apiservice.php:70
-#: src/settings-general.php:255
-#: src/settings-general.php:299
-#: src/settings-general.php:360
+#: src/settings-apiservice.php:72
+#: src/settings-general.php:260
+#: src/settings-general.php:304
+#: src/settings-general.php:366
 msgid "Enable"
 msgstr ""
 
-#: src/settings-apiservice.php:83
+#: src/settings-apiservice.php:82
+msgid "Service API URL not set. To enable the API service, add your custom API service URL as the SUCURISCAN_API_URL constant value to the main configuration file (wp-config.php). If you do not have a custom API to store the audit logs, the plugin will still store these logs on your hosting environment."
+msgstr ""
+
+#: src/settings-apiservice.php:82
+msgid "Service API URL: "
+msgstr ""
+
+#: src/settings-apiservice.php:85
 msgid "NONE"
 msgstr ""
 
-#: src/settings-apiservice.php:143
-#: src/settings-apiservice.php:150
+#. translators: %s: URL of the checksum API
+#: src/settings-apiservice.php:146
+#: src/settings-apiservice.php:154
+#, php-format
 msgid "Core integrity API changed: %s"
 msgstr ""
 
-#: src/settings-apiservice.php:146
-#: src/settings-apiservice.php:153
+#: src/settings-apiservice.php:149
+#: src/settings-apiservice.php:157
 msgid "The URL to retrieve the WordPress checksums has been changed"
 msgstr ""
 
@@ -1687,137 +1858,153 @@ msgstr ""
 msgid "Directory used to store the plugin settings, cache and system logs"
 msgstr ""
 
-#: src/settings-general.php:64
+#. translators: %s: number of seconds
+#: src/settings-general.php:65
+#, php-format
 msgid "Cache to store the system logs obtained from the API service; expires after %s seconds."
 msgstr ""
 
-#: src/settings-general.php:65
+#: src/settings-general.php:66
 msgid "Local queue to store the most recent logs before they are sent to the remote API service."
 msgstr ""
 
-#: src/settings-general.php:66
+#: src/settings-general.php:67
 msgid "Deprecated on 1.8.12; it was used to store a list of blocked user names."
 msgstr ""
 
-#: src/settings-general.php:67
+#: src/settings-general.php:68
 msgid "Stores the data for every failed login attempt. The data is moved to \"oldfailedlogins\" every hour during a brute force password attack."
 msgstr ""
 
-#: src/settings-general.php:68
+#: src/settings-general.php:69
 msgid "Temporarily stores data to complement the logs during destructive operations like deleting a post, page, comment, etc."
 msgstr ""
 
-#: src/settings-general.php:69
+#: src/settings-general.php:70
 msgid "Stores a list of files and folders chosen by the user to be ignored by the file system scanner."
 msgstr ""
 
-#: src/settings-general.php:70
+#: src/settings-general.php:71
 msgid "Stores a list of files marked as fixed by the user via the WordPress Integrity tool."
 msgstr ""
 
-#: src/settings-general.php:71
+#: src/settings-general.php:72
 msgid "Stores the data associated to every successful user login. The data never expires; manually delete if the file is too large."
 msgstr ""
 
-#: src/settings-general.php:72
+#: src/settings-general.php:73
 msgid "Stores the data for every failed login attempt after the plugin sends a report about a brute force password attack via email."
 msgstr ""
 
-#: src/settings-general.php:73
+#. translators: %s: number of seconds
+#: src/settings-general.php:75
+#, php-format
 msgid "Cache to store the data associated to the installed plugins listed in the Post-Hack page. Expires after %s seconds."
 msgstr ""
 
-#: src/settings-general.php:74
+#: src/settings-general.php:76
 msgid "Stores all the options used to configure the functionality and behavior of the plugin."
 msgstr ""
 
-#: src/settings-general.php:75
+#. translators: %s: number of seconds
+#: src/settings-general.php:78
+#, php-format
 msgid "Cache to store the result of the malware scanner. Expires after %s seconds, reset at any time to force a re-scan."
 msgstr ""
 
-#: src/settings-general.php:76
+#: src/settings-general.php:79
 msgid "Stores a list of IP addresses trusted by the plugin, events triggered by one of these IPs will not be reported to the remote monitoring API service."
 msgstr ""
 
-#: src/settings-general.php:111
+#. translators: %s: comma-separated list of filenames
+#: src/settings-general.php:115
+#, php-format
 msgid "%s were deleted."
 msgstr ""
 
-#: src/settings-general.php:118
-msgid "%d out of %d files have been deleted."
+#. translators: %1$d: number of deleted files, %2$d: total number of files
+#: src/settings-general.php:123
+#, php-format
+msgid "%1$d out of %2$d files have been deleted."
 msgstr ""
 
-#: src/settings-general.php:136
-#: src/settings-posthack.php:369
+#: src/settings-general.php:141
+#: src/settings-posthack.php:370
 msgid "Not Writable"
 msgstr ""
 
-#: src/settings-general.php:137
+#: src/settings-general.php:142
 msgid "Does Not Exist"
 msgstr ""
 
-#: src/settings-general.php:143
+#: src/settings-general.php:148
 msgid "Exists"
 msgstr ""
 
-#: src/settings-general.php:149
+#: src/settings-general.php:154
 #: src/strings.php:448
 msgid "Writable"
 msgstr ""
 
-#: src/settings-general.php:223
+#: src/settings-general.php:228
 msgid "Log exporter was disabled"
 msgstr ""
 
-#: src/settings-general.php:229
+#: src/settings-general.php:234
 msgid "The log exporter feature has been disabled"
 msgstr ""
 
-#: src/settings-general.php:231
+#: src/settings-general.php:236
 msgid "File should not be publicly accessible."
 msgstr ""
 
-#: src/settings-general.php:233
+#: src/settings-general.php:238
 msgid "File already exists and will not be overwritten."
 msgstr ""
 
-#: src/settings-general.php:235
+#: src/settings-general.php:240
 msgid "File parent directory is not writable."
 msgstr ""
 
-#: src/settings-general.php:239
+#: src/settings-general.php:244
 msgid "Log exporter file path was correctly set"
 msgstr ""
 
-#: src/settings-general.php:245
+#: src/settings-general.php:250
 msgid "The log exporter feature has been enabled and the data file was successfully set."
 msgstr ""
 
-#: src/settings-general.php:321
+#: src/settings-general.php:326
 msgid "INVALID"
 msgstr ""
 
-#: src/settings-general.php:339
+#. translators: %s: status (enabled/disabled)
+#: src/settings-general.php:345
+#, php-format
 msgid "DNS lookups for reverse proxy detection <code>%s</code>"
 msgstr ""
 
-#: src/settings-general.php:344
+#: src/settings-general.php:350
 msgid "The status of the DNS lookups for the reverse proxy detection has been changed"
 msgstr ""
 
-#: src/settings-general.php:492
-msgid "%d out of %d option have been successfully imported"
+#. translators: %1$d: number of imported options, %2$d: total options
+#: src/settings-general.php:498
+#, php-format
+msgid "%1$d out of %2$d option have been successfully imported"
 msgstr ""
 
-#: src/settings-general.php:498
+#: src/settings-general.php:504
 msgid "Data is incorrectly encoded"
 msgstr ""
 
-#: src/settings-general.php:556
+#. translators: %s: timezone
+#: src/settings-general.php:563
+#, php-format
 msgid "Timezone override will use %s"
 msgstr ""
 
-#: src/settings-general.php:561
+#: src/settings-general.php:568
 msgid "The timezone for the date and time in the audit logs has been changed"
 msgstr ""
 
@@ -1837,10 +2024,10 @@ msgstr ""
 #: src/settings-hardening.php:288
 #: src/settings-hardening.php:352
 #: src/settings-hardening.php:429
-#: src/settings-hardening.php:475
-#: src/settings-hardening.php:520
-#: src/settings-hardening.php:638
-#: src/settings-hardening.php:692
+#: src/settings-hardening.php:476
+#: src/settings-hardening.php:521
+#: src/settings-hardening.php:639
+#: src/settings-hardening.php:693
 msgid "Apply Hardening"
 msgstr ""
 
@@ -1852,10 +2039,10 @@ msgstr ""
 #: src/settings-hardening.php:348
 #: src/settings-hardening.php:421
 #: src/settings-hardening.php:425
-#: src/settings-hardening.php:478
-#: src/settings-hardening.php:516
-#: src/settings-hardening.php:634
-#: src/settings-hardening.php:697
+#: src/settings-hardening.php:479
+#: src/settings-hardening.php:517
+#: src/settings-hardening.php:635
+#: src/settings-hardening.php:698
 msgid "Revert Hardening"
 msgstr ""
 
@@ -1956,192 +2143,198 @@ msgstr ""
 msgid "Block PHP Files in WP-INCLUDES Directory"
 msgstr ""
 
-#: src/settings-hardening.php:451
+#. translators: %s: path to the wordpress root
+#: src/settings-hardening.php:452
+#, php-format
 msgid "Cannot delete <code>%s/readme.html</code>"
 msgstr ""
 
-#: src/settings-hardening.php:455
-#: src/settings-hardening.php:459
+#: src/settings-hardening.php:456
+#: src/settings-hardening.php:460
 msgid "Hardening applied to the <code>readme.html</code> file"
 msgstr ""
 
-#: src/settings-hardening.php:466
+#: src/settings-hardening.php:467
 msgid "Avoid Information Leakage"
 msgstr ""
 
-#: src/settings-hardening.php:467
+#: src/settings-hardening.php:468
 msgid "Checks if the WordPress README file still exists in the website. The information in this file can be used by malicious users to pin-point which disclosed vulnerabilities are associated to the website. WordPress recreates this file automatically with every update."
 msgstr ""
 
-#: src/settings-hardening.php:507
+#: src/settings-hardening.php:508
 msgid "Verify Default Admin Account"
 msgstr ""
 
-#: src/settings-hardening.php:508
+#: src/settings-hardening.php:509
 msgid "Check if the primary user account still uses the name \"admin\". This allows malicious users to easily identify which account has the highest privileges to target an attack."
 msgstr ""
 
-#: src/settings-hardening.php:543
-#: src/settings-hardening.php:584
+#: src/settings-hardening.php:544
+#: src/settings-hardening.php:585
 msgid "WordPress configuration file was not found."
 msgstr ""
 
-#: src/settings-hardening.php:545
-#: src/settings-hardening.php:586
+#: src/settings-hardening.php:546
+#: src/settings-hardening.php:587
 #: src/settings-posthack.php:77
 msgid "WordPress configuration file is not writable."
 msgstr ""
 
-#: src/settings-hardening.php:572
-#: src/settings-hardening.php:576
+#: src/settings-hardening.php:573
+#: src/settings-hardening.php:577
 msgid "Hardening applied to the plugin and theme editor"
 msgstr ""
 
-#: src/settings-hardening.php:604
+#: src/settings-hardening.php:605
 msgid "File Editor was not disabled using this tool. You must scan your project for a constant defined as DISALLOW_FILE_EDIT, then either delete it or set its value to False. Any plugin/theme can disable the file editor, so it is impossible to determine the origin of the constant."
 msgstr ""
 
-#: src/settings-hardening.php:613
-#: src/settings-hardening.php:617
+#: src/settings-hardening.php:614
+#: src/settings-hardening.php:618
 msgid "Hardening reverted in the plugin and theme editor"
 msgstr ""
 
-#: src/settings-hardening.php:625
+#: src/settings-hardening.php:626
 msgid "Disable Plugin and Theme Editor"
 msgstr ""
 
-#: src/settings-hardening.php:626
+#: src/settings-hardening.php:627
 msgid "Disables the theme and plugin editors to prevent unwanted modifications to the code. If you are having problems reverting this please open the wp-config.php file and delete the line with the constant DISALLOW_FILE_EDIT."
 msgstr ""
 
-#: src/settings-hardening.php:661
+#: src/settings-hardening.php:662
 msgid "Automatic Secret Keys Updater enabled. The default frequency is \"Weekly\", but you can change the frequency on Settings -> Post-Hack -> Update Secret Keys section."
 msgstr ""
 
-#: src/settings-hardening.php:665
+#: src/settings-hardening.php:666
 #: src/settings-posthack.php:159
 #: src/settings-posthack.php:160
 msgid "Automatic Secret Keys Updater enabled."
 msgstr ""
 
-#: src/settings-hardening.php:667
-#: src/settings-hardening.php:677
+#: src/settings-hardening.php:668
+#: src/settings-hardening.php:678
 #: src/settings-posthack.php:151
 #: src/settings-posthack.php:162
 msgid "Something went wrong."
 msgstr ""
 
-#: src/settings-hardening.php:674
 #: src/settings-hardening.php:675
+#: src/settings-hardening.php:676
 #: src/settings-posthack.php:148
 #: src/settings-posthack.php:149
 msgid "Automatic Secret Keys Updater disabled."
 msgstr ""
 
-#: src/settings-hardening.php:684
+#: src/settings-hardening.php:685
 msgid "Activate Automatic Secret Keys Updater"
 msgstr ""
 
-#: src/settings-hardening.php:685
+#: src/settings-hardening.php:686
 msgid "Changing the Secret Keys will invalidate all existing cookies, forcing all logged in users to login again. Doing this frequently will decrease the chances of misuse of sessions left open on unprotected devices."
 msgstr ""
 
-#: src/settings-hardening.php:741
+#: src/settings-hardening.php:742
 msgid "The file has been allowed"
 msgstr ""
 
-#: src/settings-hardening.php:746
+#: src/settings-hardening.php:747
 msgid "Specified folder is not hardened by this plugin"
 msgstr ""
 
-#: src/settings-hardening.php:773
+#: src/settings-hardening.php:774
 msgid "Some files could not be removed"
 msgstr ""
 
-#: src/settings-hardening.php:775
+#: src/settings-hardening.php:776
 msgid "Selected files have been removed"
 msgstr ""
 
 #: src/settings-headers.php:38
-#: src/settings-headers.php:298
-#: src/settings-headers.php:376
+#: src/settings-headers.php:301
+#: src/settings-headers.php:379
 msgid "Invalid nonce."
 msgstr ""
 
-#: src/settings-headers.php:55
+#: src/settings-headers.php:56
 msgid "disabled"
 msgstr ""
 
-#: src/settings-headers.php:56
+#: src/settings-headers.php:57
 msgid "static"
 msgstr ""
 
-#: src/settings-headers.php:57
+#: src/settings-headers.php:58
 msgid "occasional"
 msgstr ""
 
-#: src/settings-headers.php:58
+#: src/settings-headers.php:59
 msgid "frequent"
 msgstr ""
 
-#: src/settings-headers.php:59
+#: src/settings-headers.php:60
 msgid "busy"
 msgstr ""
 
-#: src/settings-headers.php:60
+#: src/settings-headers.php:61
 msgid "custom"
 msgstr ""
 
-#: src/settings-headers.php:96
+#: src/settings-headers.php:98
 msgid "Cache-Control header was deactivated."
 msgstr ""
 
-#: src/settings-headers.php:98
+#: src/settings-headers.php:100
 msgid "Cache-Control header was activated."
 msgstr ""
 
-#: src/settings-headers.php:101
+#: src/settings-headers.php:103
 msgid "Invalid cache control mode selected."
 msgstr ""
 
-#: src/settings-headers.php:315
-#: src/settings-headers.php:358
+#: src/settings-headers.php:318
+#: src/settings-headers.php:361
 msgid "Report Only"
 msgstr ""
 
-#: src/settings-headers.php:324
+#: src/settings-headers.php:327
 msgid "Invalid CSP mode selected."
 msgstr ""
 
-#: src/settings-headers.php:331
+#: src/settings-headers.php:334
 msgid "Content Security Policy settings were updated."
 msgstr ""
 
-#: src/settings-headers.php:402
+#: src/settings-headers.php:405
 msgid "Invalid CORS mode selected."
 msgstr ""
 
-#: src/settings-headers.php:409
+#: src/settings-headers.php:412
 msgid "CORS settings were updated."
 msgstr ""
 
-#: src/settings-integrity.php:65
+#: src/settings-integrity.php:66
 msgid "Your hosting provider has blocked the execution of external commands."
 msgstr ""
 
-#: src/settings-integrity.php:68
+#. translators: %s: status (enabled/disabled)
+#: src/settings-integrity.php:70
+#, php-format
 msgid "Integrity diff utility has been <code>%s</code>"
 msgstr ""
 
-#: src/settings-integrity.php:73
+#: src/settings-integrity.php:75
 msgid "The status of the integrity diff utility has been changed"
 msgstr ""
 
-#: src/settings-integrity.php:112
+#. translators: %s: comma-separated list of filenames
+#: src/settings-integrity.php:115
+#, php-format
 msgid "Core files that will not be ignored anymore: (multiple entries): %s"
 msgstr ""
 
-#: src/settings-integrity.php:114
+#: src/settings-integrity.php:117
 msgid "The selected files have been successfully processed."
 msgstr ""
 
@@ -2173,88 +2366,106 @@ msgstr ""
 msgid "No frequency selected for the automatic secret key updater."
 msgstr ""
 
-#: src/settings-posthack.php:264
+#. translators: %d: user ID
+#: src/settings-posthack.php:265
+#, php-format
 msgid "Password changed for user #%d"
 msgstr ""
 
-#: src/settings-posthack.php:359
+#: src/settings-posthack.php:360
 msgid "not installed"
 msgstr ""
 
-#: src/settings-posthack.php:366
+#: src/settings-posthack.php:367
 msgid "Plugin is Premium"
 msgstr ""
 
-#: src/settings-posthack.php:372
+#: src/settings-posthack.php:373
 msgid "Missing Library"
 msgstr ""
 
-#: src/settings-posthack.php:382
+#: src/settings-posthack.php:383
 msgid "Cannot Download"
 msgstr ""
 
-#: src/settings-posthack.php:385
+#: src/settings-posthack.php:386
 msgid "Cannot Backup"
 msgstr ""
 
-#: src/settings-posthack.php:398
+#: src/settings-posthack.php:399
 msgid "Cannot Install"
 msgstr ""
 
-#: src/settings-posthack.php:407
+#. translators: %s: version number
+#: src/settings-posthack.php:409
+#, php-format
 msgid "Installed v%s"
 msgstr ""
 
-#: src/settings-posthack.php:481
+#: src/settings-posthack.php:483
 msgid "Newest WordPress"
 msgstr ""
 
-#: src/settings-posthack.php:519
+#: src/settings-posthack.php:521
 msgid "There are no updates available."
 msgstr ""
 
-#: src/settings-scanner.php:68
+#. translators: %d: number of tasks
+#: src/settings-scanner.php:71
+#, php-format
 msgid "%d tasks has been scheduled to run in the next ten seconds."
 msgstr ""
 
-#: src/settings-scanner.php:74
+#. translators: %s: list of tasks
+#: src/settings-scanner.php:78
+#, php-format
 msgid "Force execution of scheduled tasks: (multiple entries): %s"
 msgstr ""
 
-#: src/settings-scanner.php:86
+#. translators: %d: number of tasks
+#: src/settings-scanner.php:91
+#, php-format
 msgid "%d scheduled tasks have been removed."
 msgstr ""
 
-#: src/settings-scanner.php:92
+#. translators: %s: list of tasks
+#: src/settings-scanner.php:98
+#, php-format
 msgid "Delete scheduled tasks: (multiple entries): %s"
 msgstr ""
 
-#: src/settings-scanner.php:103
-msgid "%d tasks has been re-scheduled to run <code>%s</code>."
-msgstr ""
-
+#. translators: %1$d: number of tasks, %2$s: frequency
 #: src/settings-scanner.php:110
-msgid "Re-configure scheduled tasks %s: (multiple entries): %s"
+#, php-format
+msgid "%1$d tasks has been re-scheduled to run <code>%2$s</code>."
 msgstr ""
 
-#: src/settings-scanner.php:122
+#. translators: %1$s: frequency, %2$s: list of tasks
+#: src/settings-scanner.php:118
+#, php-format
+msgid "Re-configure scheduled tasks %1$s: (multiple entries): %2$s"
+msgstr ""
+
+#: src/settings-scanner.php:130
 msgid "No scheduled tasks were selected from the list."
 msgstr ""
 
-#: src/settings-scanner.php:131
+#: src/settings-scanner.php:139
 msgid "Execute Now (in +10 seconds)"
 msgstr ""
 
-#: src/settings-scanner.php:207
-#: src/settings-scanner.php:216
+#: src/settings-scanner.php:215
+#: src/settings-scanner.php:225
 msgid "Selected files have been successfully processed."
 msgstr ""
 
-#: src/settings-scanner.php:208
+#. translators: %s: directory path
+#: src/settings-scanner.php:217
+#, php-format
 msgid "This directory will not be scanned: %s"
 msgstr ""
 
-#: src/settings-scanner.php:218
+#: src/settings-scanner.php:227
 msgid "Directories will be scanned: (multiple entries): "
 msgstr ""
 
@@ -2266,47 +2477,61 @@ msgstr ""
 msgid "active"
 msgstr ""
 
-#: src/sitecheck.lib.php:178
+#. translators: %s: PHP version
+#: src/sitecheck.lib.php:179
+#, php-format
 msgid "PHP Version: %s"
 msgstr ""
 
-#: src/sitecheck.lib.php:179
+#. translators: %s: WordPress version
+#: src/sitecheck.lib.php:181
+#, php-format
 msgid "Version: %s"
 msgstr ""
 
-#: src/sitecheck.lib.php:190
+#. translators: %s: Hosting provider name
+#: src/sitecheck.lib.php:193
+#, php-format
 msgid "Hosting: %s"
 msgstr ""
 
-#: src/sitecheck.lib.php:194
+#. translators: %s: CMS name
+#: src/sitecheck.lib.php:198
+#, php-format
 msgid "CMS: %s"
 msgstr ""
 
-#: src/sitecheck.lib.php:272
+#: src/sitecheck.lib.php:276
 msgid "Site is Clean"
 msgstr ""
 
-#: src/sitecheck.lib.php:278
+#: src/sitecheck.lib.php:282
 msgid "Site is not Clean"
 msgstr ""
 
-#: src/sitecheck.lib.php:317
+#: src/sitecheck.lib.php:321
 msgid "Not blocklisted"
 msgstr ""
 
-#: src/sitecheck.lib.php:342
+#: src/sitecheck.lib.php:346
 msgid "In the blocklist"
 msgstr ""
 
-#: src/sitecheck.lib.php:396
+#. translators: %d: number of iframes
+#: src/sitecheck.lib.php:401
+#, php-format
 msgid "iFrames: %d"
 msgstr ""
 
-#: src/sitecheck.lib.php:411
+#. translators: %d: number of links
+#: src/sitecheck.lib.php:417
+#, php-format
 msgid "Links: %d"
 msgstr ""
 
-#: src/sitecheck.lib.php:432
+#. translators: %d: number of scripts
+#: src/sitecheck.lib.php:439
+#, php-format
 msgid "Scripts: %d"
 msgstr ""
 
@@ -3513,11 +3738,11 @@ msgstr ""
 msgid "Content Security Policy"
 msgstr ""
 
-#: src/template.lib.php:140
+#: src/template.lib.php:141
 msgid "Activate Your Firewall API Key"
 msgstr ""
 
-#: src/template.lib.php:280
+#: src/template.lib.php:281
 msgid "Invalid template type"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -261,6 +261,7 @@ This version adds an option to refresh the malware scan results on demand, as we
 == Changelog ==
 = 2.7 =
 * Fixes a lot of readiness warning/errors from PCP.
+* Updates how the plugin stores WAF API key.
 
 = 2.6 =
 * Create new permissions library.

--- a/src/api.lib.php
+++ b/src/api.lib.php
@@ -1325,6 +1325,10 @@ class SucuriScanAPI extends SucuriScanOption
 			'timeout' => 30
 		);
 
+		if (SucuriScan::isBehindFirewall()) {
+			$args['headers']['X-Sucuri-WAF'] = '1';
+		}
+
 		$response = wp_remote_get($url, $args);
 
 		if (is_wp_error($response)) {

--- a/src/api.lib.php
+++ b/src/api.lib.php
@@ -186,8 +186,7 @@ class SucuriScanAPI extends SucuriScanOption
         if (!empty($api_key)) {
             SucuriScanEvent::notifyEvent(
                 'plugin_change',
-                /* translators: %s: API key */
-                sprintf(__('API key was successfully set: %s', 'sucuri-scanner'), $api_key)
+                __('API key was successfully set.', 'sucuri-scanner')
             );
         }
 
@@ -302,7 +301,7 @@ class SucuriScanAPI extends SucuriScanOption
         if (stripos($raw, 'wrong api key') !== false) {
             $key = SucuriScanOption::getOption(':cloudproxy_apikey');
             $key = SucuriScan::escape($key);
-            $msg .= sprintf('; invalid firewall API key: %s', $key);
+            $msg .= '; invalid firewall API key.';
 
             SucuriScanOption::setRevProxy('disable', true);
             SucuriScanOption::setAddrHeader('REMOTE_ADDR', true);

--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -694,6 +694,248 @@ class SucuriScanOption extends SucuriScanRequest
     }
 
     /**
+     * Resolve the storage name for encrypted secret payloads.
+     *
+     * @param string $option Option name.
+     * @return string
+     */
+    private static function getSecretEncryptedStorageName($option = '')
+    {
+        return self::getSecretStorageName($option) . '_enc';
+    }
+
+    /**
+     * Check whether secret encryption can be enabled.
+     *
+     * @return bool
+     */
+    private static function canEncryptSecrets()
+    {
+        if (!function_exists('openssl_encrypt') || !function_exists('openssl_decrypt')) {
+            return false;
+        }
+
+        if (!function_exists('openssl_get_cipher_methods') || !function_exists('wp_salt')) {
+            return false;
+        }
+
+        $methods = openssl_get_cipher_methods();
+
+        return is_array($methods) && in_array('aes-256-gcm', $methods, true);
+    }
+
+    /**
+     * Build encryption key from WordPress salts.
+     *
+     * @return string|bool
+     */
+    private static function getSecretEncryptionKey()
+    {
+        if (!function_exists('wp_salt')) {
+            return false;
+        }
+
+        $context = 'sucuriscan_waf_key_v1';
+
+        return substr(hash_hmac('sha256', $context, wp_salt('auth'), true), 0, 32);
+    }
+
+    /**
+     * Generate random bytes for encryption.
+     *
+     * @param int $length Number of bytes.
+     * @return string|bool
+     */
+    private static function getSecretRandomBytes($length)
+    {
+        if (function_exists('random_bytes')) {
+            return random_bytes($length);
+        }
+
+        if (function_exists('openssl_random_pseudo_bytes')) {
+            return openssl_random_pseudo_bytes($length);
+        }
+
+        return false;
+    }
+
+    /**
+     * Encrypt a secret value with AES-256-GCM.
+     *
+     * @param string $plaintext Secret value.
+     * @return array|bool
+     */
+    private static function encryptSecretValue($plaintext)
+    {
+        if (!self::canEncryptSecrets()) {
+            return false;
+        }
+
+        $key = self::getSecretEncryptionKey();
+        if (!$key) {
+            return false;
+        }
+
+        $iv = self::getSecretRandomBytes(12);
+        if (!$iv) {
+            return false;
+        }
+
+        $tag = '';
+        $ciphertext = openssl_encrypt(
+            $plaintext,
+            'aes-256-gcm',
+            $key,
+            OPENSSL_RAW_DATA,
+            $iv,
+            $tag
+        );
+
+        if ($ciphertext === false || $tag === '') {
+            return false;
+        }
+
+        return array(
+            'v' => 1,
+            'alg' => 'aes-256-gcm',
+            'iv' => base64_encode($iv),
+            'tag' => base64_encode($tag),
+            'ct' => base64_encode($ciphertext),
+        );
+    }
+
+    /**
+     * Decrypt a secret payload.
+     *
+     * @param array $payload Encrypted payload.
+     * @return string|bool
+     */
+    private static function decryptSecretValue($payload)
+    {
+        if (!self::canEncryptSecrets()) {
+            return false;
+        }
+
+        if (!is_array($payload)
+            || !isset($payload['v'])
+            || !isset($payload['alg'])
+            || !isset($payload['iv'])
+            || !isset($payload['tag'])
+            || !isset($payload['ct'])
+        ) {
+            return false;
+        }
+
+        if ((int) $payload['v'] !== 1 || $payload['alg'] !== 'aes-256-gcm') {
+            return false;
+        }
+
+        $key = self::getSecretEncryptionKey();
+        if (!$key) {
+            return false;
+        }
+
+        $iv = base64_decode($payload['iv']);
+        $tag = base64_decode($payload['tag']);
+        $ct = base64_decode($payload['ct']);
+
+        if ($iv === false || $tag === false || $ct === false) {
+            return false;
+        }
+
+        return openssl_decrypt(
+            $ct,
+            'aes-256-gcm',
+            $key,
+            OPENSSL_RAW_DATA,
+            $iv,
+            $tag
+        );
+    }
+
+    /**
+     * Return the option name for decrypt error flags.
+     *
+     * @return string
+     */
+    private static function wafKeyDecryptErrorOption()
+    {
+        return 'sucuriscan_waf_key_decrypt_error';
+    }
+
+    /**
+     * Set a decryption error flag for the WAF key.
+     *
+     * @param string $message Error detail for logging.
+     * @return void
+     */
+    private static function setWafKeyDecryptError($message = '')
+    {
+        if (!function_exists('get_option') || !function_exists('update_option')) {
+            return;
+        }
+
+        if ($message) {
+            $message = sprintf(
+                /* translators: %s: error message */
+                __('Firewall API key decryption failed: %s', 'sucuri-scanner'),
+                $message
+            );
+        }
+
+        $option = self::wafKeyDecryptErrorOption();
+        $current = get_option($option, array());
+        $timestamp = isset($current['ts']) ? (int) $current['ts'] : 0;
+
+        if ($timestamp && (time() - $timestamp) < 3600) {
+            return;
+        }
+
+        update_option($option, array('ts' => time(), 'message' => (string) $message), false);
+
+        if ($message) {
+            SucuriScanEvent::reportWarningEvent($message);
+        }
+    }
+
+    /**
+     * Clear the WAF key decryption error flag.
+     *
+     * @return void
+     */
+    private static function clearWafKeyDecryptError()
+    {
+        if (function_exists('delete_option')) {
+            delete_option(self::wafKeyDecryptErrorOption());
+        }
+    }
+
+    /**
+     * Render a decryption error notice on selected admin pages.
+     *
+     * @return void
+     */
+    public static function renderWafKeyDecryptNotice()
+    {
+        if (!function_exists('get_option')) {
+            return;
+        }
+
+        if (!SucuriScanPermissions::canManagePlugin()) {
+            return;
+        }
+
+        $flag = get_option(self::wafKeyDecryptErrorOption(), array());
+        if (empty($flag) || !is_array($flag)) {
+            return;
+        }
+
+        SucuriScanInterface::error(
+            __('The Sucuri WAF API key could not be decrypted. Please re-save the key in the Firewall settings to restore functionality.', 'sucuri-scanner')
+        );
+    }
+
+    /**
      * Retrieve a secret option from the database.
      *
      * @param string $option Option name.
@@ -707,9 +949,34 @@ class SucuriScanOption extends SucuriScanRequest
 
         $option = self::varPrefix($option);
         $storage = self::getSecretStorageName($option);
+        $encrypted_storage = self::getSecretEncryptedStorageName($option);
+
+        $encrypted_payload = get_option($encrypted_storage, null);
+        if ($encrypted_payload !== null) {
+            $payload = is_array($encrypted_payload) ? $encrypted_payload : @json_decode($encrypted_payload, true);
+            $decrypted = self::decryptSecretValue($payload);
+
+            if ($decrypted !== false) {
+                self::clearWafKeyDecryptError();
+                return $decrypted;
+            }
+
+            self::setWafKeyDecryptError('decryption failed; please re-save the key.');
+            return false;
+        }
+
         $value = get_option($storage, null);
 
         if ($value !== null) {
+            if (self::canEncryptSecrets()) {
+                $payload = self::encryptSecretValue($value);
+                if ($payload !== false) {
+                    update_option($encrypted_storage, $payload, false);
+                    delete_option($storage);
+                }
+            }
+
+            self::clearWafKeyDecryptError();
             return $value;
         }
 
@@ -739,8 +1006,22 @@ class SucuriScanOption extends SucuriScanRequest
 
         $option = self::varPrefix($option);
         $storage = self::getSecretStorageName($option);
+        $encrypted_storage = self::getSecretEncryptedStorageName($option);
 
-        return update_option($storage, $value, false);
+        if (self::canEncryptSecrets()) {
+            $payload = self::encryptSecretValue($value);
+            if ($payload !== false) {
+                update_option($encrypted_storage, $payload, false);
+                delete_option($storage);
+                self::clearWafKeyDecryptError();
+                return true;
+            }
+        }
+
+        delete_option($encrypted_storage);
+        $result = update_option($storage, $value, false);
+        self::clearWafKeyDecryptError();
+        return $result;
     }
 
     /**
@@ -757,11 +1038,15 @@ class SucuriScanOption extends SucuriScanRequest
 
         $option = self::varPrefix($option);
         $storage = self::getSecretStorageName($option);
+        $encrypted_storage = self::getSecretEncryptedStorageName($option);
 
+        delete_option($encrypted_storage);
         $deleted = delete_option($storage);
 
         // Remove legacy storage if still present.
         delete_option($option);
+
+        self::clearWafKeyDecryptError();
 
         return $deleted;
     }

--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -1229,7 +1229,19 @@ class SucuriScanOption extends SucuriScanRequest
 
             if (strpos($option, SUCURISCAN . '_') === 0) {
                 $value = self::getDefaultOptions($option);
-                self::updateSecretOption($option, $value);
+
+                /**
+                 * Do not persist "unset" default values for secret options.
+                 *
+                 * For some secret options (e.g. WAF key) the default is an
+                 * empty string. Persisting that value into secret storage
+                 * makes it harder to distinguish between an option that has
+                 * never been set and one that was explicitly set to an
+                 * empty value. Only persist non-empty defaults.
+                 */
+                if ($value !== '' && $value !== null) {
+                    self::updateSecretOption($option, $value);
+                }
                 return $value;
             }
 

--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -971,8 +971,10 @@ class SucuriScanOption extends SucuriScanRequest
             if (self::canEncryptSecrets()) {
                 $payload = self::encryptSecretValue($value);
                 if ($payload !== false) {
-                    update_option($encrypted_storage, $payload, false);
-                    delete_option($storage);
+                    $updated = update_option($encrypted_storage, $payload, false);
+                    if ($updated) {
+                        delete_option($storage);
+                    }
                 }
             }
 

--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -1011,10 +1011,12 @@ class SucuriScanOption extends SucuriScanRequest
         if (self::canEncryptSecrets()) {
             $payload = self::encryptSecretValue($value);
             if ($payload !== false) {
-                update_option($encrypted_storage, $payload, false);
-                delete_option($storage);
-                self::clearWafKeyDecryptError();
-                return true;
+                $encrypted_result = update_option($encrypted_storage, $payload, false);
+                if ($encrypted_result) {
+                    delete_option($storage);
+                    self::clearWafKeyDecryptError();
+                    return true;
+                }
             }
         }
 

--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -1075,6 +1075,37 @@ class SucuriScanOption extends SucuriScanRequest
     }
 
     /**
+     * Retrieve a secret option value from the DB or settings file.
+     *
+     * @param string $option Option name.
+     * @param array $options Settings file options.
+     * @return mixed
+     */
+    private static function getSecretOptionValue($option, $options)
+    {
+        $value = self::getSecretOption($option);
+
+        if ($value !== null) {
+            return $value;
+        }
+
+        if (array_key_exists($option, $options)) {
+            $value = $options[$option];
+            self::updateSecretOption($option, $value);
+            self::deleteOptionFromFile($option);
+            return $value;
+        }
+
+        if (strpos($option, SUCURISCAN . '_') === 0) {
+            $value = self::getDefaultOptions($option);
+            self::updateSecretOption($option, $value);
+            return $value;
+        }
+
+        return false;
+    }
+
+    /**
      * Name of all valid plugin's options.
      *
      * @return array Name of all valid plugin's options.
@@ -1213,41 +1244,7 @@ class SucuriScanOption extends SucuriScanRequest
         $option = self::varPrefix($option);
 
         if (self::isSecretOption($option)) {
-            $value = self::getSecretOption($option);
-
-            if ($value !== null) {
-                return $value;
-            }
-
-            if (array_key_exists($option, $options)) {
-                $value = $options[$option];
-                $written = self::updateSecretOption($option, $value);
-
-                if ($written === true) {
-                    self::deleteOptionFromFile($option);
-                }
-                return $value;
-            }
-
-            if (strpos($option, SUCURISCAN . '_') === 0) {
-                $value = self::getDefaultOptions($option);
-
-                /**
-                 * Do not persist "unset" default values for secret options.
-                 *
-                 * For some secret options (e.g. WAF key) the default is an
-                 * empty string. Persisting that value into secret storage
-                 * makes it harder to distinguish between an option that has
-                 * never been set and one that was explicitly set to an
-                 * empty value. Only persist non-empty defaults.
-                 */
-                if ($value !== '' && $value !== null) {
-                    self::updateSecretOption($option, $value);
-                }
-                return $value;
-            }
-
-            return false;
+            return self::getSecretOptionValue($option, $options);
         }
 
         if (array_key_exists($option, $options)) {

--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -1219,8 +1219,11 @@ class SucuriScanOption extends SucuriScanRequest
 
             if (array_key_exists($option, $options)) {
                 $value = $options[$option];
-                self::updateSecretOption($option, $value);
-                self::deleteOptionFromFile($option);
+                $written = self::updateSecretOption($option, $value);
+
+                if ($written === true) {
+                    self::deleteOptionFromFile($option);
+                }
                 return $value;
             }
 

--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -654,6 +654,138 @@ class SucuriScanOption extends SucuriScanRequest
     }
 
     /**
+     * Map of options that must be stored as secrets.
+     *
+     * @return array
+     */
+    private static function getSecretOptionMap()
+    {
+        return array(
+            'sucuriscan_cloudproxy_apikey' => 'sucuriscan_secret_cloudproxy_apikey',
+        );
+    }
+
+    /**
+     * Check whether an option is stored as a secret.
+     *
+     * @param string $option Option name.
+     * @return bool
+     */
+    private static function isSecretOption($option = '')
+    {
+        $option = self::varPrefix($option);
+        $map = self::getSecretOptionMap();
+
+        return array_key_exists($option, $map);
+    }
+
+    /**
+     * Resolve the storage name for a secret option.
+     *
+     * @param string $option Option name.
+     * @return string
+     */
+    private static function getSecretStorageName($option = '')
+    {
+        $option = self::varPrefix($option);
+        $map = self::getSecretOptionMap();
+
+        return array_key_exists($option, $map) ? $map[$option] : $option;
+    }
+
+    /**
+     * Retrieve a secret option from the database.
+     *
+     * @param string $option Option name.
+     * @return mixed|null
+     */
+    private static function getSecretOption($option = '')
+    {
+        if (!function_exists('get_option')) {
+            return null;
+        }
+
+        $option = self::varPrefix($option);
+        $storage = self::getSecretStorageName($option);
+        $value = get_option($storage, null);
+
+        if ($value !== null) {
+            return $value;
+        }
+
+        // Backward compatibility: migrate legacy DB value to secret storage.
+        $legacy = get_option($option, null);
+        if ($legacy !== null) {
+            self::updateSecretOption($option, $legacy);
+            delete_option($option);
+            return $legacy;
+        }
+
+        return null;
+    }
+
+    /**
+     * Update a secret option in the database (non-autoloaded).
+     *
+     * @param string $option Option name.
+     * @param mixed $value Option value.
+     * @return bool
+     */
+    private static function updateSecretOption($option = '', $value = '')
+    {
+        if (!function_exists('update_option')) {
+            return false;
+        }
+
+        $option = self::varPrefix($option);
+        $storage = self::getSecretStorageName($option);
+
+        return update_option($storage, $value, false);
+    }
+
+    /**
+     * Delete a secret option from the database.
+     *
+     * @param string $option Option name.
+     * @return bool
+     */
+    private static function deleteSecretOption($option = '')
+    {
+        if (!function_exists('delete_option')) {
+            return false;
+        }
+
+        $option = self::varPrefix($option);
+        $storage = self::getSecretStorageName($option);
+
+        $deleted = delete_option($storage);
+
+        // Remove legacy storage if still present.
+        delete_option($option);
+
+        return $deleted;
+    }
+
+    /**
+     * Delete an option from the settings file only.
+     *
+     * @param string $option Option name.
+     * @return bool
+     */
+    private static function deleteOptionFromFile($option = '')
+    {
+        $options = self::getAllOptions();
+        $option = self::varPrefix($option);
+
+        if (array_key_exists($option, $options)) {
+            unset($options[$option]);
+            return self::writeNewOptions($options);
+        }
+
+        return false;
+    }
+
+    /**
      * Name of all valid plugin's options.
      *
      * @return array Name of all valid plugin's options.
@@ -791,6 +923,29 @@ class SucuriScanOption extends SucuriScanRequest
         $options = self::getAllOptions();
         $option = self::varPrefix($option);
 
+        if (self::isSecretOption($option)) {
+            $value = self::getSecretOption($option);
+
+            if ($value !== null) {
+                return $value;
+            }
+
+            if (array_key_exists($option, $options)) {
+                $value = $options[$option];
+                self::updateSecretOption($option, $value);
+                self::deleteOptionFromFile($option);
+                return $value;
+            }
+
+            if (strpos($option, SUCURISCAN . '_') === 0) {
+                $value = self::getDefaultOptions($option);
+                self::updateSecretOption($option, $value);
+                return $value;
+            }
+
+            return false;
+        }
+
         if (array_key_exists($option, $options)) {
             return $options[$option];
         }
@@ -861,6 +1016,10 @@ class SucuriScanOption extends SucuriScanRequest
      */
     public static function updateOption($option = '', $value = '')
     {
+        if (self::isSecretOption($option)) {
+            return self::updateSecretOption($option, $value);
+        }
+
         if (strpos($option, ':') === 0 || strpos($option, SUCURISCAN) === 0) {
             $options = self::getAllOptions();
             $option = self::varPrefix($option);
@@ -884,6 +1043,10 @@ class SucuriScanOption extends SucuriScanRequest
      */
     public static function deleteOption($option = '')
     {
+        if (self::isSecretOption($option)) {
+            return self::deleteSecretOption($option);
+        }
+
         if (strpos($option, ':') === 0 || strpos($option, SUCURISCAN) === 0) {
             $options = self::getAllOptions();
             $option = self::varPrefix($option);

--- a/src/pagehandler.php
+++ b/src/pagehandler.php
@@ -158,6 +158,7 @@ function sucuriscan_page()
     $params = array();
 
     SucuriScanInterface::startupChecks();
+    SucuriScanOption::renderWafKeyDecryptNotice();
 
     /* load data for the Integrity section */
     $params['Integrity'] = SucuriScanIntegrity::pageIntegrity();
@@ -207,6 +208,7 @@ function sucuriscan_page()
 function sucuriscan_firewall_page()
 {
     SucuriScanInterface::startupChecks();
+    SucuriScanOption::renderWafKeyDecryptNotice();
 
     $params = array(
         'Firewall.Settings' => SucuriScanFirewall::settingsPage(),
@@ -465,4 +467,3 @@ function sucuriscan_ajax()
 
     wp_send_json(array('ok' => false, 'error' => 'invalid ajax action'), 200);
 }
-

--- a/src/settings-general.php
+++ b/src/settings-general.php
@@ -403,7 +403,6 @@ function sucuriscan_settings_general_importexport($nonce)
         ':addr_header',
         ':api_protocol',
         ':api_service',
-        ':cloudproxy_apikey',
         ':diff_utility',
         ':dns_lookups',
         ':email_subject',

--- a/tests/OptionSecretTest.php
+++ b/tests/OptionSecretTest.php
@@ -1,0 +1,192 @@
+<?php declare(strict_types=1);
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+final class OptionSecretTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private $options = array();
+    private $autoload = array();
+    private $cache = array();
+    private $settingsFile = '';
+    private $originalSettingsContent = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        $this->settingsFile = SucuriScanOption::optionsFilePath();
+        $this->originalSettingsContent = file_exists($this->settingsFile)
+            ? (string) file_get_contents($this->settingsFile)
+            : '';
+
+        $self = $this;
+
+        Functions\when('__')->returnArg();
+        Functions\when('wp_salt')->justReturn('test-salt');
+        Functions\when('wp_strip_all_tags')->alias(function ($text) {
+            return $text;
+        });
+        Functions\when('sucuriscan_lastlogins_datastore_exists')->justReturn(true);
+        Functions\when('get_home_path')->justReturn('/');
+
+        Functions\when('wp_cache_get')->alias(function ($key, $group = '') use ($self) {
+            $cacheKey = $group . ':' . $key;
+            return array_key_exists($cacheKey, $self->cache) ? $self->cache[$cacheKey] : false;
+        });
+
+        Functions\when('wp_cache_set')->alias(function ($key, $value, $group = '') use ($self) {
+            $cacheKey = $group . ':' . $key;
+            $self->cache[$cacheKey] = $value;
+            return true;
+        });
+
+        Functions\when('wp_cache_delete')->alias(function ($key, $group = '') use ($self) {
+            $cacheKey = $group . ':' . $key;
+            unset($self->cache[$cacheKey]);
+            return true;
+        });
+
+        Functions\when('get_option')->alias(function ($option, $default = false) use ($self) {
+            return array_key_exists($option, $self->options) ? $self->options[$option] : $default;
+        });
+
+        Functions\when('update_option')->alias(function ($option, $value, $autoload = null) use ($self) {
+            $self->options[$option] = $value;
+            $self->autoload[$option] = $autoload;
+            return true;
+        });
+
+        Functions\when('delete_option')->alias(function ($option) use ($self) {
+            unset($self->options[$option]);
+            unset($self->autoload[$option]);
+            return true;
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->settingsFile) {
+            file_put_contents($this->settingsFile, $this->originalSettingsContent);
+        }
+
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function testMigratesWafKeyFromFileToSecretStorage()
+    {
+        $key = str_repeat('a', 32) . '/' . str_repeat('b', 32);
+        $this->writeSettingsFile(array('sucuriscan_cloudproxy_apikey' => $key));
+
+        $value = SucuriScanOption::getOption(':cloudproxy_apikey');
+
+        $this->assertSame($key, $value);
+        $this->assertArrayHasKey('sucuriscan_secret_cloudproxy_apikey_enc', $this->options);
+        $this->assertArrayNotHasKey('sucuriscan_secret_cloudproxy_apikey', $this->options);
+
+        $data = $this->readSettingsFile();
+        $this->assertArrayNotHasKey('sucuriscan_cloudproxy_apikey', $data);
+    }
+
+    public function testSecretOptionTakesPrecedenceOverFile()
+    {
+        $secret = str_repeat('c', 32) . '/' . str_repeat('d', 32);
+        $fileKey = str_repeat('e', 32) . '/' . str_repeat('f', 32);
+
+        $payload = $this->encryptPayload($secret);
+        $this->options['sucuriscan_secret_cloudproxy_apikey_enc'] = $payload;
+        $this->writeSettingsFile(array('sucuriscan_cloudproxy_apikey' => $fileKey));
+
+        $value = SucuriScanOption::getOption(':cloudproxy_apikey');
+
+        $this->assertSame($secret, $value);
+        $data = $this->readSettingsFile();
+        $this->assertSame($fileKey, $data['sucuriscan_cloudproxy_apikey']);
+    }
+
+    public function testDecryptFailureSetsNoticeFlag()
+    {
+        $payload = array(
+            'v' => 1,
+            'alg' => 'aes-256-gcm',
+            'iv' => 'YmFk',
+            'tag' => 'YmFk',
+            'ct' => 'YmFk',
+        );
+
+        $this->options['sucuriscan_secret_cloudproxy_apikey_enc'] = $payload;
+        $this->options['sucuriscan_secret_cloudproxy_apikey'] = 'legacy-secret';
+
+        $value = SucuriScanOption::getOption(':cloudproxy_apikey');
+
+        $this->assertFalse($value);
+        $this->assertArrayHasKey('sucuriscan_waf_key_decrypt_error', $this->options);
+        $this->assertArrayHasKey('ts', $this->options['sucuriscan_waf_key_decrypt_error']);
+    }
+
+    public function testDecryptSuccessClearsNoticeFlag()
+    {
+        $payload = $this->encryptPayload('secret');
+
+        $this->options['sucuriscan_waf_key_decrypt_error'] = array('ts' => time());
+        $this->options['sucuriscan_secret_cloudproxy_apikey_enc'] = $payload;
+
+        $value = SucuriScanOption::getOption(':cloudproxy_apikey');
+
+        $this->assertSame('secret', $value);
+        $this->assertArrayNotHasKey('sucuriscan_waf_key_decrypt_error', $this->options);
+    }
+
+    public function testUpdateOptionClearsNoticeFlag()
+    {
+        $this->options['sucuriscan_waf_key_decrypt_error'] = array('ts' => time());
+
+        $value = str_repeat('g', 32) . '/' . str_repeat('h', 32);
+        SucuriScanOption::updateOption(':cloudproxy_apikey', $value);
+
+        $this->assertArrayNotHasKey('sucuriscan_waf_key_decrypt_error', $this->options);
+    }
+
+    private function writeSettingsFile(array $options)
+    {
+        $content = "<?php exit(0); ?>\n";
+        $content .= json_encode($options) . "\n";
+        file_put_contents($this->settingsFile, $content);
+
+        $this->cache = array();
+    }
+
+    private function readSettingsFile(): array
+    {
+        $content = (string) file_get_contents($this->settingsFile);
+        $lines = explode("\n", $content, 2);
+        if (count($lines) < 2) {
+            return array();
+        }
+
+        $data = json_decode($lines[1], true);
+        return is_array($data) ? $data : array();
+    }
+
+    private function encryptPayload($plaintext)
+    {
+        $key = substr(hash_hmac('sha256', 'sucuriscan_waf_key_v1', 'test-salt', true), 0, 32);
+        $iv = str_repeat("\x01", 12);
+        $tag = '';
+        $ciphertext = openssl_encrypt($plaintext, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag);
+
+        return array(
+            'v' => 1,
+            'alg' => 'aes-256-gcm',
+            'iv' => base64_encode($iv),
+            'tag' => base64_encode($tag),
+            'ct' => base64_encode($ciphertext),
+        );
+    }
+}

--- a/tests/e2e-prepare.sh
+++ b/tests/e2e-prepare.sh
@@ -56,14 +56,3 @@ cat <<EOF > wp-content/.htaccess
   </IfModule>
 </Files>
 EOF
-
-# Seed legacy settings file with WAF API key for migration tests
-mkdir -p wp-content/uploads/sucuri
-cat <<'EOF' > wp-content/uploads/sucuri/sucuri-settings.php
-<?php exit(0); ?>
-{"sucuriscan_cloudproxy_apikey":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","sucuriscan_addr_header":"REMOTE_ADDR","sucuriscan_notify_to":"alerts@example.com"}
-EOF
-
-# Ensure secret options are cleared so migration runs
-wp option delete sucuriscan_secret_cloudproxy_apikey_enc
-wp option delete sucuriscan_secret_cloudproxy_apikey

--- a/tests/e2e-prepare.sh
+++ b/tests/e2e-prepare.sh
@@ -56,3 +56,14 @@ cat <<EOF > wp-content/.htaccess
   </IfModule>
 </Files>
 EOF
+
+# Seed legacy settings file with WAF API key for migration tests
+mkdir -p wp-content/uploads/sucuri
+cat <<'EOF' > wp-content/uploads/sucuri/sucuri-settings.php
+<?php exit(0); ?>
+{"sucuriscan_cloudproxy_apikey":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","sucuriscan_addr_header":"REMOTE_ADDR","sucuriscan_notify_to":"alerts@example.com"}
+EOF
+
+# Ensure secret options are cleared so migration runs
+wp option delete sucuriscan_secret_cloudproxy_apikey_enc
+wp option delete sucuriscan_secret_cloudproxy_apikey

--- a/tests/e2e-seed-waf-migration.sh
+++ b/tests/e2e-seed-waf-migration.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+mkdir -p wp-content/uploads/sucuri
+cat <<'EOF' > wp-content/uploads/sucuri/sucuri-settings.php
+<?php exit(0); ?>
+{"sucuriscan_cloudproxy_apikey":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","sucuriscan_addr_header":"REMOTE_ADDR","sucuriscan_notify_to":"alerts@example.com"}
+EOF
+
+wp option delete sucuriscan_secret_cloudproxy_apikey_enc
+wp option delete sucuriscan_secret_cloudproxy_apikey


### PR DESCRIPTION
This pull request implements a significant update to how the plugin stores and manages the WAF (Web Application Firewall) API key, migrating from file-based storage to encrypted database options. It includes changes to the plugin code, new and updated end-to-end (E2E) and unit tests, and workflow improvements to support and verify this migration process.