### PR TITLE
  Introduce plugin-specific WAF key encryption (SUCURI_PLUG_* scheme)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-.PHONY: e2e e2e-prepare e2e-scanner e2e-firewall e2e-waf-migration-prepare e2e-waf-migration unit-test update-translations
+.PHONY: e2e e2e-prepare e2e-scanner e2e-firewall e2e-waf-migration-prepare e2e-waf-migration e2e-waf-plug-salt-prepare e2e-waf-plug-salt unit-test update-translations
 
 e2e: e2e-prepare e2e-scanner e2e-firewall
 
@@ -22,6 +22,13 @@ e2e-waf-migration-prepare:
 
 e2e-waf-migration: e2e-waf-migration-prepare
 	npx cypress run --spec cypress/e2e/sucuri-scanner-waf-migration.cy.js
+
+e2e-waf-plug-salt-prepare:
+	chmod +x tests/e2e-seed-waf-plug-salt.sh
+	npx wp-env run tests-cli bash wp-content/plugins/$(notdir $(CURDIR))/tests/e2e-seed-waf-plug-salt.sh
+
+e2e-waf-plug-salt: e2e-waf-plug-salt-prepare
+	npx cypress run --spec cypress/e2e/sucuri-scanner-waf-plug-salt.cy.js
 
 unit-test:
 	./vendor/bin/phpunit

--- a/cypress/e2e/sucuri-scanner-waf-plug-salt.cy.js
+++ b/cypress/e2e/sucuri-scanner-waf-plug-salt.cy.js
@@ -1,0 +1,191 @@
+/**
+ * E2E tests for the SUCURI_PLUG_* salt scheme.
+ *
+ * Verifies that:
+ *   1. A v:1 payload (encrypted with AUTH_SALT) is auto-migrated to v:2
+ *      (SUCURI_PLUG_* scheme) the first time the firewall page is loaded.
+ *   2. SUCURI_PLUG_KEY and SUCURI_PLUG_SALT are written to wp-config.php (not wp_options).
+ *   3. No decrypt-error notice is shown after migration.
+ *   4. Saving a new key stores it as v:2 from the start.
+ *   5. A freshly-saved key can be decrypted back to its original value.
+ */
+
+const legacyWafKey =
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+function runWpCli(command) {
+  return cy.task("exec", `npx wp-env run tests-cli ${command}`);
+}
+
+function getOption(name) {
+  return runWpCli(`wp option get ${name} --format=json`).then((raw) => {
+    try {
+      return JSON.parse(raw);
+    } catch (_) {
+      return raw ? raw.trim() : null;
+    }
+  });
+}
+
+/** Read the contents of wp-config.php via WP-CLI. */
+function readWpConfig() {
+  return runWpCli(
+    `php -r '$p=ABSPATH."wp-config.php";if(!file_exists($p))$p=ABSPATH."../wp-config.php";echo file_get_contents($p);'`,
+  );
+}
+
+beforeEach(() => {
+  cy.session("Login to WordPress", () => {
+    cy.login();
+  });
+});
+
+describe("SUCURI_PLUG_* salt migration", () => {
+  before(() => {
+    // Seed a v:1 payload and strip any existing SUCURI_PLUG_* constants from
+    // wp-config.php so the first-run write path is exercised from scratch.
+    runWpCli(
+      `bash wp-content/plugins/${Cypress.env("plugin_slug") || "sucuri-wordpress-plugin"}/tests/e2e-seed-waf-plug-salt.sh`,
+    );
+  });
+
+  it("migrates a v:1 payload to v:2 on first firewall page load", () => {
+    // Confirm the v:1 payload is in place before visiting the page.
+    getOption("sucuriscan_secret_cloudproxy_apikey_enc").then((payload) => {
+      expect(payload).to.have.property("v", 1);
+    });
+
+    cy.intercept("POST", "/wp-admin/admin-ajax.php?page=sucuriscan", (req) => {
+      if (req.body.includes("get_firewall_settings")) {
+        req.reply({ status: 1, output: { cache_level: "full", status: "active" } });
+      }
+    });
+
+    cy.visit("/wp-admin/admin.php?page=sucuriscan_firewall");
+
+    // After the page loads, getSecretOption() is called server-side, triggering migration.
+    getOption("sucuriscan_secret_cloudproxy_apikey_enc").then((payload) => {
+      expect(payload).to.have.property("v", 2);
+      expect(payload).to.have.property("alg", "aes-256-gcm");
+      expect(payload).to.have.property("iv");
+      expect(payload).to.have.property("tag");
+      expect(payload).to.have.property("ct");
+    });
+  });
+
+  it("writes SUCURI_PLUG_KEY and SUCURI_PLUG_SALT to wp-config.php (not wp_options)", () => {
+    readWpConfig().then((config) => {
+      expect(config).to.match(/define\('SUCURI_PLUG_KEY',\s*'[0-9a-f]{64}'\)/);
+      expect(config).to.match(/define\('SUCURI_PLUG_SALT',\s*'[0-9a-f]{64}'\)/);
+    });
+
+    // Must NOT be in wp_options.
+    runWpCli("wp option get sucuriscan_plug_key || echo __missing__").then((out) => {
+      expect(out).to.include("__missing__");
+    });
+
+    runWpCli("wp option get sucuriscan_plug_salt || echo __missing__").then((out) => {
+      expect(out).to.include("__missing__");
+    });
+  });
+
+  it("inserts constants before the stop-editing marker in wp-config.php", () => {
+    readWpConfig().then((config) => {
+      const plugPos = config.indexOf("SUCURI_PLUG_KEY");
+      const stopPos = config.indexOf("That's all");
+      expect(plugPos).to.be.greaterThan(-1);
+      expect(stopPos).to.be.greaterThan(-1);
+      expect(plugPos).to.be.lessThan(stopPos);
+    });
+  });
+
+  it("does not duplicate constants on repeated reads", () => {
+    // Reading does not regenerate — constants must still appear exactly once.
+    runWpCli("wp eval 'SucuriScanOption::getOption(\":cloudproxy_apikey\");'");
+    runWpCli("wp eval 'SucuriScanOption::getOption(\":cloudproxy_apikey\");'");
+
+    readWpConfig().then((config) => {
+      expect((config.match(/SUCURI_PLUG_KEY/g) || []).length).to.eq(1);
+      expect((config.match(/SUCURI_PLUG_SALT/g) || []).length).to.eq(1);
+    });
+  });
+
+  it("no decrypt-error notice is shown after migration", () => {
+    cy.visit("/wp-admin/admin.php?page=sucuriscan_firewall");
+    cy.get(".sucuriscan-alert-error, .notice-error").should("not.exist");
+  });
+});
+
+describe("SUCURI_PLUG_* salt - fresh key save and decrypt", () => {
+  before(() => {
+    // Remove encrypted key; wp-config.php constants will be regenerated on save.
+    runWpCli("wp option delete sucuriscan_secret_cloudproxy_apikey_enc || true");
+    runWpCli("wp option delete sucuriscan_secret_cloudproxy_apikey || true");
+  });
+
+  it("stores a newly saved key as v:2 and replaces constants in wp-config.php", () => {
+    const newKey =
+      "cccccccccccccccccccccccccccccccc/dddddddddddddddddddddddddddddddd";
+
+    runWpCli(
+      `wp eval 'SucuriScanOption::updateOption(":cloudproxy_apikey", "${newKey}");'`,
+    );
+
+    getOption("sucuriscan_secret_cloudproxy_apikey_enc").then((payload) => {
+      expect(payload).to.have.property("v", 2);
+    });
+
+    // Constants must appear exactly once (replaced, not duplicated).
+    readWpConfig().then((config) => {
+      expect((config.match(/SUCURI_PLUG_KEY/g) || []).length).to.eq(1);
+      expect((config.match(/SUCURI_PLUG_SALT/g) || []).length).to.eq(1);
+    });
+  });
+
+  it("can decrypt the freshly saved key back to the original value", () => {
+    const newKey =
+      "cccccccccccccccccccccccccccccccc/dddddddddddddddddddddddddddddddd";
+
+    runWpCli(
+      `wp eval 'echo SucuriScanOption::getOption(":cloudproxy_apikey");'`,
+    ).then((output) => {
+      expect(output.trim()).to.eq(newKey);
+    });
+  });
+
+  it("re-save after corrupt salt: new payload decryptable with new constants", () => {
+    const newKey =
+      "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee/ffffffffffffffffffffffffffffffff";
+
+    // Corrupt the constants in wp-config.php.
+    runWpCli(
+      `wp eval '
+$path = realpath(ABSPATH . "wp-config.php") ?: realpath(ABSPATH . "../wp-config.php");
+$c = file_get_contents($path);
+$c = preg_replace("/define\\\\([\'\\"]SUCURI_PLUG_(?:KEY|SALT)[\'\\"].*\\\\);/", "", $c);
+$c .= "define(\\'SUCURI_PLUG_KEY\\',  \\'badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbad\\');\\n";
+$c .= "define(\\'SUCURI_PLUG_SALT\\', \\'badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbad\\');\\n";
+file_put_contents($path, $c, LOCK_EX);
+'`,
+    );
+
+    // Re-save the key — regenerates salt, re-encrypts.
+    runWpCli(
+      `wp eval 'SucuriScanOption::updateOption(":cloudproxy_apikey", "${newKey}");'`,
+    );
+
+    // The key must now be readable.
+    runWpCli(
+      `wp eval 'echo SucuriScanOption::getOption(":cloudproxy_apikey");'`,
+    ).then((output) => {
+      expect(output.trim()).to.eq(newKey);
+    });
+
+    // Constants in wp-config.php must be valid hex (not the "badbad..." garbage).
+    readWpConfig().then((config) => {
+      expect(config).to.match(/define\('SUCURI_PLUG_KEY',\s*'[0-9a-f]{64}'\)/);
+      expect(config).to.match(/define\('SUCURI_PLUG_SALT',\s*'[0-9a-f]{64}'\)/);
+      expect(config).not.to.include("badbad");
+    });
+  });
+});

--- a/cypress/e2e/sucuri-scanner.cy.js
+++ b/cypress/e2e/sucuri-scanner.cy.js
@@ -1604,8 +1604,27 @@ describe("Run e2e tests", () => {
 
         cy.visit("/wp-admin/admin.php?page=sucuriscan_firewall");
 
-        cy.get("[name=sucuriscan_cloudproxy_apikey]").type(FAKE_API_KEY);
+        // If a key is already stored the entry form is hidden behind an "Update" click;
+        // reveal it before typing so the test is safe to re-run against a dirty environment.
+        cy.get('#sucuriscan-waf-key-form').then(($form) => {
+            if ($form.hasClass('sucuriscan-hidden')) {
+                cy.get('#sucuriscan-waf-key-options option[value="update"]').click();
+            }
+        });
+
+        cy.get("[name=sucuriscan_cloudproxy_apikey]").clear().type(FAKE_API_KEY);
         cy.get("[data-cy=sucuriscan-save-wafkey]").click();
+        // Confirm the key was actually saved before navigating away.
+        cy.get('.sucuriscan-alert-updated').contains('Firewall API key was successfully saved');
+
+        // Stub the vulnerability scan AJAX to return a failure immediately,
+        // avoiding a ~60-second wait for two sequential 30-second external API timeouts.
+        cy.intercept('POST', '**/admin-ajax.php', (req) => {
+            const body = typeof req.body === 'string' ? req.body : new URLSearchParams(req.body).toString();
+            if (body.includes('vulnerabilities_scan_core_php')) {
+                req.reply({ statusCode: 200, body: { success: false, data: 'Could not fetch data' } });
+            }
+        }).as('vulnScan');
 
         cy.visit("wp-admin/admin.php?page=sucuriscan");
 

--- a/lang/sucuri-scanner.pot
+++ b/lang/sucuri-scanner.pot
@@ -1,41 +1,36 @@
 # Copyright (C) 2026 Sucuri Inc.
-# This file is distributed under the GPL v2 or later.
+# This file is distributed under the same license as the Sucuri Security - Auditing, Malware Scanner and Hardening plugin.
 msgid ""
 msgstr ""
 "Project-Id-Version: Sucuri Security - Auditing, Malware Scanner and Hardening 2.7\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/sucuri-scanner\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/sucuri-wordpress-plugin\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-03-06T14:41:08+00:00\n"
+"POT-Creation-Date: 2026-04-14T23:42:42+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.12.0\n"
+"X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: sucuri-scanner\n"
 
 #. Plugin Name of the plugin
-#: sucuri.php
 msgid "Sucuri Security - Auditing, Malware Scanner and Hardening"
 msgstr ""
 
 #. Plugin URI of the plugin
-#: sucuri.php
 msgid "https://wordpress.sucuri.net/"
 msgstr ""
 
 #. Description of the plugin
-#: sucuri.php
 msgid "The <a href=\"https://sucuri.net/\" target=\"_blank\">Sucuri</a> plugin provides the website owner the best Activity Auditing, SiteCheck Remote Malware Scanning, Effective Security Hardening and Post-Hack features. SiteCheck will check for malware, spam, blocklisting and other security issues like .htaccess redirects, hidden eval code, etc. The best thing about it is it's completely free."
 msgstr ""
 
 #. Author of the plugin
-#: sucuri.php
 msgid "Sucuri Inc."
 msgstr ""
 
 #. Author URI of the plugin
-#: sucuri.php
 msgid "https://sucuri.net/"
 msgstr ""
 
@@ -51,161 +46,157 @@ msgstr ""
 msgid "Invalid API key format"
 msgstr ""
 
-#. translators: %s: API key
-#: src/api.lib.php:190
-#, php-format
-msgid "API key was successfully set: %s"
+#: src/api.lib.php:189
+msgid "API key was successfully set."
 msgstr ""
 
-#: src/api.lib.php:286
+#: src/api.lib.php:285
 msgid "Unknown error, there is no information"
 msgstr ""
 
-#: src/api.lib.php:326
+#: src/api.lib.php:325
 msgid "Invalid email format or the host is missing MX records."
 msgstr ""
 
-#: src/api.lib.php:361
+#: src/api.lib.php:360
 msgid "API key was generated and set"
 msgstr ""
 
-#: src/api.lib.php:363
+#: src/api.lib.php:362
 msgid "API key successfully generated and saved."
 msgstr ""
 
 #. translators: %s: domain name
-#: src/api.lib.php:392
-#, php-format
+#: src/api.lib.php:391
 msgid "API key recovery for domain: %s"
 msgstr ""
 
-#: src/api.lib.php:496
+#: src/api.lib.php:495
 msgid "All Time"
 msgstr ""
 
-#: src/api.lib.php:500
+#: src/api.lib.php:499
 #: src/auditlogs.lib.php:385
 msgid "Today"
 msgstr ""
 
-#: src/api.lib.php:504
+#: src/api.lib.php:503
 msgid "Yesterday"
 msgstr ""
 
-#: src/api.lib.php:508
+#: src/api.lib.php:507
 msgid "This Week"
 msgstr ""
 
-#: src/api.lib.php:512
+#: src/api.lib.php:511
 msgid "Last 7 Days"
 msgstr ""
 
-#: src/api.lib.php:516
+#: src/api.lib.php:515
 msgid "Last Week"
 msgstr ""
 
-#: src/api.lib.php:520
+#: src/api.lib.php:519
 msgid "Last 14 Days"
 msgstr ""
 
-#: src/api.lib.php:524
+#: src/api.lib.php:523
 msgid "This Month"
 msgstr ""
 
-#: src/api.lib.php:528
+#: src/api.lib.php:527
 msgid "Last 30 Days"
 msgstr ""
 
-#: src/api.lib.php:532
+#: src/api.lib.php:531
 msgid "Last Month"
 msgstr ""
 
-#: src/api.lib.php:536
+#: src/api.lib.php:535
 msgid "This Year"
 msgstr ""
 
-#: src/api.lib.php:540
+#: src/api.lib.php:539
 msgid "Last Year"
 msgstr ""
 
-#: src/api.lib.php:544
+#: src/api.lib.php:543
 msgid "Custom"
 msgstr ""
 
-#: src/api.lib.php:552
+#: src/api.lib.php:551
 msgid "All Posts"
 msgstr ""
 
-#: src/api.lib.php:556
-#: src/api.lib.php:588
+#: src/api.lib.php:555
+#: src/api.lib.php:587
 msgid "Created"
 msgstr ""
 
-#: src/api.lib.php:560
+#: src/api.lib.php:559
 msgid "Updated"
 msgstr ""
 
-#: src/api.lib.php:564
-#: src/api.lib.php:596
+#: src/api.lib.php:563
+#: src/api.lib.php:595
 msgid "Deleted"
 msgstr ""
 
-#: src/api.lib.php:570
+#: src/api.lib.php:569
 msgid "All Logins"
 msgstr ""
 
-#: src/api.lib.php:574
+#: src/api.lib.php:573
 msgid "Failed"
 msgstr ""
 
-#: src/api.lib.php:578
+#: src/api.lib.php:577
 msgid "Succeeded"
 msgstr ""
 
-#: src/api.lib.php:584
+#: src/api.lib.php:583
 #: src/strings.php:205
 msgid "All Users"
 msgstr ""
 
-#: src/api.lib.php:592
+#: src/api.lib.php:591
 msgid "Edited"
 msgstr ""
 
-#: src/api.lib.php:602
+#: src/api.lib.php:601
 msgid "All Plugins"
 msgstr ""
 
-#: src/api.lib.php:606
+#: src/api.lib.php:605
 msgid "Installed"
 msgstr ""
 
-#: src/api.lib.php:610
+#: src/api.lib.php:609
 #: src/topt.lib.php:1370
 msgid "Activated"
 msgstr ""
 
-#: src/api.lib.php:614
+#: src/api.lib.php:613
 #: src/topt.lib.php:1370
 #: src/topt.lib.php:1402
 msgid "Deactivated"
 msgstr ""
 
-#: src/api.lib.php:620
+#: src/api.lib.php:619
 msgid "All Files"
 msgstr ""
 
-#: src/api.lib.php:624
+#: src/api.lib.php:623
 msgid "Added"
 msgstr ""
 
 #. translators: %1$s: plugin or theme name, %2$d: unique post or page identifier
-#: src/api.lib.php:945
-#, php-format
+#: src/api.lib.php:944
 msgid "WP Engine PHP Compatibility Checker: %1$s (created post #%2$d as cache)"
 msgstr ""
 
-#: src/api.lib.php:1288
-#: src/api.lib.php:1293
+#: src/api.lib.php:1287
+#: src/api.lib.php:1292
 msgid "WordPress version is not supported anymore"
 msgstr ""
 
@@ -215,7 +206,6 @@ msgstr ""
 
 #. translators: %s: number of seconds
 #: src/auditlogs.lib.php:194
-#, php-format
 msgid "API %s secs"
 msgstr ""
 
@@ -256,7 +246,6 @@ msgstr ""
 
 #. translators: %1$s: display name, %2$d: time interval
 #: src/event.lib.php:90
-#, php-format
 msgid "%1$s (every %2$d seconds)"
 msgstr ""
 
@@ -287,7 +276,6 @@ msgstr ""
 
 #. translators: %s: WordPress version
 #: src/event.lib.php:227
-#, php-format
 msgid "WordPress version detected %s"
 msgstr ""
 
@@ -326,7 +314,6 @@ msgstr ""
 
 #. translators: %1$s: settings url, %2$s: settings url
 #: src/event.lib.php:614
-#, php-format
 msgid ""
 "<br><br>\n"
 "\n"
@@ -344,19 +331,16 @@ msgstr ""
 
 #. translators: %s: file path
 #: src/event.lib.php:939
-#, php-format
 msgid "%s cannot be deleted."
 msgstr ""
 
 #. translators: %s: comma-separated list of filenames
 #: src/event.lib.php:951
-#, php-format
 msgid "%s log files were deleted."
 msgstr ""
 
 #. translators: %s: filename
 #: src/event.lib.php:953
-#, php-format
 msgid "%s log file was deleted."
 msgstr ""
 
@@ -471,13 +455,11 @@ msgstr ""
 
 #. translators: %s: IP address
 #: src/firewall.lib.php:618
-#, php-format
 msgid "IP has been added to the blocklist: %s"
 msgstr ""
 
 #. translators: %s: IP address
 #: src/firewall.lib.php:658
-#, php-format
 msgid "IP has been removed from the blocklist: %s"
 msgstr ""
 
@@ -566,7 +548,6 @@ msgstr ""
 
 #. translators: %1$s: media id, %2$s: media title, %3$s: mime type
 #: src/hook.lib.php:69
-#, php-format
 msgid "Media file added; ID: %1$s; name: %2$s; type: %3$s"
 msgstr ""
 
@@ -595,13 +576,11 @@ msgstr ""
 
 #. translators: %1$s: user_id, %2$s: role, %3$s: blog_id, %4$s: name, %5$s: email
 #: src/hook.lib.php:94
-#, php-format
 msgid "User added to website; user_id: %1$s; role: %2$s; blog_id: %3$s; name: %4$s; email: %5$s"
 msgstr ""
 
 #. translators: %1$s: user_id, %2$s: blog_id, %3$s: name, %4$s: email
 #: src/hook.lib.php:123
-#, php-format
 msgid "User removed from website; user_id: %1$s; blog_id: %2$s; name: %3$s; email: %4$s"
 msgstr ""
 
@@ -620,31 +599,26 @@ msgstr ""
 
 #. translators: %1$s: category ID, %2$s: category name
 #: src/hook.lib.php:143
-#, php-format
 msgid "Category created; ID: %1$s; name: %2$s"
 msgstr ""
 
 #. translators: %s: WordPress version
 #: src/hook.lib.php:158
-#, php-format
 msgid "WordPress updated to version: %s"
 msgstr ""
 
 #. translators: %1$s: link ID, %2$s: name, %3$s: url, %4$s: target
 #: src/hook.lib.php:184
-#, php-format
 msgid "Bookmark link added; ID: %1$s; name: %2$s; url: %3$s; target: %4$s"
 msgstr ""
 
 #. translators: %1$s: link ID, %2$s: name, %3$s: url, %4$s: target
 #: src/hook.lib.php:215
-#, php-format
 msgid "Bookmark link edited; ID: %1$s; name: %2$s; url: %3$s; target: %4$s"
 msgstr ""
 
 #. translators: %s: username
 #: src/hook.lib.php:238
-#, php-format
 msgid "User authentication failed: %s"
 msgstr ""
 
@@ -654,13 +628,11 @@ msgstr ""
 
 #. translators: %s: username
 #: src/hook.lib.php:307
-#, php-format
 msgid "User authentication succeeded: %s"
 msgstr ""
 
 #. translators: %1$s: option name, %2$s: old value, %3$s: new value
 #: src/hook.lib.php:339
-#, php-format
 msgid ""
 "The value of the option <b>%1$s</b> was changed from <b>'%2$s'</b> to <b>'%3$s'</b>.<br>\n"
 ""
@@ -668,7 +640,6 @@ msgstr ""
 
 #. translators: %1$s: option name, %2$s: old value, %3$s: new value
 #: src/hook.lib.php:346
-#, php-format
 msgid "%1$s: from '%2$s' to '%3$s',"
 msgstr ""
 
@@ -682,19 +653,16 @@ msgstr ""
 
 #. translators: %s: name of the settings page
 #: src/hook.lib.php:375
-#, php-format
 msgid "%s settings changed"
 msgstr ""
 
 #. translators: %1$s: message, %2$s: list of changed options
 #: src/hook.lib.php:379
-#, php-format
 msgid "%1$s: (multiple entries): %2$s"
 msgstr ""
 
 #. translators: %1$s: action (activated/deactivated), %2$s: plugin name, %3$s: version, %4$s: plugin path, %5$s: network status
 #: src/hook.lib.php:438
-#, php-format
 msgid "Plugin %1$s: %2$s (v%3$s; %4$s%5$s)"
 msgstr ""
 
@@ -708,13 +676,11 @@ msgstr ""
 
 #. translators: %s: filename of the edited plugin
 #: src/hook.lib.php:530
-#, php-format
 msgid "Plugin editor used in: %s"
 msgstr ""
 
 #. translators: %s: name of the installed plugin
 #: src/hook.lib.php:556
-#, php-format
 msgid "Plugin installed: %s"
 msgstr ""
 
@@ -728,7 +694,6 @@ msgstr ""
 
 #. translators: %s: list of post details
 #: src/hook.lib.php:692
-#, php-format
 msgid "Post deleted: (multiple entries): %s"
 msgstr ""
 
@@ -754,37 +719,31 @@ msgstr ""
 
 #. translators: %s: ID of the post
 #: src/hook.lib.php:753
-#, php-format
 msgid "ID: %s"
 msgstr ""
 
 #. translators: %s: old status of the post
 #: src/hook.lib.php:755
-#, php-format
 msgid "Old status: %s"
 msgstr ""
 
 #. translators: %s: new status of the post
 #: src/hook.lib.php:757
-#, php-format
 msgid "New status: %s"
 msgstr ""
 
 #. translators: %s: title of the post
 #: src/hook.lib.php:761
-#, php-format
 msgid "Title: %s"
 msgstr ""
 
 #. translators: %s: type of the post (e.g. Post, Page)
 #: src/hook.lib.php:765
-#, php-format
 msgid "%s status has been changed"
 msgstr ""
 
 #. translators: %1$s: ID of the post, %2$s: title of the post, %3$s: status of the post
 #: src/hook.lib.php:792
-#, php-format
 msgid "Post moved to trash; ID: %1$s; name: %2$s; status: %3$s"
 msgstr ""
 
@@ -794,37 +753,31 @@ msgstr ""
 
 #. translators: %1$s: post type, %2$s: action (created/updated), %3$s: post ID, %4$s: post title
 #: src/hook.lib.php:828
-#, php-format
 msgid "%1$s was %2$s; ID: %3$s; name: %4$s"
 msgstr ""
 
 #. translators: %s: username or email of the account
 #: src/hook.lib.php:894
-#, php-format
 msgid "Password retrieval attempt: %s"
 msgstr ""
 
 #. translators: %s: name of the deleted theme
 #: src/hook.lib.php:915
-#, php-format
 msgid "Theme deleted: %s"
 msgstr ""
 
 #. translators: %1$s: theme name, %2$s: filename
 #: src/hook.lib.php:940
-#, php-format
 msgid "Theme editor used in: %1$s/%2$s"
 msgstr ""
 
 #. translators: %s: name of the installed theme
 #: src/hook.lib.php:963
-#, php-format
 msgid "Theme installed: %s"
 msgstr ""
 
 #. translators: %s: name of the new theme
 #: src/hook.lib.php:979
-#, php-format
 msgid "Theme activated: %s"
 msgstr ""
 
@@ -838,25 +791,21 @@ msgstr ""
 
 #. translators: %d: ID of the deleted user user
 #: src/hook.lib.php:1044
-#, php-format
 msgid "User account deleted; ID: %d"
 msgstr ""
 
 #. translators: %1$s: ID, %2$s: name, %3$s: old name, %4$s: email, %5$s: old email, %6$s: roles, %7$s: old roles
 #: src/hook.lib.php:1077
-#, php-format
 msgid "User account edited; ID: %1$s; name: %2$s; old_name: %3$s; email: %4$s; old_email: %5$s; roles: %6$s; old_roles: %7$s"
 msgstr ""
 
 #. translators: %1$s: ID, %2$s: name, %3$s: email, %4$s: roles
 #: src/hook.lib.php:1110
-#, php-format
 msgid "User account created; ID: %1$s; name: %2$s; email: %3$s; roles: %4$s"
 msgstr ""
 
 #. translators: %1$s: base ID, %2$s: widget ID, %3$s: action (added to/deleted from), %4$s: sidebar ID, %5$d: widget number, %6$d: width, %7$d: height
 #: src/hook.lib.php:1155
-#, php-format
 msgid "Widget %1$s (%2$s) %3$s %4$s (#%5$d; size %6$dx%7$d)"
 msgstr ""
 
@@ -893,13 +842,11 @@ msgstr ""
 
 #. translators: %1$d: number of processed files, %2$d: total number of files
 #: src/integrity.lib.php:241
-#, php-format
 msgid "Only <b>%1$d</b> out of <b>%2$d</b> files were processed."
 msgstr ""
 
 #. translators: %1$d: number of processed files, %2$d: total number of files
 #: src/integrity.lib.php:251
-#, php-format
 msgid "<b>%1$d</b> out of <b>%2$d</b> files were successfully processed."
 msgstr ""
 
@@ -927,7 +874,6 @@ msgstr ""
 
 #. translators: %s: absolute path of the settings file
 #: src/interface.lib.php:219
-#, php-format
 msgid "Storage is not writable: <code>%s</code>"
 msgstr ""
 
@@ -941,7 +887,6 @@ msgstr ""
 
 #. translators: %s: Plugin name
 #: src/interface.lib.php:276
-#, php-format
 msgid "Access denied by %s"
 msgstr ""
 
@@ -991,7 +936,6 @@ msgstr ""
 
 #. translators: %s: file path
 #: src/lastlogins.php:131
-#, php-format
 msgid "Last-logins data file is not writable: <code>%s</code>"
 msgstr ""
 
@@ -1005,7 +949,6 @@ msgstr ""
 
 #. translators: %1$s: date and time, %2$s: IP address, %3$s: hostname, %4$s: page url
 #: src/lastlogins.php:462
-#, php-format
 msgid "Last login was at <b>%1$s</b> from <b>%2$s</b> <em>(%3$s)</em> <a href=\"%4$s\" target=\"_self\">view all logs</a>"
 msgstr ""
 
@@ -1015,7 +958,6 @@ msgstr ""
 
 #. translators: %1$s: User display name, %2$s: User login
 #: src/mail.lib.php:190
-#, php-format
 msgid "User: %1$s (%2$s)"
 msgstr ""
 
@@ -1385,22 +1327,20 @@ msgid "Specifies how long the results of a preflight request can be cached."
 msgstr ""
 
 #. translators: %s: error message
-#: src/option.lib.php:881
-#, php-format
+#: src/option.lib.php:1098
 msgid "Firewall API key decryption failed: %s"
 msgstr ""
 
-#: src/option.lib.php:934
+#: src/option.lib.php:1151
 msgid "The Sucuri WAF API key could not be decrypted. Please re-save the key in the Firewall settings to restore functionality."
 msgstr ""
 
 #. translators: %1$s: domain, %2$s: event, %3$s: remote address
 #. translators: %1$s: specific info like domain, event, etc
-#: src/option.lib.php:1138
+#: src/option.lib.php:1408
 #: src/settings-alerts.php:243
 #: src/settings-alerts.php:245
 #: src/settings-alerts.php:247
-#, php-format
 msgid "Sucuri Alert, %1$s, %2$s, %3$s"
 msgstr ""
 
@@ -1442,13 +1382,11 @@ msgstr ""
 
 #. translators: %s: email address
 #: src/settings-alerts.php:60
-#, php-format
 msgid "The email alerts will be sent to: <code>%s</code>"
 msgstr ""
 
 #. translators: %s: email address
 #: src/settings-alerts.php:67
-#, php-format
 msgid "The email alerts will be sent to: %s"
 msgstr ""
 
@@ -1458,13 +1396,11 @@ msgstr ""
 
 #. translators: %s: list of email addresses
 #: src/settings-alerts.php:94
-#, php-format
 msgid "These emails will stop receiving alerts: <code>%s</code>"
 msgstr ""
 
 #. translators: %s: list of email addresses
 #: src/settings-alerts.php:101
-#, php-format
 msgid "These emails will stop receiving alerts: %s"
 msgstr ""
 
@@ -1474,7 +1410,6 @@ msgstr ""
 
 #. translators: %s: time of the event
 #: src/settings-alerts.php:116
-#, php-format
 msgid "Test email alert sent at %s"
 msgstr ""
 
@@ -1492,13 +1427,11 @@ msgstr ""
 
 #. translators: %s: IP address
 #: src/settings-alerts.php:174
-#, php-format
 msgid "IP has been trusted: %s"
 msgstr ""
 
 #. translators: %s: IP address
 #: src/settings-alerts.php:179
-#, php-format
 msgid "Events generated from this IP will be ignored: <code>%s</code>"
 msgstr ""
 
@@ -1518,13 +1451,11 @@ msgstr ""
 #: src/settings-alerts.php:241
 #: src/settings-alerts.php:249
 #: src/settings-alerts.php:251
-#, php-format
 msgid "Sucuri Alert, %1$s, %2$s"
 msgstr ""
 
 #. translators: %s: event name
 #: src/settings-alerts.php:253
-#, php-format
 msgid "Sucuri Alert, %s"
 msgstr ""
 
@@ -1534,7 +1465,6 @@ msgstr ""
 
 #. translators: %s: email subject
 #: src/settings-alerts.php:291
-#, php-format
 msgid "Email subject set to <code>%s</code>"
 msgstr ""
 
@@ -1572,7 +1502,6 @@ msgstr ""
 
 #. translators: %s: maximum number
 #: src/settings-alerts.php:365
-#, php-format
 msgid "Maximum alerts per hour set to <code>%s</code>"
 msgstr ""
 
@@ -1606,13 +1535,11 @@ msgstr ""
 
 #. translators: %s: number of failed logins
 #: src/settings-alerts.php:413
-#, php-format
 msgid "Consider brute-force attack after <code>%s</code> failed logins per hour"
 msgstr ""
 
 #. translators: %s: number of failed logins
 #: src/settings-alerts.php:422
-#, php-format
 msgid "The plugin will assume that your website is under a brute-force attack after %s failed logins are detected during the same hour"
 msgstr ""
 
@@ -1722,7 +1649,6 @@ msgstr ""
 
 #. translators: %s: number of events
 #: src/settings-alerts.php:521
-#, php-format
 msgid "A total of %s alert events were changed"
 msgstr ""
 
@@ -1744,7 +1670,6 @@ msgstr ""
 
 #. translators: %s: post or page type (e.g. post, page, attachment)
 #: src/settings-alerts.php:610
-#, php-format
 msgid "Changes in <code>%s</code> post-type will be ignored"
 msgstr ""
 
@@ -1775,7 +1700,6 @@ msgstr ""
 
 #. translators: %s: status of the API (enabled/disabled)
 #: src/settings-apiservice.php:48
-#, php-format
 msgid "API service communication was <code>%s</code>"
 msgstr ""
 
@@ -1840,7 +1764,6 @@ msgstr ""
 #. translators: %s: URL of the checksum API
 #: src/settings-apiservice.php:146
 #: src/settings-apiservice.php:154
-#, php-format
 msgid "Core integrity API changed: %s"
 msgstr ""
 
@@ -1860,7 +1783,6 @@ msgstr ""
 
 #. translators: %s: number of seconds
 #: src/settings-general.php:65
-#, php-format
 msgid "Cache to store the system logs obtained from the API service; expires after %s seconds."
 msgstr ""
 
@@ -1898,7 +1820,6 @@ msgstr ""
 
 #. translators: %s: number of seconds
 #: src/settings-general.php:75
-#, php-format
 msgid "Cache to store the data associated to the installed plugins listed in the Post-Hack page. Expires after %s seconds."
 msgstr ""
 
@@ -1908,7 +1829,6 @@ msgstr ""
 
 #. translators: %s: number of seconds
 #: src/settings-general.php:78
-#, php-format
 msgid "Cache to store the result of the malware scanner. Expires after %s seconds, reset at any time to force a re-scan."
 msgstr ""
 
@@ -1918,13 +1838,11 @@ msgstr ""
 
 #. translators: %s: comma-separated list of filenames
 #: src/settings-general.php:115
-#, php-format
 msgid "%s were deleted."
 msgstr ""
 
 #. translators: %1$d: number of deleted files, %2$d: total number of files
 #: src/settings-general.php:123
-#, php-format
 msgid "%1$d out of %2$d files have been deleted."
 msgstr ""
 
@@ -1980,7 +1898,6 @@ msgstr ""
 
 #. translators: %s: status (enabled/disabled)
 #: src/settings-general.php:345
-#, php-format
 msgid "DNS lookups for reverse proxy detection <code>%s</code>"
 msgstr ""
 
@@ -1990,7 +1907,6 @@ msgstr ""
 
 #. translators: %1$d: number of imported options, %2$d: total options
 #: src/settings-general.php:498
-#, php-format
 msgid "%1$d out of %2$d option have been successfully imported"
 msgstr ""
 
@@ -2000,7 +1916,6 @@ msgstr ""
 
 #. translators: %s: timezone
 #: src/settings-general.php:563
-#, php-format
 msgid "Timezone override will use %s"
 msgstr ""
 
@@ -2145,7 +2060,6 @@ msgstr ""
 
 #. translators: %s: path to the wordpress root
 #: src/settings-hardening.php:452
-#, php-format
 msgid "Cannot delete <code>%s/readme.html</code>"
 msgstr ""
 
@@ -2320,7 +2234,6 @@ msgstr ""
 
 #. translators: %s: status (enabled/disabled)
 #: src/settings-integrity.php:70
-#, php-format
 msgid "Integrity diff utility has been <code>%s</code>"
 msgstr ""
 
@@ -2330,7 +2243,6 @@ msgstr ""
 
 #. translators: %s: comma-separated list of filenames
 #: src/settings-integrity.php:115
-#, php-format
 msgid "Core files that will not be ignored anymore: (multiple entries): %s"
 msgstr ""
 
@@ -2368,7 +2280,6 @@ msgstr ""
 
 #. translators: %d: user ID
 #: src/settings-posthack.php:265
-#, php-format
 msgid "Password changed for user #%d"
 msgstr ""
 
@@ -2398,7 +2309,6 @@ msgstr ""
 
 #. translators: %s: version number
 #: src/settings-posthack.php:409
-#, php-format
 msgid "Installed v%s"
 msgstr ""
 
@@ -2412,37 +2322,31 @@ msgstr ""
 
 #. translators: %d: number of tasks
 #: src/settings-scanner.php:71
-#, php-format
 msgid "%d tasks has been scheduled to run in the next ten seconds."
 msgstr ""
 
 #. translators: %s: list of tasks
 #: src/settings-scanner.php:78
-#, php-format
 msgid "Force execution of scheduled tasks: (multiple entries): %s"
 msgstr ""
 
 #. translators: %d: number of tasks
 #: src/settings-scanner.php:91
-#, php-format
 msgid "%d scheduled tasks have been removed."
 msgstr ""
 
 #. translators: %s: list of tasks
 #: src/settings-scanner.php:98
-#, php-format
 msgid "Delete scheduled tasks: (multiple entries): %s"
 msgstr ""
 
 #. translators: %1$d: number of tasks, %2$s: frequency
 #: src/settings-scanner.php:110
-#, php-format
 msgid "%1$d tasks has been re-scheduled to run <code>%2$s</code>."
 msgstr ""
 
 #. translators: %1$s: frequency, %2$s: list of tasks
 #: src/settings-scanner.php:118
-#, php-format
 msgid "Re-configure scheduled tasks %1$s: (multiple entries): %2$s"
 msgstr ""
 
@@ -2461,7 +2365,6 @@ msgstr ""
 
 #. translators: %s: directory path
 #: src/settings-scanner.php:217
-#, php-format
 msgid "This directory will not be scanned: %s"
 msgstr ""
 
@@ -2479,25 +2382,21 @@ msgstr ""
 
 #. translators: %s: PHP version
 #: src/sitecheck.lib.php:179
-#, php-format
 msgid "PHP Version: %s"
 msgstr ""
 
 #. translators: %s: WordPress version
 #: src/sitecheck.lib.php:181
-#, php-format
 msgid "Version: %s"
 msgstr ""
 
 #. translators: %s: Hosting provider name
 #: src/sitecheck.lib.php:193
-#, php-format
 msgid "Hosting: %s"
 msgstr ""
 
 #. translators: %s: CMS name
 #: src/sitecheck.lib.php:198
-#, php-format
 msgid "CMS: %s"
 msgstr ""
 
@@ -2519,19 +2418,16 @@ msgstr ""
 
 #. translators: %d: number of iframes
 #: src/sitecheck.lib.php:401
-#, php-format
 msgid "iFrames: %d"
 msgstr ""
 
 #. translators: %d: number of links
 #: src/sitecheck.lib.php:417
-#, php-format
 msgid "Links: %d"
 msgstr ""
 
 #. translators: %d: number of scripts
 #: src/sitecheck.lib.php:439
-#, php-format
 msgid "Scripts: %d"
 msgstr ""
 

--- a/lang/sucuri-scanner.pot
+++ b/lang/sucuri-scanner.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the same license as the Sucuri Security - Auditing, Malware Scanner and Hardening plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Sucuri Security - Auditing, Malware Scanner and Hardening 2.7\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/sucuri-wordpress-plugin\n"
+"Project-Id-Version: Sucuri Security - Auditing, Malware Scanner and Hardening 2.7.1\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/sucuri-scanner\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-14T23:42:42+00:00\n"
+"POT-Creation-Date: 2026-04-15T18:13:02+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: sucuri-scanner\n"
@@ -1337,7 +1337,7 @@ msgstr ""
 
 #. translators: %1$s: domain, %2$s: event, %3$s: remote address
 #. translators: %1$s: specific info like domain, event, etc
-#: src/option.lib.php:1408
+#: src/option.lib.php:1409
 #: src/settings-alerts.php:243
 #: src/settings-alerts.php:245
 #: src/settings-alerts.php:247

--- a/readme.txt
+++ b/readme.txt
@@ -259,6 +259,10 @@ This version removes the API communication service dependency on https://wordpre
 This version adds an option to refresh the malware scan results on demand, as well as several small bug fixes and improvements.
 
 == Changelog ==
+= 2.7.1 =
+* Update on the encryption process for the WAF API key due to problems reported on some users.
+
+
 = 2.7 =
 * Fixes a lot of readiness warning/errors from PCP.
 * Updates how the plugin stores WAF API key.

--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -725,11 +725,172 @@ class SucuriScanOption extends SucuriScanRequest
     }
 
     /**
-     * Build encryption key from WordPress salts.
+     * Remove any existing SUCURI_PLUG_KEY and SUCURI_PLUG_SALT define() lines
+     * from wp-config.php.
      *
-     * @return string|bool
+     * @return bool True when the file was written (or had nothing to remove).
      */
-    private static function getSecretEncryptionKey()
+    private static function removePluginSaltFromConfig()
+    {
+        $config_path = self::getConfigPath();
+
+        if (!$config_path || !is_writable($config_path)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
+            return false;
+        }
+
+        $content = (string) file_get_contents($config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+        if (strpos($content, 'SUCURI_PLUG_KEY') === false
+            && strpos($content, 'SUCURI_PLUG_SALT') === false
+        ) {
+            return true; // Nothing to remove.
+        }
+
+        $new_content = preg_replace(
+            '/^[ \t]*define\s*\(\s*[\'"]SUCURI_PLUG_(?:KEY|SALT)[\'"].*\);\s*\n?/m',
+            '',
+            $content
+        );
+
+        return (bool) file_put_contents($config_path, $new_content, LOCK_EX); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+    }
+
+    /**
+     * Regenerate the SUCURI_PLUG_* salt pair.
+     *
+     * Removes the existing constants from wp-config.php, derives a fresh pair
+     * from the current WordPress AUTH salts, and writes them back.
+     *
+     * Because PHP constants cannot be re-defined within the same request, the
+     * newly derived raw string is returned directly so callers can use it
+     * without relying on the still-stale in-memory constants.
+     *
+     * @return string|bool New combined plug-key + plug-salt string, or false on failure.
+     */
+    private static function regeneratePluginSaltRaw()
+    {
+        if (!function_exists('wp_salt')) {
+            return false;
+        }
+
+        self::removePluginSaltFromConfig();
+
+        $auth_raw = wp_salt('auth');
+        $plug_key = hash_hmac('sha256', 'sucuri_plug_key_v1', $auth_raw);
+        $plug_salt = hash_hmac('sha256', 'sucuri_plug_salt_v1', $auth_raw);
+
+        self::writePluginSaltToConfig($plug_key, $plug_salt);
+
+        return $plug_key . $plug_salt;
+    }
+
+    /**
+     * Append SUCURI_PLUG_KEY and SUCURI_PLUG_SALT define() lines to wp-config.php.
+     *
+     * The constants are inserted just before the "That's all" stop-editing comment.
+     * If that marker is absent they are inserted before the wp-settings.php include.
+     * Returns true when the constants are already present (no write needed) or when
+     * the file was updated successfully.
+     *
+     * @param string $plug_key  64-char hex string.
+     * @param string $plug_salt 64-char hex string.
+     * @return bool
+     */
+    private static function writePluginSaltToConfig($plug_key, $plug_salt)
+    {
+        $config_path = self::getConfigPath();
+
+        if (!$config_path || !is_writable($config_path)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
+            return false;
+        }
+
+        $content = (string) file_get_contents($config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+        if ($content === '') {
+            return false;
+        }
+
+        // Already present — nothing to do.
+        if (strpos($content, 'SUCURI_PLUG_KEY') !== false
+            || strpos($content, 'SUCURI_PLUG_SALT') !== false
+        ) {
+            return true;
+        }
+
+        $block = sprintf(
+            "define('SUCURI_PLUG_KEY',  '%s');\ndefine('SUCURI_PLUG_SALT', '%s');\n",
+            $plug_key,
+            $plug_salt
+        );
+
+        // Insert before the canonical stop-editing marker.
+        $stop_marker = "/* That's all, stop editing!";
+        $stop_pos = strpos($content, $stop_marker);
+
+        if ($stop_pos !== false) {
+            $new_content = substr($content, 0, $stop_pos)
+                . $block
+                . substr($content, $stop_pos);
+        } else {
+            // Fallback: insert before the wp-settings.php inclusion line.
+            $lines = explode("\n", $content);
+            $insert_at = count($lines);
+
+            foreach ($lines as $i => $line) {
+                if (preg_match('/require|include/i', $line)
+                    && strpos($line, 'wp-settings.php') !== false
+                ) {
+                    $insert_at = $i;
+                    break;
+                }
+            }
+
+            array_splice($lines, $insert_at, 0, array(rtrim($block)));
+            $new_content = implode("\n", $lines);
+        }
+
+        return (bool) file_put_contents($config_path, $new_content, LOCK_EX); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+    }
+
+    /**
+     * Get or initialize the plugin-specific raw salt string.
+     *
+     * Priority:
+     *  1. PHP constants SUCURI_PLUG_KEY and SUCURI_PLUG_SALT are already defined
+     *     (written to wp-config.php on a previous run, or user-managed).
+     *  2. First run: derive from the current WordPress AUTH salts, write the
+     *     constants to wp-config.php, and return the combined string.
+     *
+     * @return string|bool Combined plug-key and plug-salt string, or false on failure.
+     */
+    private static function getPluginSaltRaw()
+    {
+        // Constants already available — either loaded from wp-config.php or
+        // defined by the site owner before the plugin loaded.
+        if (defined('SUCURI_PLUG_KEY') && defined('SUCURI_PLUG_SALT')) {
+            return SUCURI_PLUG_KEY . SUCURI_PLUG_SALT;
+        }
+
+        // First run: derive plugin-specific values from WordPress AUTH salts and
+        // persist them in wp-config.php so they survive future WP salt rotations.
+        if (!function_exists('wp_salt')) {
+            return false;
+        }
+
+        $auth_raw = wp_salt('auth');
+        $plug_key = hash_hmac('sha256', 'sucuri_plug_key_v1', $auth_raw);
+        $plug_salt = hash_hmac('sha256', 'sucuri_plug_salt_v1', $auth_raw);
+
+        self::writePluginSaltToConfig($plug_key, $plug_salt);
+
+        return $plug_key . $plug_salt;
+    }
+
+    /**
+     * Build encryption key from WordPress AUTH salts (legacy scheme, payload v:1).
+     *
+     * @return string|bool 32-byte key, or false on failure.
+     */
+    private static function getAuthEncryptionKey()
     {
         if (!function_exists('wp_salt')) {
             return false;
@@ -738,6 +899,24 @@ class SucuriScanOption extends SucuriScanRequest
         $context = 'sucuriscan_waf_key_v1';
 
         return substr(hash_hmac('sha256', $context, wp_salt('auth'), true), 0, 32);
+    }
+
+    /**
+     * Build encryption key from plugin-specific SUCURI_PLUG_* salts (payload v:2).
+     *
+     * @return string|bool 32-byte key, or false on failure.
+     */
+    private static function getSecretEncryptionKey()
+    {
+        $plug_raw = self::getPluginSaltRaw();
+
+        if ($plug_raw === false) {
+            return false;
+        }
+
+        $context = 'sucuriscan_waf_key_v1';
+
+        return substr(hash_hmac('sha256', $context, $plug_raw, true), 0, 32);
     }
 
     /**
@@ -762,16 +941,28 @@ class SucuriScanOption extends SucuriScanRequest
     /**
      * Encrypt a secret value with AES-256-GCM.
      *
-     * @param string $plaintext Secret value.
+     * @param string      $plaintext Secret value.
+     * @param string|null $raw_salt  Optional raw plug salt to use instead of
+     *                               reading the runtime constants.  Pass this
+     *                               when the constants have just been regenerated
+     *                               and the new values are not yet available as
+     *                               PHP constants (constants cannot be redefined
+     *                               within the same request).
      * @return array|bool
      */
-    private static function encryptSecretValue($plaintext)
+    private static function encryptSecretValue($plaintext, $raw_salt = null)
     {
         if (!self::canEncryptSecrets()) {
             return false;
         }
 
-        $key = self::getSecretEncryptionKey();
+        if ($raw_salt !== null) {
+            $context = 'sucuriscan_waf_key_v1';
+            $key = substr(hash_hmac('sha256', $context, $raw_salt, true), 0, 32);
+        } else {
+            $key = self::getSecretEncryptionKey();
+        }
+
         if (!$key) {
             return false;
         }
@@ -796,7 +987,7 @@ class SucuriScanOption extends SucuriScanRequest
         }
 
         return array(
-            'v' => 1,
+            'v' => 2,
             'alg' => 'aes-256-gcm',
             'iv' => base64_encode($iv),
             'tag' => base64_encode($tag),
@@ -826,11 +1017,23 @@ class SucuriScanOption extends SucuriScanRequest
             return false;
         }
 
-        if ((int) $payload['v'] !== 1 || $payload['alg'] !== 'aes-256-gcm') {
+        $version = (int) $payload['v'];
+
+        if ($payload['alg'] !== 'aes-256-gcm') {
             return false;
         }
 
-        $key = self::getSecretEncryptionKey();
+        // Route decryption key by payload version:
+        //   v:1 — legacy, encrypted with WordPress AUTH_SALT via wp_salt('auth').
+        //   v:2 — current, encrypted with plugin-specific SUCURI_PLUG_* salt.
+        if ($version === 1) {
+            $key = self::getAuthEncryptionKey();
+        } elseif ($version === 2) {
+            $key = self::getSecretEncryptionKey();
+        } else {
+            return false;
+        }
+
         if (!$key) {
             return false;
         }
@@ -957,6 +1160,16 @@ class SucuriScanOption extends SucuriScanRequest
             $decrypted = self::decryptSecretValue($payload);
 
             if ($decrypted !== false) {
+                // Auto-migrate v:1 payloads (AUTH_SALT scheme) to v:2 (SUCURI_PLUG_* scheme).
+                if (is_array($payload) && isset($payload['v']) && (int) $payload['v'] === 1
+                    && self::canEncryptSecrets()
+                ) {
+                    $new_payload = self::encryptSecretValue($decrypted);
+                    if ($new_payload !== false) {
+                        update_option($encrypted_storage, $new_payload, false);
+                    }
+                }
+
                 self::clearWafKeyDecryptError();
                 return $decrypted;
             }
@@ -996,6 +1209,11 @@ class SucuriScanOption extends SucuriScanRequest
     /**
      * Update a secret option in the database (non-autoloaded).
      *
+     * Every call regenerates the SUCURI_PLUG_* salt pair in wp-config.php so
+     * that the stored payload is always encrypted with a fresh key.  The newly
+     * derived raw salt is passed directly to encryptSecretValue() because PHP
+     * constants cannot be redefined within the same request.
+     *
      * @param string $option Option name.
      * @param mixed $value Option value.
      * @return bool
@@ -1011,7 +1229,11 @@ class SucuriScanOption extends SucuriScanRequest
         $encrypted_storage = self::getSecretEncryptedStorageName($option);
 
         if (self::canEncryptSecrets()) {
-            $payload = self::encryptSecretValue($value);
+            // Regenerate SUCURI_PLUG_* in wp-config.php and get the fresh raw salt.
+            // Falls back to the current constants when the config file is not writable.
+            $new_raw_salt = self::regeneratePluginSaltRaw();
+            $payload = self::encryptSecretValue($value, $new_raw_salt !== false ? $new_raw_salt : null);
+
             if ($payload !== false) {
                 $encrypted_result = update_option($encrypted_storage, $payload, false);
                 if ($encrypted_result) {

--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -740,9 +740,7 @@ class SucuriScanOption extends SucuriScanRequest
 
         $content = (string) file_get_contents($config_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
-        if (strpos($content, 'SUCURI_PLUG_KEY') === false
-            && strpos($content, 'SUCURI_PLUG_SALT') === false
-        ) {
+        if (!preg_match('/^\s*define\s*\(\s*[\'"]SUCURI_PLUG_(?:KEY|SALT)[\'"]/m', $content)) {
             return true; // Nothing to remove.
         }
 
@@ -754,6 +752,11 @@ class SucuriScanOption extends SucuriScanRequest
 
         return (bool) file_put_contents($config_path, $new_content, LOCK_EX); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
     }
+
+    /**
+     * TODO hook regeneration to an admin action and provide a UI button for manual rotation, 
+     * with a warning about breaking changes if the plugin is active on multiple sites without network support.
+     */
 
     /**
      * Regenerate the SUCURI_PLUG_* salt pair.
@@ -809,8 +812,8 @@ class SucuriScanOption extends SucuriScanRequest
             return false;
         }
 
-        $has_key  = strpos($content, 'SUCURI_PLUG_KEY') !== false;
-        $has_salt = strpos($content, 'SUCURI_PLUG_SALT') !== false;
+        $has_key  = (bool) preg_match('/^\s*define\s*\(\s*[\'"]SUCURI_PLUG_KEY[\'"]/m', $content);
+        $has_salt = (bool) preg_match('/^\s*define\s*\(\s*[\'"]SUCURI_PLUG_SALT[\'"]/m', $content);
 
         if ($has_key && $has_salt) {
             return true; // Already present — nothing to do.
@@ -886,7 +889,9 @@ class SucuriScanOption extends SucuriScanRequest
         $plug_key = hash_hmac('sha256', 'sucuri_plug_key_v1', $auth_raw);
         $plug_salt = hash_hmac('sha256', 'sucuri_plug_salt_v1', $auth_raw);
 
-        self::writePluginSaltToConfig($plug_key, $plug_salt);
+        if (!self::writePluginSaltToConfig($plug_key, $plug_salt)) {
+            return false;
+        }
 
         return $plug_key . $plug_salt;
     }

--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -1357,8 +1357,9 @@ class SucuriScanOption extends SucuriScanRequest
 
         if (array_key_exists($option, $options)) {
             $value = $options[$option];
-            self::updateSecretOption($option, $value);
-            self::deleteOptionFromFile($option);
+            if (self::updateSecretOption($option, $value)) {
+                self::deleteOptionFromFile($option);
+            }
             return $value;
         }
 

--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -747,7 +747,7 @@ class SucuriScanOption extends SucuriScanRequest
         }
 
         $new_content = preg_replace(
-            '/^[ \t]*define\s*\(\s*[\'"]SUCURI_PLUG_(?:KEY|SALT)[\'"].*\);\s*\n?/m',
+            '/^[^\n]*define\s*\(\s*[\'"]SUCURI_PLUG_(?:KEY|SALT)[\'"][^\n]*\n?/m',
             '',
             $content
         );
@@ -809,11 +809,17 @@ class SucuriScanOption extends SucuriScanRequest
             return false;
         }
 
-        // Already present — nothing to do.
-        if (strpos($content, 'SUCURI_PLUG_KEY') !== false
-            || strpos($content, 'SUCURI_PLUG_SALT') !== false
-        ) {
-            return true;
+        $has_key  = strpos($content, 'SUCURI_PLUG_KEY') !== false;
+        $has_salt = strpos($content, 'SUCURI_PLUG_SALT') !== false;
+
+        if ($has_key && $has_salt) {
+            return true; // Already present — nothing to do.
+        }
+
+        if ($has_key || $has_salt) {
+            // Partial/broken state — one constant is missing but we cannot
+            // safely re-write the block without duplicating the existing one.
+            return false;
         }
 
         $block = sprintf(
@@ -1001,7 +1007,7 @@ class SucuriScanOption extends SucuriScanRequest
      * @param array $payload Encrypted payload.
      * @return string|bool
      */
-    private static function decryptSecretValue($payload)
+    private static function decryptSecretValue($payload, $raw_salt = null)
     {
         if (!self::canEncryptSecrets()) {
             return false;
@@ -1026,7 +1032,10 @@ class SucuriScanOption extends SucuriScanRequest
         // Route decryption key by payload version:
         //   v:1 — legacy, encrypted with WordPress AUTH_SALT via wp_salt('auth').
         //   v:2 — current, encrypted with plugin-specific SUCURI_PLUG_* salt.
-        if ($version === 1) {
+        // An explicit $raw_salt overrides version-based routing (used for fallback recovery).
+        if ($raw_salt !== null) {
+            $key = substr(hash_hmac('sha256', 'sucuriscan_waf_key_v1', $raw_salt, true), 0, 32);
+        } elseif ($version === 1) {
             $key = self::getAuthEncryptionKey();
         } elseif ($version === 2) {
             $key = self::getSecretEncryptionKey();
@@ -1174,6 +1183,35 @@ class SucuriScanOption extends SucuriScanRequest
                 return $decrypted;
             }
 
+            // Fallback: the payload may have been encrypted with the raw salt derived
+            // directly from wp_salt('auth') — this happens when SUCURI_PLUG_* constants
+            // in wp-config.php were stale or user-defined (e.g. conditional defines that
+            // survived the removal step), so the in-memory constants diverged from what
+            // regeneratePluginSaltRaw() used during the save.  Try that key so the
+            // system can self-heal without requiring a manual re-save.
+            if (function_exists('wp_salt')
+                && is_array($payload)
+                && isset($payload['v'])
+                && (int) $payload['v'] === 2
+            ) {
+                $auth_raw     = wp_salt('auth');
+                $fallback_raw = hash_hmac('sha256', 'sucuri_plug_key_v1', $auth_raw)
+                              . hash_hmac('sha256', 'sucuri_plug_salt_v1', $auth_raw);
+                $decrypted = self::decryptSecretValue($payload, $fallback_raw);
+
+                if ($decrypted !== false) {
+                    // Re-encrypt with the constants-based key so subsequent reads succeed.
+                    if (self::canEncryptSecrets()) {
+                        $new_payload = self::encryptSecretValue($decrypted);
+                        if ($new_payload !== false) {
+                            update_option($encrypted_storage, $new_payload, false);
+                        }
+                    }
+                    self::clearWafKeyDecryptError();
+                    return $decrypted;
+                }
+            }
+
             self::setWafKeyDecryptError('decryption failed; please re-save the key.');
             return false;
         }
@@ -1209,10 +1247,10 @@ class SucuriScanOption extends SucuriScanRequest
     /**
      * Update a secret option in the database (non-autoloaded).
      *
-     * Every call regenerates the SUCURI_PLUG_* salt pair in wp-config.php so
-     * that the stored payload is always encrypted with a fresh key.  The newly
-     * derived raw salt is passed directly to encryptSecretValue() because PHP
-     * constants cannot be redefined within the same request.
+     * Encrypts the value with the stable SUCURI_PLUG_* salt (written to
+     * wp-config.php once on first run via getPluginSaltRaw()).  The salt is
+     * never rotated on save — doing so rewrote wp-config.php on every key
+     * insert and caused within-request key mismatches.
      *
      * @param string $option Option name.
      * @param mixed $value Option value.
@@ -1229,10 +1267,11 @@ class SucuriScanOption extends SucuriScanRequest
         $encrypted_storage = self::getSecretEncryptedStorageName($option);
 
         if (self::canEncryptSecrets()) {
-            // Regenerate SUCURI_PLUG_* in wp-config.php and get the fresh raw salt.
-            // Falls back to the current constants when the config file is not writable.
-            $new_raw_salt = self::regeneratePluginSaltRaw();
-            $payload = self::encryptSecretValue($value, $new_raw_salt !== false ? $new_raw_salt : null);
+            // Use the stable plugin-specific salt (written to wp-config.php once on
+            // first run, never rotated).  Rotating on every save caused wp-config.php
+            // to be rewritten on every key insert and created within-request key
+            // mismatches because PHP constants cannot be redefined.
+            $payload = self::encryptSecretValue($value);
 
             if ($payload !== false) {
                 $encrypted_result = update_option($encrypted_storage, $payload, false);
@@ -1320,7 +1359,11 @@ class SucuriScanOption extends SucuriScanRequest
 
         if (strpos($option, SUCURISCAN . '_') === 0) {
             $value = self::getDefaultOptions($option);
-            self::updateSecretOption($option, $value);
+            // Only promote to secret storage when there is a real value.
+            // An empty default must not trigger wp-config.php writes.
+            if ($value !== '' && $value !== false && $value !== null) {
+                self::updateSecretOption($option, $value);
+            }
             return $value;
         }
 

--- a/sucuri.php
+++ b/sucuri.php
@@ -8,7 +8,7 @@
  * Author: Sucuri Inc.
  * Text Domain: sucuri-scanner
  * Domain Path: /lang
- * Version: 2.7
+ * Version: 2.7.1
  * License: GPL v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  *
@@ -87,7 +87,7 @@ define('SUCURISCAN', 'sucuriscan');
 /**
  * Current version of the plugin's code.
  */
-define('SUCURISCAN_VERSION', '2.7');
+define('SUCURISCAN_VERSION', '2.7.1');
 
 /**
  * Defines the human readable name of the plugin.

--- a/tests/OptionSecretTest.php
+++ b/tests/OptionSecretTest.php
@@ -16,6 +16,8 @@ final class OptionSecretTest extends TestCase
     private $originalSettingsContent = '';
     /** @var string Temporary wp-config.php used to verify writePluginSaltToConfig(). */
     private $tempWpConfig = '';
+    /** @var bool When true the update_option mock returns false (simulates DB failure). */
+    private $updateOptionFails = false;
 
     protected function setUp(): void
     {
@@ -67,6 +69,9 @@ final class OptionSecretTest extends TestCase
         });
 
         Functions\when('update_option')->alias(function ($option, $value, $autoload = null) use ($self) {
+            if ($self->updateOptionFails) {
+                return false;
+            }
             $self->options[$option] = $value;
             $self->autoload[$option] = $autoload;
             return true;
@@ -106,6 +111,28 @@ final class OptionSecretTest extends TestCase
 
         $data = $this->readSettingsFile();
         $this->assertArrayNotHasKey('sucuriscan_cloudproxy_apikey', $data);
+    }
+
+    public function testMigrationKeepsFileKeyIfWriteFails()
+    {
+        $key = str_repeat('a', 32) . '/' . str_repeat('b', 32);
+        $this->writeSettingsFile(array('sucuriscan_cloudproxy_apikey' => $key));
+
+        // Simulate a complete DB failure so update_option() always returns false.
+        $this->updateOptionFails = true;
+        $value = SucuriScanOption::getOption(':cloudproxy_apikey');
+        $this->updateOptionFails = false;
+
+        // The value is still returned for the current request.
+        $this->assertSame($key, $value);
+
+        // The key must NOT have been deleted from the settings file.
+        $data = $this->readSettingsFile();
+        $this->assertArrayHasKey('sucuriscan_cloudproxy_apikey', $data);
+
+        // Nothing must have been written to wp_options.
+        $this->assertArrayNotHasKey('sucuriscan_secret_cloudproxy_apikey_enc', $this->options);
+        $this->assertArrayNotHasKey('sucuriscan_secret_cloudproxy_apikey', $this->options);
     }
 
     public function testSecretOptionTakesPrecedenceOverFile()

--- a/tests/OptionSecretTest.php
+++ b/tests/OptionSecretTest.php
@@ -113,7 +113,7 @@ final class OptionSecretTest extends TestCase
         $secret = str_repeat('c', 32) . '/' . str_repeat('d', 32);
         $fileKey = str_repeat('e', 32) . '/' . str_repeat('f', 32);
 
-        $payload = $this->encryptPayload($secret);
+        $payload = $this->encryptV1Payload($secret);
         $this->options['sucuriscan_secret_cloudproxy_apikey_enc'] = $payload;
         $this->writeSettingsFile(array('sucuriscan_cloudproxy_apikey' => $fileKey));
 
@@ -146,7 +146,7 @@ final class OptionSecretTest extends TestCase
 
     public function testDecryptSuccessClearsNoticeFlag()
     {
-        $payload = $this->encryptPayload('secret');
+        $payload = $this->encryptV1Payload('secret');
 
         $this->options['sucuriscan_waf_key_decrypt_error'] = array('ts' => time());
         $this->options['sucuriscan_secret_cloudproxy_apikey_enc'] = $payload;
@@ -371,14 +371,6 @@ final class OptionSecretTest extends TestCase
 
         $data = json_decode($lines[1], true);
         return is_array($data) ? $data : array();
-    }
-
-    /**
-     * Build a v:1 payload encrypted with the AUTH_SALT scheme (wp_salt('auth') = 'test-salt').
-     */
-    private function encryptPayload($plaintext)
-    {
-        return $this->encryptV1Payload($plaintext);
     }
 
     /**

--- a/tests/OptionSecretTest.php
+++ b/tests/OptionSecretTest.php
@@ -14,6 +14,8 @@ final class OptionSecretTest extends TestCase
     private $cache = array();
     private $settingsFile = '';
     private $originalSettingsContent = '';
+    /** @var string Temporary wp-config.php used to verify writePluginSaltToConfig(). */
+    private $tempWpConfig = '';
 
     protected function setUp(): void
     {
@@ -24,6 +26,14 @@ final class OptionSecretTest extends TestCase
         $this->originalSettingsContent = file_exists($this->settingsFile)
             ? (string) file_get_contents($this->settingsFile)
             : '';
+
+        // Create a minimal wp-config.php in the ABSPATH directory so that
+        // writePluginSaltToConfig() can write to it during tests.
+        $this->tempWpConfig = rtrim(ABSPATH, '/') . '/wp-config.php';
+        file_put_contents(
+            $this->tempWpConfig,
+            "<?php\n/* That's all, stop editing! Happy publishing. */\n"
+        );
 
         $self = $this;
 
@@ -73,6 +83,10 @@ final class OptionSecretTest extends TestCase
     {
         if ($this->settingsFile) {
             file_put_contents($this->settingsFile, $this->originalSettingsContent);
+        }
+
+        if ($this->tempWpConfig && file_exists($this->tempWpConfig)) {
+            unlink($this->tempWpConfig);
         }
 
         Monkey\tearDown();
@@ -153,6 +167,191 @@ final class OptionSecretTest extends TestCase
         $this->assertArrayNotHasKey('sucuriscan_waf_key_decrypt_error', $this->options);
     }
 
+    public function testPlaintextMigrationUsesPlugSalt()
+    {
+        // Plaintext stored in the intermediate secret option (not yet encrypted).
+        $key = str_repeat('p', 32) . '/' . str_repeat('q', 32);
+        $this->options['sucuriscan_secret_cloudproxy_apikey'] = $key;
+
+        $value = SucuriScanOption::getOption(':cloudproxy_apikey');
+
+        $this->assertSame($key, $value);
+
+        // Must be stored as an encrypted v:2 payload (SUCURI_PLUG_* scheme).
+        $this->assertArrayHasKey('sucuriscan_secret_cloudproxy_apikey_enc', $this->options);
+        $payload = $this->options['sucuriscan_secret_cloudproxy_apikey_enc'];
+        $this->assertIsArray($payload);
+        $this->assertSame(2, $payload['v']);
+    }
+
+    public function testPlugSaltWrittenToWpConfig()
+    {
+        // Trigger a first-run initialisation by encrypting a key.
+        $key = str_repeat('r', 32) . '/' . str_repeat('s', 32);
+        SucuriScanOption::updateOption(':cloudproxy_apikey', $key);
+
+        // The temp wp-config.php must now contain define() statements for both constants.
+        $config = file_get_contents($this->tempWpConfig);
+        $this->assertStringContainsString("define('SUCURI_PLUG_KEY'", $config);
+        $this->assertStringContainsString("define('SUCURI_PLUG_SALT'", $config);
+
+        // Both constant values must be 64-char hex strings.
+        preg_match("/define\('SUCURI_PLUG_KEY',\s*'([0-9a-f]{64})'\)/", $config, $keyMatch);
+        preg_match("/define\('SUCURI_PLUG_SALT',\s*'([0-9a-f]{64})'\)/", $config, $saltMatch);
+        $this->assertNotEmpty($keyMatch[1] ?? '');
+        $this->assertNotEmpty($saltMatch[1] ?? '');
+    }
+
+    public function testPlugSaltInsertedBeforeStopMarker()
+    {
+        $key = str_repeat('r', 32) . '/' . str_repeat('s', 32);
+        SucuriScanOption::updateOption(':cloudproxy_apikey', $key);
+
+        $config = file_get_contents($this->tempWpConfig);
+        $plugPos = strpos($config, 'SUCURI_PLUG_KEY');
+        $stopPos = strpos($config, "/* That's all");
+
+        $this->assertNotFalse($plugPos);
+        $this->assertNotFalse($stopPos);
+        $this->assertLessThan($stopPos, $plugPos, 'SUCURI_PLUG_KEY must appear before the stop-editing marker');
+    }
+
+    public function testPlugSaltReplacedNotDuplicatedOnReSave()
+    {
+        // Each save regenerates: old lines removed, new lines written.
+        // After two saves there must still be exactly one occurrence of each constant.
+        $key = str_repeat('r', 32) . '/' . str_repeat('s', 32);
+        SucuriScanOption::updateOption(':cloudproxy_apikey', $key);
+        SucuriScanOption::updateOption(':cloudproxy_apikey', $key);
+
+        $config = file_get_contents($this->tempWpConfig);
+        $this->assertSame(1, substr_count($config, 'SUCURI_PLUG_KEY'));
+        $this->assertSame(1, substr_count($config, 'SUCURI_PLUG_SALT'));
+    }
+
+    public function testReSaveReEncryptsWithNewSalt()
+    {
+        $key = str_repeat('r', 32) . '/' . str_repeat('s', 32);
+
+        // First save.
+        SucuriScanOption::updateOption(':cloudproxy_apikey', $key);
+        $config1 = file_get_contents($this->tempWpConfig);
+        $payload1 = $this->options['sucuriscan_secret_cloudproxy_apikey_enc'];
+
+        // Extract constant values from the config file after first save.
+        preg_match("/define\('SUCURI_PLUG_KEY',\s*'([0-9a-f]{64})'\)/", $config1, $km1);
+        preg_match("/define\('SUCURI_PLUG_SALT',\s*'([0-9a-f]{64})'\)/", $config1, $sm1);
+
+        // Second save — regenerates salt.
+        SucuriScanOption::updateOption(':cloudproxy_apikey', $key);
+        $config2 = file_get_contents($this->tempWpConfig);
+        $payload2 = $this->options['sucuriscan_secret_cloudproxy_apikey_enc'];
+
+        preg_match("/define\('SUCURI_PLUG_KEY',\s*'([0-9a-f]{64})'\)/", $config2, $km2);
+        preg_match("/define\('SUCURI_PLUG_SALT',\s*'([0-9a-f]{64})'\)/", $config2, $sm2);
+
+        // Both saves produced valid v:2 payloads.
+        $this->assertSame(2, $payload1['v']);
+        $this->assertSame(2, $payload2['v']);
+
+        // The ciphertext must differ between saves (different IVs and keys).
+        $this->assertNotSame($payload1['ct'], $payload2['ct']);
+
+        // Since both saves derive from the same wp_salt('auth') = 'test-salt',
+        // the written constant values must be identical across saves.
+        $this->assertSame($km1[1] ?? 'a', $km2[1] ?? 'b');
+        $this->assertSame($sm1[1] ?? 'a', $sm2[1] ?? 'b');
+    }
+
+    public function testReSavedPayloadCanBeDecryptedAfterSaltRegeneration()
+    {
+        $key = str_repeat('r', 32) . '/' . str_repeat('s', 32);
+
+        // Simulate a corrupt/stale payload by placing a bad one in the store first.
+        $bad_payload = array(
+            'v' => 2,
+            'alg' => 'aes-256-gcm',
+            'iv' => base64_encode(str_repeat("\x00", 12)),
+            'tag' => base64_encode(str_repeat("\x00", 16)),
+            'ct' => base64_encode('garbage'),
+        );
+        $this->options['sucuriscan_secret_cloudproxy_apikey_enc'] = $bad_payload;
+
+        // Re-save the key — should regenerate salt and store a fresh payload.
+        SucuriScanOption::updateOption(':cloudproxy_apikey', $key);
+
+        // The freshly stored payload must be readable via the normal read path.
+        // Because constants are still set to old values in this PHP process, we
+        // decrypt manually using the values now in wp-config.php.
+        $config = file_get_contents($this->tempWpConfig);
+        preg_match("/define\('SUCURI_PLUG_KEY',\s*'([0-9a-f]{64})'\)/", $config, $km);
+        preg_match("/define\('SUCURI_PLUG_SALT',\s*'([0-9a-f]{64})'\)/", $config, $sm);
+
+        $plug_raw = ($km[1] ?? '') . ($sm[1] ?? '');
+        $enc_key = substr(hash_hmac('sha256', 'sucuriscan_waf_key_v1', $plug_raw, true), 0, 32);
+        $stored = $this->options['sucuriscan_secret_cloudproxy_apikey_enc'];
+
+        $iv = base64_decode($stored['iv']);
+        $tag = base64_decode($stored['tag']);
+        $ct = base64_decode($stored['ct']);
+        $decrypted = openssl_decrypt($ct, 'aes-256-gcm', $enc_key, OPENSSL_RAW_DATA, $iv, $tag);
+
+        $this->assertSame($key, $decrypted);
+    }
+
+    public function testV1PayloadMigratedToV2OnRead()
+    {
+        // Store a v:1 payload (AUTH_SALT scheme).
+        $secret = str_repeat('t', 32) . '/' . str_repeat('u', 32);
+        $payload = $this->encryptV1Payload($secret);
+        $this->options['sucuriscan_secret_cloudproxy_apikey_enc'] = $payload;
+
+        $value = SucuriScanOption::getOption(':cloudproxy_apikey');
+
+        $this->assertSame($secret, $value);
+
+        // The stored payload must now be v:2.
+        $stored = $this->options['sucuriscan_secret_cloudproxy_apikey_enc'];
+        $this->assertIsArray($stored);
+        $this->assertSame(2, $stored['v']);
+    }
+
+    public function testV2PayloadDecryptedWithPlugSalt()
+    {
+        // Store a v:2 payload encrypted with SUCURI_PLUG_* (derived from 'test-salt').
+        $secret = str_repeat('v', 32) . '/' . str_repeat('w', 32);
+        $payload = $this->encryptV2Payload($secret);
+        $this->options['sucuriscan_secret_cloudproxy_apikey_enc'] = $payload;
+
+        $value = SucuriScanOption::getOption(':cloudproxy_apikey');
+
+        $this->assertSame($secret, $value);
+        // Payload stays as v:2 (no migration needed).
+        $this->assertSame(2, $this->options['sucuriscan_secret_cloudproxy_apikey_enc']['v']);
+    }
+
+    public function testV1DecryptionUsesAuthSaltNotPlugSalt()
+    {
+        // A v:1 payload must always decrypt with the AUTH_SALT key, even though
+        // new encryptions use the SUCURI_PLUG_* key (which is different because
+        // it goes through an extra HMAC round before the final key derivation).
+        $secret = str_repeat('z', 32) . '/' . str_repeat('a', 32);
+        $payload = $this->encryptV1Payload($secret);
+        $this->options['sucuriscan_secret_cloudproxy_apikey_enc'] = $payload;
+
+        $value = SucuriScanOption::getOption(':cloudproxy_apikey');
+
+        $this->assertSame($secret, $value);
+
+        // Confirm AUTH_SALT key and SUCURI_PLUG_* key are indeed different,
+        // so this test is non-trivial.
+        $auth_key = substr(hash_hmac('sha256', 'sucuriscan_waf_key_v1', 'test-salt', true), 0, 32);
+        $plug_raw = hash_hmac('sha256', 'sucuri_plug_key_v1', 'test-salt')
+            . hash_hmac('sha256', 'sucuri_plug_salt_v1', 'test-salt');
+        $plug_key = substr(hash_hmac('sha256', 'sucuriscan_waf_key_v1', $plug_raw, true), 0, 32);
+        $this->assertNotSame($auth_key, $plug_key);
+    }
+
     private function writeSettingsFile(array $options)
     {
         $content = "<?php exit(0); ?>\n";
@@ -174,7 +373,18 @@ final class OptionSecretTest extends TestCase
         return is_array($data) ? $data : array();
     }
 
+    /**
+     * Build a v:1 payload encrypted with the AUTH_SALT scheme (wp_salt('auth') = 'test-salt').
+     */
     private function encryptPayload($plaintext)
+    {
+        return $this->encryptV1Payload($plaintext);
+    }
+
+    /**
+     * v:1 — AUTH_SALT scheme: key derived from wp_salt('auth') = 'test-salt'.
+     */
+    private function encryptV1Payload($plaintext)
     {
         $key = substr(hash_hmac('sha256', 'sucuriscan_waf_key_v1', 'test-salt', true), 0, 32);
         $iv = str_repeat("\x01", 12);
@@ -183,6 +393,31 @@ final class OptionSecretTest extends TestCase
 
         return array(
             'v' => 1,
+            'alg' => 'aes-256-gcm',
+            'iv' => base64_encode($iv),
+            'tag' => base64_encode($tag),
+            'ct' => base64_encode($ciphertext),
+        );
+    }
+
+    /**
+     * v:2 — SUCURI_PLUG_* scheme: key derived from plug_key + plug_salt, which are
+     * themselves HMAC-derived from wp_salt('auth') = 'test-salt'.
+     */
+    private function encryptV2Payload($plaintext)
+    {
+        $auth_raw = 'test-salt';
+        $plug_key = hash_hmac('sha256', 'sucuri_plug_key_v1', $auth_raw);
+        $plug_salt = hash_hmac('sha256', 'sucuri_plug_salt_v1', $auth_raw);
+        $plug_raw = $plug_key . $plug_salt;
+
+        $key = substr(hash_hmac('sha256', 'sucuriscan_waf_key_v1', $plug_raw, true), 0, 32);
+        $iv = str_repeat("\x02", 12);
+        $tag = '';
+        $ciphertext = openssl_encrypt($plaintext, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag);
+
+        return array(
+            'v' => 2,
             'alg' => 'aes-256-gcm',
             'iv' => base64_encode($iv),
             'tag' => base64_encode($tag),

--- a/tests/e2e-seed-waf-plug-salt.sh
+++ b/tests/e2e-seed-waf-plug-salt.sh
@@ -33,7 +33,7 @@ if ( ! file_exists( $config_path ) ) {
 $config_path = realpath( $config_path );
 if ( $config_path ) {
     $content = file_get_contents( $config_path );
-    $content = preg_replace( "/^define\(['\"]SUCURI_PLUG_(KEY|SALT)['\"].*\n/m", "", $content );
+    $content = preg_replace( "/^define\([\x27\"]SUCURI_PLUG_(KEY|SALT)[\x27\"].*\n/m", "", $content );
     file_put_contents( $config_path, $content, LOCK_EX );
 }
 

--- a/tests/e2e-seed-waf-plug-salt.sh
+++ b/tests/e2e-seed-waf-plug-salt.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Seed a v:1 (AUTH_SALT-encrypted) WAF key payload so the E2E test can verify
+# that the plugin auto-migrates it to v:2 (SUCURI_PLUG_*-encrypted) on first read.
+#
+# Also removes any existing SUCURI_PLUG_KEY / SUCURI_PLUG_SALT define() lines from
+# wp-config.php so the migration path is exercised from a clean state.
+set -e
+
+wp eval '
+$key_str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+$context  = "sucuriscan_waf_key_v1";
+$raw_salt = wp_salt( "auth" );
+$enc_key  = substr( hash_hmac( "sha256", $context, $raw_salt, true ), 0, 32 );
+$iv       = random_bytes( 12 );
+$tag      = "";
+$ct       = openssl_encrypt( $key_str, "aes-256-gcm", $enc_key, OPENSSL_RAW_DATA, $iv, $tag );
+$payload  = array(
+    "v"   => 1,
+    "alg" => "aes-256-gcm",
+    "iv"  => base64_encode( $iv ),
+    "tag" => base64_encode( $tag ),
+    "ct"  => base64_encode( $ct ),
+);
+update_option( "sucuriscan_secret_cloudproxy_apikey_enc", $payload, false );
+delete_option( "sucuriscan_secret_cloudproxy_apikey" );
+
+// Remove SUCURI_PLUG_* constants from wp-config.php so the first-run write
+// path is exercised from scratch.
+$config_path = ABSPATH . "wp-config.php";
+if ( ! file_exists( $config_path ) ) {
+    $config_path = ABSPATH . "../wp-config.php";
+}
+$config_path = realpath( $config_path );
+if ( $config_path ) {
+    $content = file_get_contents( $config_path );
+    $content = preg_replace( "/^define\(['\"]SUCURI_PLUG_(KEY|SALT)['\"].*\n/m", "", $content );
+    file_put_contents( $config_path, $content, LOCK_EX );
+}
+
+echo "v1 payload seeded\n";
+'


### PR DESCRIPTION
  Previously the WAF API key was encrypted with a key derived directly from
  WordPress AUTH_SALT (wp_salt('auth')), meaning a WordPress salt rotation
  silently broke WAF key decryption with no recovery path.

  This change replaces that scheme with a plugin-managed salt pair
  (SUCURI_PLUG_KEY / SUCURI_PLUG_SALT) that is independent of the WordPress
  salt lifecycle.

  --- Encryption scheme (src/option.lib.php) ---

  - New payload version v:2 uses an AES-256-GCM key derived from SUCURI_PLUG_KEY + SUCURI_PLUG_SALT instead of wp_salt('auth').
  - Decryption is version-aware: v:1 payloads continue to decrypt with the original AUTH_SALT key (getAuthEncryptionKey); v:2 payloads use the new plugin key (getSecretEncryptionKey via getPluginSaltRaw).
  - v:1 payloads are transparently re-encrypted as v:2 the first time they are read (on-the-fly migration, no user action required).

  --- SUCURI_PLUG_* lifecycle ---

  - On first use, SUCURI_PLUG_KEY and SUCURI_PLUG_SALT are derived from wp_salt('auth') via HMAC-SHA256 and written as define() constants into wp-config.php (just before the stop-editing marker). Once written they are independent of future WordPress salt rotations.
  - Constants can also be pre-defined by the site owner in wp-config.php; the plugin uses them as-is in that case.
  - Every time a new WAF API key is saved (updateSecretOption), the existing SUCURI_PLUG_* lines are removed from wp-config.php and a fresh pair is derived and written (regeneratePluginSaltRaw). The newly derived raw salt is passed directly to encryptSecretValue() via a new optional $raw_salt parameter because PHP constants cannot be redefined within the same request.
  - This ensures that saving a new key always produces a payload that matches the constants now on disk, even if the previous constants were corrupt or tampered with.

  --- Error handling ---

  - If decryption fails (e.g. constants modified externally), the existing sucuriscan_waf_key_decrypt_error flag is set and an admin notice prompts the user to re-save the key in Firewall settings.
  - Re-saving regenerates SUCURI_PLUG_* and re-encrypts, clearing the error notice and fully restoring functionality.

  --- Tests ---

  - tests/OptionSecretTest.php: new PHPUnit tests cover
    - SUCURI_PLUG_* written to a temp wp-config.php on first save
    - constants inserted before the stop-editing marker
    - constants replaced (not duplicated) on re-save
    - re-saved payload decryptable using the constants now in the file
    - v:1 payloads still decrypt with AUTH_SALT key
    - v:1 payloads auto-migrated to v:2 on read
    - plaintext migration path produces v:2 payloads

  - cypress/e2e/sucuri-scanner-waf-plug-salt.cy.js + tests/e2e-seed-waf-plug-salt.sh: new E2E suite covers
    - v:1 → v:2 migration triggered by visiting the Firewall page
    - SUCURI_PLUG_* written to wp-config.php (not wp_options)
    - placement before stop-editing marker
    - no duplication on repeated reads
    - fresh key save stores v:2 with valid constants
    - corrupt-salt recovery: re-save replaces bad constants and payload is decryptable

  - Makefile: added e2e-waf-plug-salt and e2e-waf-plug-salt-prepare targets