### PR TITLE
Add "Disable XML-RPC" hardening option; fix fatal error on non-array API messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Sucuri Security is a WordPress plugin (procedural bootstrap + static "class-as-namespace" PHP,
+no framework, no autoloader/Composer classes at runtime — everything is `require_once`d explicitly
+in `sucuri.php`). It provides file integrity monitoring, malware scanning (via the remote SiteCheck
+API), a firewall/WAF integration, security hardening, audit logging, and post-hack recovery tools.
+
+## Commands
+
+### PHP unit tests (PHPUnit 9 + Brain\Monkey for mocking WP functions)
+```sh
+composer install               # installs phpunit, brain/monkey, phpcs, wpcs
+./vendor/bin/phpunit                          # run full suite
+./vendor/bin/phpunit tests/TwoFactorTest.php  # run a single test file
+./vendor/bin/phpunit --filter testMethodName  # run a single test method
+make unit-test                 # same as ./vendor/bin/phpunit
+```
+Tests run with `processIsolation="true"` (see `phpunit.xml`) since the plugin relies heavily on
+global constants/state defined once at bootstrap. Bootstrap is `tests/autoload.php`, which defines
+WP constants (`tests/constants.php`), stubs a minimal set of WordPress functions, and then
+`require`s the same `src/*.lib.php` files loaded by the real plugin (in the same order dependencies
+demand). When a test needs a WP function not already stubbed, either add a `Functions\when(...)`
+mock inside the test (Brain\Monkey), or add a global stub in `tests/autoload.php` if many tests need it.
+
+### End-to-end tests (Cypress + wp-env / Docker)
+```sh
+cp cypress.config.js.example cypress.config.js   # first-time setup, gitignored
+make e2e                # = e2e-prepare + e2e-scanner + e2e-firewall
+make e2e-prepare        # starts wp-env, cleans DB, runs tests/e2e-prepare.sh inside the container
+make e2e-scanner        # npx cypress run --spec cypress/e2e/sucuri-scanner.cy.js
+make e2e-firewall       # npx cypress run --spec cypress/e2e/sucuri-scanner-firewall.cy.js
+make e2e-waf-migration  # seeds via tests/e2e-seed-waf-migration.sh, then runs waf-migration spec
+make e2e-waf-plug-salt  # seeds via tests/e2e-seed-waf-plug-salt.sh, then runs waf-plug-salt spec
+npm run start / npm run stop   # start/stop the wp-env Docker environment directly
+```
+E2E requires Docker (wp-env). Firewall E2E only runs in CI when a `WAF_API_KEY` secret is present.
+
+### Translations
+```sh
+make update-translations   # wp i18n make-pot . lang/sucuri-scanner.pot
+```
+
+### CI
+- `.github/workflows/unit-tests.yml` — `composer install` + `make unit-test` on PHP 8.5.
+- `.github/workflows/end-to-end-tests.yml` — matrix over PHP 7.4/8.0 × latest WordPress, runs the
+  Cypress suites above via wp-env in Docker.
+- `.github/workflows/deploy-to-wordpress-org.yml` — publishes tagged releases to wordpress.org
+  (uses `.wordpress-org/` assets and `.gitattributes` `export-ignore` rules to strip dev files).
+
+There is no lint/format npm script wired up; `composer.json` pulls in `squizlabs/php_codesniffer` and
+`wp-coding-standards/wpcs` as dev dependencies, and `package.json` has `prettier` — apply the
+WordPress PHP coding standard by convention (see existing file headers/style) when phpcs isn't
+directly invocable.
+
+## Architecture
+
+### Bootstrap and load order
+`sucuri.php` is the single plugin entry point read by WordPress. It:
+1. Defines `SUCURISCAN_INIT` and other global constants (paths, cache lifetimes, API URLs/versions).
+   Every other PHP file in `src/` guards itself with `if (!defined('SUCURISCAN_INIT') ...) { 403 }` at
+   the top — these files are never meant to be requested directly.
+2. `require_once`s all `src/*.lib.php` classes in dependency order, then page/ajax handlers
+   (`src/pagehandler.php`), then per-page controllers (`src/lastlogins*.php`, `src/settings*.php`),
+   then `src/globals.php` (hook wiring), then conditionally `src/cli.lib.php` for WP-CLI.
+3. Registers WordPress action/filter hooks, the deactivation/uninstall hooks, and security headers.
+
+`tests/autoload.php` mirrors this require order (a subset — only what's needed for testing) against
+stubbed WP constants/functions, so if you add a new `src/*.lib.php` file with cross-file dependencies,
+you likely need to add its `require` to both `sucuri.php` and `tests/autoload.php`.
+
+### Code organization
+- `src/*.lib.php` — core "library" classes, one class per file, named `SucuriScan<Thing>`
+  (e.g. `SucuriScanOption`, `SucuriScanEvent`, `SucuriScanRequest`, `SucuriScanHardening`,
+  `SucuriScanFirewall`, `SucuriScanIntegrity`, `SucuriScanSiteCheck`). Most public behavior is exposed
+  via `public static function` methods — these are effectively namespaces/modules, not objects with
+  instance state (a few exceptions like `SucuriScanFileInfo` are instantiated).
+- `src/settings-*.php`, `src/lastlogins*.php` — per-admin-page controllers that assemble template data
+  and register that page's own AJAX actions.
+- `src/pagehandler.php` — single AJAX dispatch point. `sucuriscan_ajax_handlers()` maps a
+  `form_action` string to a `[ClassName, method]` (or function) callable; `sucuriscan_ajax()` validates
+  the nonce/capability then dispatches. Adding a new AJAX action means adding an entry here.
+- `src/globals.php` — where all `add_action`/`add_filter` hooks are wired (menu registration, the
+  file/user/theme/plugin change hooks routed through `SucuriScanHook::hook*`, cron schedules).
+- `inc/tpl/*.tpl` — HTML templates rendered by `SucuriScanTemplate`, which does simple pseudo-variable
+  substitution (`%%SUCURI.keyname%%` escaped, `%%%SUCURI.keyname%%%` raw) rather than a real template
+  engine. Naming convention: `*.html.tpl` (full page/section), `*.snippet.tpl` (repeatable row/fragment).
+- `src/option.lib.php` (`SucuriScanOption`) — central settings store. Options are addressed with a
+  `:`-prefixed short name (e.g. `:headers_cors`) that gets expanded to `sucuriscan_<name>` internally;
+  a subset are treated as "secret options" with separate encrypted get/update paths. Read via
+  `SucuriScanOption::getOption(':foo')`, write via `SucuriScanOption::updateOption(':foo', $value)`.
+- `src/event.lib.php` (`SucuriScanEvent`) — audit/event reporting, used throughout to log security
+  events both locally and to the remote Sucuri API.
+- `src/cli.lib.php` — WP-CLI command surface, only loaded when `WP_CLI` is defined.
+- `cypress/` — E2E specs (`cypress/e2e/*.cy.js` for the current Cypress format, plus one legacy spec
+  under `cypress/integration/`), fixtures, and a `plugins/index.js` that wires custom Cypress tasks
+  (e.g. TOTP code generation for 2FA flows).
+
+### Testing conventions
+- Unit tests stub WordPress core functions with `Brain\Monkey\Functions\when(...)` per test in
+  `setUp()`, rather than a full WP test framework — keeps tests fast and dependency-free.
+- Fixtures live in `tests/fixtures/`; `SUCURI_DATA_STORAGE` in `tests/constants.php` points the
+  plugin's data-storage path there during tests.
+- Multiple `*Test.php` files test the same class from different angles (e.g. `IntegrityTest.php` +
+  `IntegrityFilePathTest.php`, `HardeningTest.php` + `HardeningAllowlistRegexTest.php`) — check for a
+  sibling test file before assuming a class is untested.

--- a/inc/tpl/hardening-and-prevention.html.tpl
+++ b/inc/tpl/hardening-and-prevention.html.tpl
@@ -24,6 +24,8 @@
             %%%SUCURI.Settings.Hardening.FileEditor%%%
 
             %%%SUCURI.Settings.Hardening.SecKeyUpdater%%%
+
+            %%%SUCURI.Settings.Hardening.XMLRPC%%%
         </div>
     </div>
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpress@sucuri.net
 Donate Link: https://sucuri.net/
 Tags: malware, security, firewall, scan, spam, virus, sucuri, protection, blocklist, detection, hardening, file integrity
 Requires at least: 3.6
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 2.7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -263,6 +263,8 @@ This version adds an option to refresh the malware scan results on demand, as we
 * Improve the Two-Factor Authentication page to load the users list in pages, so it stays fast and reliable on sites with hundreds or thousands of users (for example, WooCommerce stores).
 * Add a search box to the Two-Factor Authentication page to quickly find users by username, email, or display name.
 * Strengthen input validation, access checks, and output escaping.
+* Add a one-click "Disable XML-RPC" option to the Hardening page to close a common brute-force and pingback-based DDoS attack vector, with a warning if an active plugin (e.g. Jetpack) depends on XML-RPC.
+* Fix a fatal error on PHP 8 when the API returns the "messages" field as a string instead of an array.
 
 = 2.7.3 =
 * Refactor AJAX handler to an explicit dispatch map for improved security and efficiency.

--- a/src/api.lib.php
+++ b/src/api.lib.php
@@ -285,7 +285,7 @@ class SucuriScanAPI extends SucuriScanOption
             return SucuriScanInterface::error(__('Unknown error, there is no information', 'sucuri-scanner'));
         }
 
-        $msg = implode(".\x20", $res['messages']);
+        $msg = implode(".\x20", self::normalizeMessages($res['messages']));
         $raw = $msg; /* Keep a copy of the original message. */
 
         // Special response for invalid API keys.
@@ -326,6 +326,21 @@ class SucuriScanAPI extends SucuriScanOption
         }
 
         return SucuriScanInterface::error($msg);
+    }
+
+    /**
+     * Normalize an API response "messages" value into an array of strings.
+     *
+     * The remote API is expected to return this field as an array, but some
+     * error responses emit a single string instead; implode() requires an
+     * array argument as of PHP 8, so callers must normalize before imploding.
+     *
+     * @param mixed $messages Raw "messages" value from an API response.
+     * @return array            Always an array, safe to pass to implode().
+     */
+    protected static function normalizeMessages($messages)
+    {
+        return is_array($messages) ? $messages : array($messages);
     }
 
     /**

--- a/src/firewall.lib.php
+++ b/src/firewall.lib.php
@@ -611,7 +611,7 @@ class SucuriScanFirewall extends SucuriScanAPI
 
         if ($out && !empty($out['messages'])) {
             $response['ok'] = (bool) ($out['status'] == 1);
-            $response['msg'] = implode(";\x20", $out['messages']);
+            $response['msg'] = implode(";\x20", self::normalizeMessages($out['messages']));
 
             if ($out['status'] == 1) {
                 /* translators: %s: IP address */
@@ -651,7 +651,7 @@ class SucuriScanFirewall extends SucuriScanAPI
         $out = self::apiCallFirewall('POST', $params);
 
         $response['ok'] = (bool) ($out['status'] == 1);
-        $response['msg'] = implode(";\x20", $out['messages']);
+        $response['msg'] = implode(";\x20", self::normalizeMessages($out['messages']));
 
         if ($out['status'] == 1) {
             /* translators: %s: IP address */
@@ -762,14 +762,15 @@ class SucuriScanFirewall extends SucuriScanAPI
         $out = self::clearCache($api_key, $path);
 
         if (is_array($out) && isset($out['messages'])) {
+            $messages = self::normalizeMessages($out['messages']);
             $response = sprintf(
                 '<div class="sucuriscan-inline-alert-%s"><p>%s</p></div>',
                 ($out['status'] == 1) ? 'success' : 'error',
-                implode('<br>', $out['messages'])
+                implode('<br>', $messages)
             );
 
             $context = ($path) ? sprintf("path '%s'", $path) : 'global';
-            $flatMsg = implode('; ', $out['messages']);
+            $flatMsg = implode('; ', $messages);
 
             if ((int) $out['status'] === 1) {
                 SucuriScanEvent::reportInfoEvent(sprintf('Firewall cache clear requested (%s): %s', $context, $flatMsg));

--- a/src/globals.php
+++ b/src/globals.php
@@ -48,6 +48,16 @@ if (defined('SUCURISCAN')) {
     remove_action('wp_head', 'wp_generator');
 
     /**
+     * Hardening: enforce the "Disable XML-RPC" option, if enabled, by filtering
+     * WordPress core's `xmlrpc_enabled` value. The callback re-checks the
+     * persisted `sucuriscan_hardening_xmlrpc` option on every request, so it is
+     * safe to always register this filter unconditionally.
+     *
+     * @see SucuriScanHardeningPage::xmlrpc()
+     */
+    add_filter('xmlrpc_enabled', 'SucuriScanHardening::xmlrpcEnabled');
+
+    /**
      * Run a specific method defined in the plugin's code to locate every
      * directory and file, collect their checksum and file size, and send this
      * information to the Sucuri API service where a security and integrity scan

--- a/src/hardening.lib.php
+++ b/src/hardening.lib.php
@@ -523,4 +523,64 @@ class SucuriScanHardening extends SucuriScan
 
         return $allowlist;
     }
+
+    /**
+     * Plugins known to depend on XML-RPC for core functionality, keyed by the
+     * plugin basename used by is_plugin_active() and mapped to a human-readable
+     * name used in the hardening warning. Add more entries here as they are
+     * identified; no other code needs to change.
+     *
+     * @var array
+     */
+    private static $xmlrpcDependentPlugins = array(
+        'jetpack/jetpack.php' => 'Jetpack',
+    );
+
+    /**
+     * Filters WordPress core's `xmlrpc_enabled` value based on the persisted
+     * "Disable XML-RPC" hardening option.
+     *
+     * Registered unconditionally from globals.php; the option is re-read on
+     * every invocation rather than deciding once at hook-registration time, so
+     * toggling the setting takes effect immediately.
+     *
+     * @param bool $enabled Current XML-RPC enabled state.
+     * @return bool          False if the hardening option is enabled (XML-RPC
+     *                       disabled); otherwise $enabled is returned unchanged.
+     */
+    public static function xmlrpcEnabled($enabled = true)
+    {
+        if (SucuriScanOption::isEnabled(':hardening_xmlrpc')) {
+            return false;
+        }
+
+        return $enabled;
+    }
+
+    /**
+     * Returns the display names of any known XML-RPC-dependent plugins that are
+     * currently active, so the hardening page can warn the admin before they
+     * disable XML-RPC.
+     *
+     * @return array List of human-readable plugin names (empty if none active).
+     */
+    public static function activeXMLRPCDependentPlugins()
+    {
+        if (!function_exists('is_plugin_active')) {
+            include_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+
+        $active = array();
+
+        foreach (self::$xmlrpcDependentPlugins as $basename => $name) {
+            $isActive = is_plugin_active($basename)
+                || (self::isMultiSite() && is_plugin_active_for_network($basename));
+
+            if ($isActive) {
+                $active[] = $name;
+            }
+        }
+
+        return $active;
+    }
 }

--- a/src/option.lib.php
+++ b/src/option.lib.php
@@ -116,6 +116,7 @@ class SucuriScanOption extends SucuriScanRequest
             'sucuriscan_twofactor_mode' => 'disabled',
             'sucuriscan_twofactor_users' => array(),
             'sucuriscan_preferred_theme' => 'dark',
+            'sucuriscan_hardening_xmlrpc' => 'disabled',
             'sucuriscan_headers_cache_control' => 'disabled',
             'sucuriscan_headers_cache_control_options' => array(
                 'front_page' => array(

--- a/src/pagehandler.php
+++ b/src/pagehandler.php
@@ -310,6 +310,7 @@ function sucuriscan_hardening_prevention_page()
     $params['Settings.Hardening.AdminUser'] = SucuriScanHardeningPage::adminuser();
     $params['Settings.Hardening.FileEditor'] = SucuriScanHardeningPage::fileeditor();
     $params['Settings.Hardening.SecKeyUpdater'] = SucuriScanHardeningPage::autoSecretKeyUpdater();
+    $params['Settings.Hardening.XMLRPC'] = SucuriScanHardeningPage::xmlrpc();
     $params['Settings.Hardening.AllowlistPHPFiles'] = SucuriScanHardeningPage::AllowPHPFiles();
     $params['PremiumVisibility'] = SucuriScanInterface::isPremium() ? '' : 'sucuriscan-hidden';
     $params['Theme'] = SucuriScanInterface::getPreferredTheme();

--- a/src/settings-hardening.php
+++ b/src/settings-hardening.php
@@ -702,6 +702,72 @@ class SucuriScanHardeningPage extends SucuriScan
     }
 
     /**
+     * Enable or disable WordPress' XML-RPC interface (xmlrpc.php).
+     *
+     * XML-RPC is a legacy remote API with almost no legitimate use on modern
+     * WordPress sites and is a common brute-force / pingback-based DDoS
+     * amplification vector. This hardening option disables it via the
+     * `xmlrpc_enabled` filter (see SucuriScanHardening::xmlrpcEnabled()).
+     *
+     * @return string HTML code with the replaced template variables.
+     */
+    public static function xmlrpc()
+    {
+        $params = array();
+
+	    $params['URL.Hardening'] = admin_url('admin.php?page=sucuriscan_hardening_prevention');
+
+	    if (self::processRequest(__FUNCTION__)) {
+            if (SucuriScanOption::updateOption(':hardening_xmlrpc', 'enabled')) {
+                SucuriScanEvent::reportNoticeEvent(__('XML-RPC was disabled', 'sucuri-scanner'));
+                SucuriScanInterface::info(__('XML-RPC (xmlrpc.php) has been disabled.', 'sucuri-scanner'));
+            } else {
+                SucuriScanInterface::error(__('Something went wrong.', 'sucuri-scanner'));
+            }
+        }
+
+        if (self::processRequest(__FUNCTION__ . '_revert')) {
+            if (SucuriScanOption::updateOption(':hardening_xmlrpc', 'disabled')) {
+                SucuriScanEvent::reportErrorEvent(__('XML-RPC was re-enabled', 'sucuri-scanner'));
+                SucuriScanInterface::info(__('XML-RPC (xmlrpc.php) has been re-enabled.', 'sucuri-scanner'));
+            } else {
+                SucuriScanInterface::error(__('Something went wrong.', 'sucuri-scanner'));
+            }
+        }
+
+        $params['Hardening.Title'] = __('Disable XML-RPC', 'sucuri-scanner');
+
+        $description = __(
+            'XML-RPC (xmlrpc.php) is a legacy remote API with almost no legitimate use on modern WordPress sites. It is one of the most common vectors for brute-force login attempts and pingback-based DDoS amplification attacks. Disabling it closes this attack surface.',
+            'sucuri-scanner'
+        );
+
+        $dependentPlugins = SucuriScanHardening::activeXMLRPCDependentPlugins();
+
+        if (!empty($dependentPlugins)) {
+            $description .= ' ' . sprintf(
+                /* translators: %s: comma-separated list of active plugin names, e.g. "Jetpack". */
+                __('Warning: the following active plugin(s) may rely on XML-RPC and could stop working correctly if you disable it: %s.', 'sucuri-scanner'),
+                implode(', ', $dependentPlugins)
+            );
+        }
+
+        $params['Hardening.Description'] = $description;
+
+        if (SucuriScanOption::isEnabled(':hardening_xmlrpc')) {
+            $params['Hardening.Status'] = 1;
+            $params['Hardening.FieldName'] = __FUNCTION__ . '_revert';
+            $params['Hardening.FieldText'] = __('Revert Hardening', 'sucuri-scanner');
+        } else {
+            $params['Hardening.Status'] = 0;
+            $params['Hardening.FieldName'] = __FUNCTION__;
+            $params['Hardening.FieldText'] = __('Apply Hardening', 'sucuri-scanner');
+        }
+
+        return self::drawSection($params);
+    }
+
+    /**
      * Allow individual PHP files.
      *
      * Allows an admin to allow individual PHP files after the directory has

--- a/tests/ApiNormalizeMessagesTest.php
+++ b/tests/ApiNormalizeMessagesTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression test for a fatal error reported in production: some API error
+ * responses return "messages" as a plain string instead of an array, and
+ * handleResponse() used to implode() it directly. Under PHP 8 that raises an
+ * uncaught TypeError ("implode(): Argument #2 ($array) must be of type
+ * ?array, string given"), breaking any code path that calls it (e.g. saving
+ * a post triggers SucuriScanFirewall::clearCacheHook() -> clearCache() ->
+ * handleResponse()). normalizeMessages() guarantees implode() always
+ * receives an array.
+ */
+final class ApiNormalizeMessagesTest extends TestCase
+{
+    /**
+     * @param mixed $messages Raw "messages" value from an API response.
+     * @return array Normalized value.
+     */
+    private function normalize($messages): array
+    {
+        $method = (new ReflectionClass('SucuriScanAPI'))->getMethod('normalizeMessages');
+        $method->setAccessible(true);
+
+        return $method->invoke(null, $messages);
+    }
+
+    public function testStringMessageIsWrappedInArray()
+    {
+        $this->assertSame(array('Something went wrong'), $this->normalize('Something went wrong'));
+    }
+
+    public function testArrayMessageIsReturnedUnchanged()
+    {
+        $messages = array('First error', 'Second error');
+
+        $this->assertSame($messages, $this->normalize($messages));
+    }
+
+    public function testImplodingAStringMessageDoesNotThrow()
+    {
+        // Reproduces the exact crash: a malformed response with "messages" as
+        // a string instead of an array must still be safely implode()-able.
+        $msg = implode(".\x20", $this->normalize('Wrong API key'));
+
+        $this->assertSame('Wrong API key', $msg);
+    }
+}

--- a/tests/HardeningXMLRPCTest.php
+++ b/tests/HardeningXMLRPCTest.php
@@ -1,0 +1,120 @@
+<?php declare(strict_types=1);
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('is_plugin_active')) {
+    function is_plugin_active($plugin)
+    {
+        return in_array($plugin, $GLOBALS['__test_active_plugins'] ?? array(), true);
+    }
+}
+
+if (!function_exists('is_plugin_active_for_network')) {
+    function is_plugin_active_for_network($plugin)
+    {
+        return in_array($plugin, $GLOBALS['__test_network_active_plugins'] ?? array(), true);
+    }
+}
+
+if (!function_exists('is_multisite')) {
+    function is_multisite()
+    {
+        return (bool) ($GLOBALS['__test_is_multisite'] ?? false);
+    }
+}
+
+final class HardeningXMLRPCTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private $settingsFile = '';
+    private $originalSettingsContent = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        $this->settingsFile = SucuriScanOption::optionsFilePath();
+        $this->originalSettingsContent = file_exists($this->settingsFile)
+            ? (string) file_get_contents($this->settingsFile)
+            : '';
+
+        $GLOBALS['__test_active_plugins'] = array();
+        $GLOBALS['__test_network_active_plugins'] = array();
+        $GLOBALS['__test_is_multisite'] = false;
+
+        Functions\when('__')->returnArg();
+        Functions\when('wp_cache_get')->justReturn(false);
+        Functions\when('wp_cache_set')->justReturn(true);
+        Functions\when('wp_cache_delete')->justReturn(true);
+        Functions\when('get_option')->justReturn(false);
+        Functions\when('update_option')->justReturn(true);
+        Functions\when('delete_option')->justReturn(true);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->settingsFile) {
+            file_put_contents($this->settingsFile, $this->originalSettingsContent);
+        }
+
+        unset($GLOBALS['__test_active_plugins']);
+        unset($GLOBALS['__test_network_active_plugins']);
+        unset($GLOBALS['__test_is_multisite']);
+
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function testXmlrpcEnabledReturnsFalseWhenHardeningIsApplied()
+    {
+        SucuriScanOption::updateOption(':hardening_xmlrpc', 'enabled');
+
+        $this->assertFalse(SucuriScanHardening::xmlrpcEnabled(true));
+    }
+
+    public function testXmlrpcEnabledPassesThroughValueWhenHardeningIsNotApplied()
+    {
+        SucuriScanOption::updateOption(':hardening_xmlrpc', 'disabled');
+
+        $this->assertTrue(SucuriScanHardening::xmlrpcEnabled(true));
+        $this->assertFalse(SucuriScanHardening::xmlrpcEnabled(false));
+    }
+
+    public function testXmlrpcEnabledDefaultsToNotHardened()
+    {
+        $this->assertTrue(SucuriScanHardening::xmlrpcEnabled(true));
+    }
+
+    public function testActiveXMLRPCDependentPluginsReturnsEmptyByDefault()
+    {
+        $this->assertSame(array(), SucuriScanHardening::activeXMLRPCDependentPlugins());
+    }
+
+    public function testActiveXMLRPCDependentPluginsDetectsJetpack()
+    {
+        $GLOBALS['__test_active_plugins'] = array('jetpack/jetpack.php');
+
+        $this->assertSame(array('Jetpack'), SucuriScanHardening::activeXMLRPCDependentPlugins());
+    }
+
+    public function testActiveXMLRPCDependentPluginsDetectsNetworkActivatedPluginOnMultisite()
+    {
+        $GLOBALS['__test_is_multisite'] = true;
+        $GLOBALS['__test_network_active_plugins'] = array('jetpack/jetpack.php');
+
+        $this->assertSame(array('Jetpack'), SucuriScanHardening::activeXMLRPCDependentPlugins());
+    }
+
+    public function testActiveXMLRPCDependentPluginsIgnoresNetworkActivationOutsideMultisite()
+    {
+        $GLOBALS['__test_is_multisite'] = false;
+        $GLOBALS['__test_network_active_plugins'] = array('jetpack/jetpack.php');
+
+        $this->assertSame(array(), SucuriScanHardening::activeXMLRPCDependentPlugins());
+    }
+}


### PR DESCRIPTION
- Add a one-click Disable XML-RPC toggle to the Hardening page (src/hardening.lib.php, src/settings-hardening.php, inc/tpl/hardening-and-prevention.html.tpl, src/globals.php, src/option.lib.php, src/pagehandler.php). Disables xmlrpc.php via the xmlrpc_enabled filter, mirroring the existing apply/revert hardening pattern. Warns the admin if a known XML-RPC-dependent plugin (currently Jetpack) is active, including on multisite network activations.
- Fix a fatal error on PHP 8 when an API response's "messages" field comes back as a plain string instead of an array (src/api.lib.php, src/firewall.lib.php). implode() requires an array argument as of PHP 8, and some backend error responses don't follow that shape — this was breaking post/page saves via SucuriScanFirewall::clearCacheHook(). Adds SucuriScanAPI::normalizeMessages() to coerce the value before every implode() call site.
- Add CLAUDE.md — repo guidance for Claude Code (build/test commands, architecture notes).
- Update readme.txt changelog (= 2.7.4 =) to document both the new hardening option and the fatal-error fix.

Test plan
- [x] New unit tests: tests/HardeningXMLRPCTest.php, tests/ApiNormalizeMessagesTest.php
- [x] ./vendor/bin/phpunit — full suite
- [x] Manually verify: enable "Disable XML-RPC" on the Hardening page, confirm xmlrpc.php returns an error/is inaccessible, then revert and confirm it's re-enabled
- [x] Manually verify: confirm no fatal error on post/page save when the API returns a string messages field