### PR TITLE
Adds one-time backup codes as a recovery method for Two-Factor Authentication

### DIFF
--- a/inc/css/shared.css
+++ b/inc/css/shared.css
@@ -589,6 +589,127 @@ body.sucuri-security_page_sucuriscan_firewall .sucuriscan-panel {
     top: -21px;
 }
 
+html.sucuriscan-backup-codes-modal-open,
+body.sucuriscan-backup-codes-modal-open {
+    overflow: hidden;
+}
+
+.sucuriscan-backup-codes-overlay {
+    align-items: center;
+    background: rgba(0, 0, 0, 0.7);
+    bottom: 0;
+    display: flex;
+    justify-content: center;
+    left: 0;
+    padding: 20px;
+    position: fixed;
+    right: 0;
+    overscroll-behavior: contain;
+    top: 0;
+    z-index: 100000;
+}
+
+.sucuriscan-backup-codes-modal {
+    background: var(--sucuri-surface-card-bg);
+    border: 1px solid var(--sucuri-surface-card-border);
+    border-radius: var(--sucuri-border-radius);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+    box-sizing: border-box;
+    color: var(--sucuri-color-text-main);
+    max-height: calc(100vh - 40px);
+    max-width: 480px;
+    overscroll-behavior: contain;
+    overflow-y: auto;
+    padding: 24px;
+    width: 100%;
+}
+
+.sucuriscan-backup-codes-modal h2 {
+    color: var(--sucuri-color-text-main);
+    font-size: 24px;
+    line-height: 1.3;
+    margin: 0 0 12px;
+}
+
+.sucuriscan-backup-codes-modal p {
+    color: var(--sucuri-color-text-secondary);
+    margin: 0;
+}
+
+.sucuriscan-backup-codes-list {
+    display: grid;
+    font-size: 14px;
+    gap: 8px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    list-style: none;
+    margin: 16px 0;
+    padding: 0;
+}
+
+.sucuriscan-backup-codes-list code {
+    background: var(--sucuri-surface-list-bg);
+    border: 1px solid var(--sucuri-surface-panel-border);
+    border-radius: 3px;
+    color: var(--sucuri-color-text-main);
+    display: block;
+    padding: 6px 8px;
+    text-align: center;
+}
+
+.sucuriscan-backup-codes-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.sucuriscan-backup-codes-modal .button {
+    background: transparent;
+    border-color: var(--sucuri-color-primary);
+    border-radius: var(--sucuri-border-radius);
+    color: var(--sucuri-color-primary);
+}
+
+.sucuriscan-backup-codes-modal .button:hover,
+.sucuriscan-backup-codes-modal .button:focus {
+    background: var(--sucuri-color-primary);
+    border-color: var(--sucuri-color-primary);
+    color: var(--sucuri-color-white);
+}
+
+.sucuriscan-backup-codes-modal .button.button-primary {
+    background: var(--sucuri-color-primary);
+    border-color: var(--sucuri-color-primary);
+    color: var(--sucuri-color-white);
+}
+
+.sucuriscan-backup-codes-modal .button.button-primary:disabled {
+    background: var(--sucuri-surface-list-bg);
+    border-color: var(--sucuri-surface-panel-border);
+    color: var(--sucuri-color-text-disabled);
+}
+
+.sucuriscan-backup-codes-ack {
+    color: var(--sucuri-color-text-main);
+    display: block;
+    margin-bottom: 16px;
+}
+
+@media screen and (max-width: 480px) {
+    .sucuriscan-backup-codes-overlay {
+        padding: 12px;
+    }
+
+    .sucuriscan-backup-codes-modal {
+        max-height: calc(100vh - 24px);
+        padding: 20px;
+    }
+
+    .sucuriscan-backup-codes-list {
+        grid-template-columns: 1fr;
+    }
+}
+
 .sucuriscan-tabs {
     margin-top: 30px;
 }

--- a/inc/js/backup-codes.js
+++ b/inc/js/backup-codes.js
@@ -1,0 +1,220 @@
+/**
+ * Renders the one-time "save your backup codes" reveal modal used across the
+ * Two-Factor profile setup, status and regenerate flows. Codes are only ever
+ * available in-memory on the client at the moment they are generated, so
+ * Copy/Download both work directly off the array passed in here rather than
+ * fetching anything from the server again.
+ */
+(function () {
+  "use strict";
+
+  const modalOpenClass = "sucuriscan-backup-codes-modal-open";
+  const overlaySelector = ".sucuriscan-backup-codes-overlay";
+
+  const createElement = (tagName, options = {}) => {
+    const element = document.createElement(tagName);
+
+    if (options.className) {
+      element.className = options.className;
+    }
+
+    if (options.text) {
+      element.textContent = options.text;
+    }
+
+    Object.entries(options.attributes || {}).forEach(([name, value]) => {
+      element.setAttribute(name, String(value));
+    });
+
+    return element;
+  };
+
+  const writeClipboard = async (text) => {
+    if (!navigator.clipboard?.writeText) {
+      return false;
+    }
+
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  };
+
+  const setPageScrollLocked = (locked) => {
+    document.documentElement.classList.toggle(modalOpenClass, locked);
+    document.body.classList.toggle(modalOpenClass, locked);
+  };
+
+  const buildCodeList = (codes) => {
+    const list = createElement("ul", {
+      className: "sucuriscan-backup-codes-list",
+    });
+
+    codes.forEach((code) => {
+      const item = document.createElement("li");
+      const value = createElement("code", { text: code });
+
+      item.append(value);
+      list.append(item);
+    });
+
+    return list;
+  };
+
+  const buildModal = (codes, onClose) => {
+    const text = codes.join("\n");
+    const overlay = createElement("div", {
+      className: "sucuriscan-backup-codes-overlay",
+      attributes: {
+        role: "dialog",
+        "aria-label": "Save your backup codes",
+        "aria-modal": "true",
+      },
+    });
+    const modal = createElement("div", {
+      className: "sucuriscan-backup-codes-modal",
+    });
+    const title = createElement("h2", { text: "Save your backup codes" });
+    const description = createElement("p", {
+      text: "Each code can be used once to sign in if you lose access to your authenticator app. Store them somewhere safe - they will not be shown again.",
+    });
+    const actions = createElement("div", {
+      className: "sucuriscan-backup-codes-actions",
+    });
+    const copyButton = createElement("button", {
+      className: "button",
+      text: "Copy codes",
+      attributes: { type: "button" },
+    });
+    const downloadButton = createElement("button", {
+      className: "button",
+      text: "Download .txt",
+      attributes: { type: "button" },
+    });
+    const acknowledgement = createElement("label", {
+      className: "sucuriscan-backup-codes-ack",
+    });
+    const acknowledgementCheckbox = createElement("input", {
+      attributes: { type: "checkbox" },
+    });
+    const closeAction = createElement("div", {
+      className: "sucuriscan-2fa-action-row",
+    });
+    const closeButton = createElement("button", {
+      className: "button button-primary",
+      text: "Close",
+      attributes: { type: "button", disabled: "disabled" },
+    });
+
+    actions.append(copyButton, downloadButton);
+    acknowledgement.append(
+      acknowledgementCheckbox,
+      " I have saved these codes",
+    );
+    closeAction.append(closeButton);
+    modal.append(
+      title,
+      description,
+      buildCodeList(codes),
+      actions,
+      acknowledgement,
+      closeAction,
+    );
+    overlay.append(modal);
+    document.body.append(overlay);
+    setPageScrollLocked(true);
+    copyButton.focus();
+
+    acknowledgementCheckbox.addEventListener("change", () => {
+      closeButton.disabled = !acknowledgementCheckbox.checked;
+    });
+
+    copyButton.addEventListener("click", async () => {
+      copyButton.disabled = true;
+      const copied = await writeClipboard(text);
+
+      copyButton.textContent = copied ? "Copied!" : "Copy unavailable";
+
+      window.setTimeout(() => {
+        copyButton.textContent = "Copy codes";
+        copyButton.disabled = false;
+      }, 1500);
+    });
+
+    downloadButton.addEventListener("click", () => {
+      if (typeof window.sucuriscanDownloadTextFile === "function") {
+        window.sucuriscanDownloadTextFile(
+          "sucuri-backup-codes.txt",
+          `${text}\n`,
+        );
+      }
+    });
+
+    const confirmBeforeUnload = (event) => {
+      if (!acknowledgementCheckbox.checked) {
+        event.preventDefault();
+      }
+    };
+
+    window.addEventListener("beforeunload", confirmBeforeUnload);
+
+    closeButton.addEventListener("click", () => {
+      window.removeEventListener("beforeunload", confirmBeforeUnload);
+      overlay.remove();
+
+      if (!document.querySelector(overlaySelector)) {
+        setPageScrollLocked(false);
+      }
+
+      if (typeof onClose === "function") {
+        onClose();
+      }
+    });
+  };
+
+  /**
+   * @param {string[]} codes
+   * @param {Function} [onClose] Called after the user closes the modal
+   *   (e.g. to defer a page reload/redirect until the codes were shown).
+   */
+  window.sucuriShowBackupCodesModal = (codes, onClose) => {
+    const validCodes = Array.isArray(codes)
+      ? codes.filter((code) => typeof code === "string" && code !== "")
+      : [];
+
+    if (!validCodes.length) {
+      if (typeof onClose === "function") {
+        onClose();
+      }
+
+      return;
+    }
+
+    buildModal(validCodes, onClose);
+  };
+
+  const revealData = document.getElementById(
+    "sucuriscan-backup-codes-reveal-data",
+  );
+
+  if (revealData) {
+    let codes = [];
+    let redirectURL = "";
+
+    try {
+      codes = JSON.parse(revealData.dataset.codes || "[]");
+      redirectURL = JSON.parse(revealData.dataset.redirectUrl || '""');
+    } catch (error) {
+      codes = [];
+      redirectURL = "";
+    }
+
+    window.sucuriShowBackupCodesModal(codes, () => {
+      if (redirectURL) {
+        window.location.assign(redirectURL);
+      }
+    });
+  }
+})();

--- a/inc/js/backup-codes.js
+++ b/inc/js/backup-codes.js
@@ -195,6 +195,37 @@
     buildModal(validCodes, onClose);
   };
 
+  /**
+   * Resolve a stashed post-reveal destination to a same-origin URL, or to an
+   * empty string when it is anything else.
+   *
+   * The server validates this value before stashing it, but it reaches us via
+   * a transient and is handed straight to window.location.assign() -- which
+   * executes "javascript:" URLs in this origin -- so the scheme/host check is
+   * repeated here instead of being trusted end to end.
+   */
+  const sameOriginURL = (value) => {
+    if (typeof value !== "string" || value === "") {
+      return "";
+    }
+
+    try {
+      const target = new URL(value, window.location.origin);
+
+      if (target.origin !== window.location.origin) {
+        return "";
+      }
+
+      if (target.protocol !== "http:" && target.protocol !== "https:") {
+        return "";
+      }
+
+      return target.href;
+    } catch (error) {
+      return "";
+    }
+  };
+
   const revealData = document.getElementById(
     "sucuriscan-backup-codes-reveal-data",
   );
@@ -205,7 +236,9 @@
 
     try {
       codes = JSON.parse(revealData.dataset.codes || "[]");
-      redirectURL = JSON.parse(revealData.dataset.redirectUrl || '""');
+      redirectURL = sameOriginURL(
+        JSON.parse(revealData.dataset.redirectUrl || '""'),
+      );
     } catch (error) {
       codes = [];
       redirectURL = "";

--- a/inc/js/scripts.js
+++ b/inc/js/scripts.js
@@ -7,6 +7,31 @@ function sucuriscanAlertClose(id) {
 }
 /* jshint ignore:end */
 
+/**
+ * Download text already available in the browser without sending it to the
+ * server. Callers are responsible for supplying an appropriate filename.
+ *
+ * @param {string} filename Suggested download filename.
+ * @param {string} content Text content to download.
+ * @return {void}
+ */
+window.sucuriscanDownloadTextFile = function(filename, content) {
+    var blob = new Blob([String(content)], { type: 'text/plain;charset=utf-8' });
+    var url = window.URL.createObjectURL(blob);
+    var link = document.createElement('a');
+
+    link.href = url;
+    link.download = String(filename);
+    link.style.display = 'none';
+    document.body.appendChild(link);
+    link.click();
+    link.parentNode.removeChild(link);
+
+    window.setTimeout(function() {
+        window.URL.revokeObjectURL(url);
+    }, 1000);
+};
+
 jQuery(document).ready(function($) {
     $('.sucuriscan-container').on('click', '.sucuriscan-modal-button', function(event) {
         event.preventDefault();

--- a/inc/tpl/2fa-setup.snippet.tpl
+++ b/inc/tpl/2fa-setup.snippet.tpl
@@ -39,7 +39,13 @@
                     $('#two-factor-info-deactivated').hide();
                     $('#two-factor-info-activated').show();
 
-                    window.location.reload();
+                    const reload = function () { window.location.reload(); };
+
+                    if (typeof window.sucuriShowBackupCodesModal === 'function') {
+                        window.sucuriShowBackupCodesModal(resp.backupCodes, reload);
+                    } else {
+                        reload();
+                    }
                 } else {
                     var err = (resp && resp.error) ? resp.error : 'Verification failed';
                     error(err);

--- a/inc/tpl/login-2fa.html.tpl
+++ b/inc/tpl/login-2fa.html.tpl
@@ -2,10 +2,13 @@
     %%%SUCURI.NonceField%%%
     <p style="display:block;">
         <label for="sucuriscan-totp-code">{{Authentication code}}<br />
-            <input type="text" name="sucuriscan_totp_code" id="sucuriscan-totp-code" class="input" maxlength="6"
-                pattern="[0-9]{6}" inputmode="numeric" autocomplete="one-time-code" placeholder="123456"
+            <input type="text" name="sucuriscan_totp_code" id="sucuriscan-totp-code" class="input" maxlength="9"
+                inputmode="text" autocomplete="one-time-code" placeholder="123456"
                 style="display:block;" />
         </label>
+    </p>
+    <p style="display:block;">
+        {{Enter the 6-digit code from your authenticator app or an 8-character backup code.}}
     </p>
     <p class="submit" style="display:block;">
         <input type="submit" name="wp-submit" id="sucuriscan-totp-submit" class="button button-primary button-large"

--- a/inc/tpl/profile-2fa-backup-codes.snippet.tpl
+++ b/inc/tpl/profile-2fa-backup-codes.snippet.tpl
@@ -1,0 +1,2 @@
+<div id="sucuriscan-backup-codes-reveal-data" style="display:none;" data-codes="%%SUCURI.CodesJSON%%"
+    data-redirect-url="%%SUCURI.RedirectURL%%"></div>

--- a/inc/tpl/profile-2fa-backup-row.snippet.tpl
+++ b/inc/tpl/profile-2fa-backup-row.snippet.tpl
@@ -1,0 +1,8 @@
+<p class="sucuriscan-2fa-backup-codes-row" data-cy="sucuriscan-2fa-backup-codes-row">
+    <span id="sucuri-2fa-backup-codes-count">%%SUCURI.BackupCodesRemaining%%</span> backup code(s) remaining.
+    <button type="button" class="button button-secondary" id="sucuri-2fa-backup-regen-btn"
+        aria-controls="sucuri-2fa-backup-regen-msg" data-cy="sucuriscan-2fa-backup-regen-btn">
+        Regenerate backup codes
+    </button>
+    <span id="sucuri-2fa-backup-regen-msg" class="sucuriscan-2fa-reset-msg" role="status" aria-live="polite"></span>
+</p>

--- a/inc/tpl/profile-2fa-setup.snippet.tpl
+++ b/inc/tpl/profile-2fa-setup.snippet.tpl
@@ -85,6 +85,14 @@
                     if (container) { container.innerHTML = resp.data.html; }
 
                     setMessage('', '');
+
+                    const reload = function () { window.location.reload(); };
+
+                    if (resp.data.backupCodes && resp.data.backupCodes.length && typeof window.sucuriShowBackupCodesModal === 'function') {
+                        window.sucuriShowBackupCodesModal(resp.data.backupCodes, reload);
+                    } else {
+                        reload();
+                    }
                 } else {
                     const err = (resp && resp.data && (resp.data.message || resp.data.error)) || 'Verification failed';
 

--- a/inc/tpl/profile-2fa-status.snippet.tpl
+++ b/inc/tpl/profile-2fa-status.snippet.tpl
@@ -5,6 +5,15 @@
         Two-Factor Authentication <strong>is enabled</strong> for this account.
     </p>
 
+    <p class="sucuriscan-2fa-backup-codes-row" data-cy="sucuriscan-2fa-backup-codes-row">
+        <span id="sucuri-2fa-backup-codes-count">%%SUCURI.BackupCodesRemaining%%</span> backup code(s) remaining.
+        <button type="button" class="button button-secondary" id="sucuri-2fa-backup-regen-btn"
+            aria-controls="sucuri-2fa-backup-regen-msg" data-cy="sucuriscan-2fa-backup-regen-btn">
+            Regenerate backup codes
+        </button>
+        <span id="sucuri-2fa-backup-regen-msg" class="sucuriscan-2fa-reset-msg" role="status" aria-live="polite"></span>
+    </p>
+
     <p class="sucuriscan-2fa-reset-row">
         <button type="button" class="button button-secondary" id="sucuri-2fa-reset-btn"
             aria-controls="sucuri-2fa-reset-msg" data-cy="sucuriscan-2fa-reset-btn">
@@ -96,6 +105,14 @@
                             const cell = $container.closest('td').get(0) || $container.get(0);
 
                             if (cell) cell.innerHTML = resp.data.html;
+
+                            const reload = () => window.location.reload();
+
+                            if (resp.data.backupCodes && resp.data.backupCodes.length && typeof window.sucuriShowBackupCodesModal === 'function') {
+                                window.sucuriShowBackupCodesModal(resp.data.backupCodes, reload);
+                            } else {
+                                reload();
+                            }
                         } else {
                             const err = (resp && resp.data && (resp.data.message || resp.data.error)) || 'Verification failed';
 
@@ -110,6 +127,41 @@
                 });
             }
         };
+
+        const $regenBtn = $('#sucuri-2fa-backup-regen-btn');
+        const $regenMsg = $('#sucuri-2fa-backup-regen-msg');
+        const $regenCount = $('#sucuri-2fa-backup-codes-count');
+
+        $regenBtn.on('click', () => {
+            if (!window.confirm('This will invalidate your existing backup codes and generate a new set. Continue?')) return;
+
+            $regenBtn.prop('disabled', true).attr('aria-disabled', 'true');
+            $regenMsg.text('Generating…').removeClass('sucuriscan-text-error sucuriscan-text-success');
+
+            $.ajax({
+                url: ajaxUrl,
+                method: 'POST',
+                dataType: 'json',
+                data: { action: 'sucuri_profile_2fa_backup_regen', nonce: ajaxNonce, user_id: userId }
+            }).done(resp => {
+                $regenBtn.prop('disabled', false).removeAttr('aria-disabled');
+                $regenMsg.text('');
+
+                if (resp && resp.success && resp.data && resp.data.backupCodes) {
+                    if ($regenCount.length) $regenCount.text(resp.data.backupCodes.length);
+
+                    if (typeof window.sucuriShowBackupCodesModal === 'function') {
+                        window.sucuriShowBackupCodesModal(resp.data.backupCodes);
+                    }
+                } else {
+                    const err = (resp && resp.data && (resp.data.message || resp.data.error)) || 'Could not regenerate backup codes';
+                    $regenMsg.text(err).addClass('sucuriscan-text-error');
+                }
+            }).fail(() => {
+                $regenBtn.prop('disabled', false).removeAttr('aria-disabled');
+                $regenMsg.text('Could not regenerate backup codes').addClass('sucuriscan-text-error');
+            });
+        });
 
         $btn.on('click', () => {
             if (!window.confirm('This will disable two-factor for this user. Continue?')) return;

--- a/inc/tpl/profile-2fa-status.snippet.tpl
+++ b/inc/tpl/profile-2fa-status.snippet.tpl
@@ -5,14 +5,7 @@
         Two-Factor Authentication <strong>is enabled</strong> for this account.
     </p>
 
-    <p class="sucuriscan-2fa-backup-codes-row" data-cy="sucuriscan-2fa-backup-codes-row">
-        <span id="sucuri-2fa-backup-codes-count">%%SUCURI.BackupCodesRemaining%%</span> backup code(s) remaining.
-        <button type="button" class="button button-secondary" id="sucuri-2fa-backup-regen-btn"
-            aria-controls="sucuri-2fa-backup-regen-msg" data-cy="sucuriscan-2fa-backup-regen-btn">
-            Regenerate backup codes
-        </button>
-        <span id="sucuri-2fa-backup-regen-msg" class="sucuriscan-2fa-reset-msg" role="status" aria-live="polite"></span>
-    </p>
+    %%%SUCURI.BackupCodesRowHTML%%%
 
     <p class="sucuriscan-2fa-reset-row">
         <button type="button" class="button button-secondary" id="sucuri-2fa-reset-btn"
@@ -132,7 +125,9 @@
         const $regenMsg = $('#sucuri-2fa-backup-regen-msg');
         const $regenCount = $('#sucuri-2fa-backup-codes-count');
 
-        $regenBtn.on('click', () => {
+        // Absent when an administrator is viewing another user's profile: backup
+        // code regeneration is self-only, so the row is not rendered there.
+        if ($regenBtn.length) $regenBtn.on('click', () => {
             if (!window.confirm('This will invalidate your existing backup codes and generate a new set. Continue?')) return;
 
             $regenBtn.prop('disabled', true).attr('aria-disabled', 'true');

--- a/src/backupcodes.lib.php
+++ b/src/backupcodes.lib.php
@@ -1,0 +1,333 @@
+<?php
+/**
+ * Code related to Two-Factor Authentication backup/recovery codes.
+ *
+ * PHP version 5
+ *
+ * @category   Library
+ * @package    Sucuri
+ * @subpackage SucuriScanner
+ * @author     Sucuri Inc.
+ * @copyright  2010-2025 Sucuri Inc.
+ * @license    https://www.gnu.org/licenses/gpl-2.0.txt GPL2
+ * @link       https://wordpress.org/plugins/sucuri-scanner
+ */
+
+// Abort if the file is loaded out of context.
+if (!defined('SUCURISCAN_INIT') || SUCURISCAN_INIT !== true) {
+    if (!headers_sent()) {
+        /* Report invalid access if possible. */
+        header('HTTP/1.1 403 Forbidden');
+    }
+    exit(1);
+}
+
+/**
+ * Generates, stores, validates and consumes one-time Two-Factor backup codes.
+ *
+ * Codes are hashed with WordPress' own password hashing primitive (never
+ * encrypted) because they are single-use secrets that never need to be
+ * redisplayed once generated; the plugin's reversible AES-GCM secret storage
+ * in SucuriScanOption is intentionally not used here.
+ */
+class SucuriScanBackupCodes extends SucuriScan
+{
+    const META_KEY = 'sucuriscan_topt_backup_codes';
+    const CODE_COUNT = 10;
+    const CODE_LENGTH = 8;
+    const LOW_CODES_THRESHOLD = 2;
+    const REVEAL_TRANSIENT_PREFIX = 'sucuriscan_backup_codes_reveal_';
+    const REVEAL_REDIRECT_TRANSIENT_PREFIX = 'sucuriscan_backup_codes_redirect_';
+    const REVEAL_TRANSIENT_TTL = 300;
+
+    /**
+     * Alphabet excludes visually ambiguous characters (0/O, 1/I/L).
+     *
+     * @var string
+     */
+    private static $alphabet = '23456789ABCDEFGHJKMNPQRSTUVWXYZ';
+
+    /**
+     * Generate a brand-new set of backup codes for a user, overwriting any
+     * existing set. Returns the plaintext codes; this is the only place the
+     * plaintext values are ever available once this call returns.
+     *
+     * @param int $user_id
+     *
+     * @return string[] Plaintext codes, formatted as XXXX-XXXX.
+     */
+    public static function generate_for_user($user_id)
+    {
+        $user_id = (int) $user_id;
+        $codes = array();
+        $hashes = array();
+
+        for ($i = 0; $i < self::CODE_COUNT; $i++) {
+            $code = self::generate_code();
+            $codes[] = $code;
+            $hashes[] = wp_hash_password(self::normalize_code($code));
+        }
+
+        update_user_meta($user_id, self::META_KEY, $hashes);
+
+        return $codes;
+    }
+
+    /**
+     * Generate a set of backup codes for a user only if none currently exist.
+     * Safe to call unconditionally from every Two-Factor "enable" code path.
+     *
+     * @param int $user_id
+     *
+     * @return string[]|null Plaintext codes on first generation, null if a
+     *                       set already existed (no-op).
+     */
+    public static function maybe_generate_for_user($user_id)
+    {
+        $user_id = (int) $user_id;
+
+        if (self::has_codes($user_id)) {
+            return null;
+        }
+
+        return self::generate_for_user($user_id);
+    }
+
+    /**
+     * Whether a user currently has any unused backup codes.
+     *
+     * @param int $user_id
+     *
+     * @return bool
+     */
+    public static function has_codes($user_id)
+    {
+        return !empty(self::get_hashes($user_id));
+    }
+
+    /**
+     * Delete all backup codes for a user. Called wherever the Two-Factor
+     * secret itself is deleted (reset flows), never on plain "deactivate"
+     * (disabling enforcement should not destroy an existing setup).
+     *
+     * @param int $user_id
+     *
+     * @return void
+     */
+    public static function delete_for_user($user_id)
+    {
+        delete_user_meta((int) $user_id, self::META_KEY);
+    }
+
+    /**
+     * Count of unused backup codes remaining for a user.
+     *
+     * @param int $user_id
+     *
+     * @return int
+     */
+    public static function remaining_count($user_id)
+    {
+        return count(self::get_hashes($user_id));
+    }
+
+    /**
+     * Validate a submitted backup code and, if valid, consume it so it can
+     * never be reused (single-use semantics).
+     *
+     * @param int    $user_id
+     * @param string $code Raw user input; dashes/whitespace are stripped and
+     *                     the value is uppercased before comparison.
+     *
+     * @return bool True if the code was valid and has now been consumed.
+     */
+    public static function validate_and_consume($user_id, $code)
+    {
+        $user_id = (int) $user_id;
+        $normalized = self::normalize_code($code);
+
+        if ($normalized === '' || strlen($normalized) !== self::CODE_LENGTH) {
+            return false;
+        }
+
+        $hashes = self::get_hashes($user_id);
+
+        foreach ($hashes as $index => $hash) {
+            if (wp_check_password($normalized, $hash, $user_id)) {
+                $previous_hashes = $hashes;
+                unset($hashes[$index]);
+                $hashes = array_values($hashes);
+
+                // Require the stored value to match the value we verified so
+                // concurrent requests cannot consume the same code twice.
+                if (!update_user_meta($user_id, self::META_KEY, $hashes, $previous_hashes)) {
+                    return false;
+                }
+
+                self::log_consumption($user_id, count($hashes));
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Stash a freshly generated plaintext code set for one-time reveal on
+     * the next page render (used by redirect-based enable flows that cannot
+     * return the codes directly in an AJAX/JSON response).
+     *
+     * @param int      $user_id
+     * @param string[] $codes
+     *
+     * @return void
+     */
+    public static function stash_reveal($user_id, array $codes, $redirect_to = '')
+    {
+        set_transient(self::reveal_transient_key($user_id), $codes, self::REVEAL_TRANSIENT_TTL);
+
+        $redirect_to = is_string($redirect_to) ? $redirect_to : '';
+
+        if ($redirect_to !== '') {
+            set_transient(self::reveal_redirect_transient_key($user_id), $redirect_to, self::REVEAL_TRANSIENT_TTL);
+        } else {
+            delete_transient(self::reveal_redirect_transient_key($user_id));
+        }
+    }
+
+    /**
+     * Read and immediately clear a stashed plaintext code set, so it can
+     * only ever be rendered once, even within the transient's TTL window.
+     *
+     * @param int $user_id
+     *
+     * @return string[] Empty array if nothing was stashed (or already read).
+     */
+    public static function consume_reveal($user_id)
+    {
+        $key = self::reveal_transient_key($user_id);
+        $codes = get_transient($key);
+        delete_transient($key);
+
+        return is_array($codes) ? $codes : array();
+    }
+
+    /**
+     * Read and immediately clear the destination to use after a stashed code
+     * reveal is acknowledged.
+     *
+     * @param int $user_id
+     *
+     * @return string
+     */
+    public static function consume_reveal_redirect($user_id)
+    {
+        $key = self::reveal_redirect_transient_key($user_id);
+        $redirect_to = get_transient($key);
+        delete_transient($key);
+
+        return is_string($redirect_to) ? $redirect_to : '';
+    }
+
+    /**
+     * @param int $user_id
+     *
+     * @return string
+     */
+    private static function reveal_transient_key($user_id)
+    {
+        return self::REVEAL_TRANSIENT_PREFIX . (int) $user_id;
+    }
+
+    /**
+     * @param int $user_id
+     *
+     * @return string
+     */
+    private static function reveal_redirect_transient_key($user_id)
+    {
+        return self::REVEAL_REDIRECT_TRANSIENT_PREFIX . (int) $user_id;
+    }
+
+    /**
+     * @param int $user_id
+     *
+     * @return array
+     */
+    private static function get_hashes($user_id)
+    {
+        $hashes = get_user_meta((int) $user_id, self::META_KEY, true);
+
+        return is_array($hashes) ? $hashes : array();
+    }
+
+    /**
+     * Uppercase and strip anything outside the code alphabet (dashes,
+     * whitespace, stray characters) so "abcd-1234", "ABCD 1234" and
+     * "ABCD1234" all normalize identically.
+     *
+     * @param mixed $code
+     *
+     * @return string
+     */
+    public static function normalize_code($code)
+    {
+        $code = is_scalar($code) ? strtoupper((string) $code) : '';
+
+        return (string) preg_replace('/[^' . self::$alphabet . ']/', '', $code);
+    }
+
+    /**
+     * @return string A single code formatted as XXXX-XXXX.
+     */
+    private static function generate_code()
+    {
+        $raw = '';
+        $max = strlen(self::$alphabet) - 1;
+
+        for ($i = 0; $i < self::CODE_LENGTH; $i++) {
+            $index = 0;
+
+            try {
+                $index = random_int(0, $max);
+            } catch (Exception $e) {
+                // random_int() can throw if no CSPRNG source is available on
+                // this platform; fall back to WP's own randomness rather
+                // than fail Two-Factor setup entirely.
+                $index = wp_rand(0, $max);
+            }
+
+            $raw .= self::$alphabet[$index];
+        }
+
+        return substr($raw, 0, 4) . '-' . substr($raw, 4);
+    }
+
+    /**
+     * @param int $user_id
+     * @param int $remaining
+     *
+     * @return void
+     */
+    private static function log_consumption($user_id, $remaining)
+    {
+        if (!class_exists('SucuriScanEvent')) {
+            return;
+        }
+
+        SucuriScanEvent::reportWarningEvent(sprintf(
+            'Two-factor backup code used for user ID %d (%d remaining).',
+            (int) $user_id,
+            (int) $remaining
+        ));
+
+        if ($remaining <= self::LOW_CODES_THRESHOLD) {
+            SucuriScanEvent::reportWarningEvent(sprintf(
+                'Two-factor backup codes running low for user ID %d (%d remaining); regeneration recommended.',
+                (int) $user_id,
+                (int) $remaining
+            ));
+        }
+    }
+}

--- a/src/backupcodes.lib.php
+++ b/src/backupcodes.lib.php
@@ -2,7 +2,7 @@
 /**
  * Code related to Two-Factor Authentication backup/recovery codes.
  *
- * PHP version 5
+ * PHP version 7.4
  *
  * @category   Library
  * @package    Sucuri

--- a/src/topt.lib.php
+++ b/src/topt.lib.php
@@ -18,6 +18,7 @@ class SucuriScanTwoFactor extends SucuriScan
     const LAST_SUCCESS_META_KEY = 'sucuriscan_topt_last_success';
     const LOGIN_TOKEN_TTL = 600;
     const LOGIN_TOKEN_MAX_ATTEMPTS = 5;
+    const BACKUP_TOKEN_MAX_ATTEMPTS = 3;
     const DEFAULT_CODE_ERROR = 'sucuriscan_profile_error';
     const LOGIN_TRANSIENT_PREFIX = 'sucuri_2fa_';
     const LOGIN_TOKEN_PATTERN = '[A-Za-z0-9]{10,128}';
@@ -37,6 +38,8 @@ class SucuriScanTwoFactor extends SucuriScan
         add_action('admin_enqueue_scripts', array(__CLASS__, 'enqueue_profile_assets'));
         add_action('wp_ajax_sucuri_profile_2fa_enable', array(__CLASS__, 'ajax_profile_enable'));
         add_action('wp_ajax_sucuri_profile_2fa_reset', array(__CLASS__, 'ajax_profile_reset'));
+        add_action('wp_ajax_sucuri_profile_2fa_backup_regen', array(__CLASS__, 'ajax_profile_backup_regen'));
+        add_action('admin_notices', array(__CLASS__, 'render_backup_codes_reveal_notice'));
     }
 
     protected static $profile_error_queue = array();
@@ -245,6 +248,7 @@ class SucuriScanTwoFactor extends SucuriScan
         }
 
         self::ensure_qr_script();
+        self::ensure_backup_codes_script();
     }
 
     protected static function create_login_token($user_id, $remember, $redirect_to, $secret_for_setup = '')
@@ -429,9 +433,37 @@ class SucuriScanTwoFactor extends SucuriScan
     }
 
     /**
+     * Extract a submitted login credential that may be either a 6-digit TOTP
+     * code or an 8-character backup code (optionally dash-separated).
+     * Wider than extract_submitted_code() since SucuriScanRequest anchors
+     * its pattern match (^...$), so a single non-digit character in a
+     * backup code would otherwise make the whole value come back false.
+     *
+     * Only strips whitespace/dashes and uppercases — it must NOT run the
+     * value through SucuriScanBackupCodes::normalize_code() here, since
+     * that filters out characters (e.g. digits "0"/"1") that are valid in a
+     * TOTP code but excluded from the backup-code alphabet, which would
+     * corrupt legitimate TOTP submissions before they're even branched on.
+     *
+     * @param string $field
+     *
+     * @return string Normalized (dashes/whitespace stripped, uppercased).
+     */
+    protected static function extract_submitted_login_credential($field)
+    {
+        $raw = SucuriScanRequest::post($field, '[A-Za-z0-9 \-]+');
+
+        if ($raw === false) {
+            return '';
+        }
+
+        return (string) preg_replace('/[\s\-]+/', '', strtoupper((string) $raw));
+    }
+
+    /**
      * Record a failed attempt. If lockout threshold reached the session is cleared and user redirected.
      * Otherwise session is updated with incremented attempts.
-     * 
+     *
      * @param string $token
      * @param array  $session (by reference)
      *
@@ -442,6 +474,30 @@ class SucuriScanTwoFactor extends SucuriScan
         $session['attempts'] = isset($session['attempts']) ? ((int) $session['attempts'] + 1) : 1;
 
         if ($session['attempts'] >= self::LOGIN_TOKEN_MAX_ATTEMPTS) {
+            self::clear_login_session($token);
+            wp_safe_redirect(wp_login_url());
+            exit;
+        }
+
+        self::update_login_session($token, $session);
+    }
+
+    /**
+     * Record a failed backup-code attempt against its own, stricter budget:
+     * unlike a TOTP code (which rotates every 30s), a backup code is a
+     * static secret from a fixed set, so it gets a lower attempt ceiling
+     * than record_failed_attempt()'s general-purpose counter.
+     *
+     * @param string $token
+     * @param array  $session (by reference)
+     *
+     * @return void (never returns on lockout)
+     */
+    protected static function record_failed_backup_attempt($token, &$session)
+    {
+        $session['backup_attempts'] = isset($session['backup_attempts']) ? ((int) $session['backup_attempts'] + 1) : 1;
+
+        if ($session['backup_attempts'] >= self::BACKUP_TOKEN_MAX_ATTEMPTS) {
             self::clear_login_session($token);
             wp_safe_redirect(wp_login_url());
             exit;
@@ -474,6 +530,13 @@ class SucuriScanTwoFactor extends SucuriScan
     protected static function process_successful_setup($user_id, $secret_key, $valid_ts, $remember, $redirect_to, $token)
     {
         self::store_user_totp_key($user_id, $secret_key);
+
+        $backup_codes = SucuriScanBackupCodes::maybe_generate_for_user($user_id);
+
+        if (!empty($backup_codes)) {
+            SucuriScanBackupCodes::stash_reveal($user_id, $backup_codes, $redirect_to);
+            $redirect_to = admin_url('profile.php');
+        }
 
         if ($valid_ts) {
             update_user_meta($user_id, self::LAST_SUCCESS_META_KEY, $valid_ts);
@@ -609,13 +672,10 @@ class SucuriScanTwoFactor extends SucuriScan
         if (SucuriScanRequest::server('REQUEST_METHOD') === 'POST') {
             check_admin_referer($nonce_action);
 
-            $submitted_code = self::extract_submitted_code('sucuriscan_totp_code');
+            $credential = self::extract_submitted_login_credential('sucuriscan_totp_code');
             $invalid_message = esc_html__('Invalid two-factor authentication code.', 'sucuri-scanner');
 
-            if (strlen($submitted_code) !== SucuriScanTOTP::DEFAULT_DIGIT_COUNT) {
-                self::record_failed_attempt($token, $session);
-                $error = $invalid_message;
-            } else {
+            if (strlen($credential) === SucuriScanTOTP::DEFAULT_DIGIT_COUNT && ctype_digit($credential)) {
                 $secret_key = self::get_user_totp_key($user_id);
 
                 if (empty($secret_key)) {
@@ -626,7 +686,7 @@ class SucuriScanTwoFactor extends SucuriScan
 
                 $valid_ts = false;
                 try {
-                    $valid_ts = SucuriScanTOTP::get_authcode_valid_ticktime($secret_key, $submitted_code);
+                    $valid_ts = SucuriScanTOTP::get_authcode_valid_ticktime($secret_key, $credential);
                 } catch (Exception $e) {
                     $valid_ts = false;
                 }
@@ -645,11 +705,24 @@ class SucuriScanTwoFactor extends SucuriScan
 
                 self::record_failed_attempt($token, $session);
                 $error = $invalid_message;
+            } elseif (strlen($credential) === SucuriScanBackupCodes::CODE_LENGTH) {
+                // Backup codes are a static, single-use secret (unlike a TOTP
+                // code, which rotates every 30s) so they're throttled with
+                // their own, stricter attempt budget.
+                if (SucuriScanBackupCodes::validate_and_consume($user_id, $credential)) {
+                    self::complete_success_login($user_id, $remember, $redirect_to, $token, 0);
+                }
+
+                self::record_failed_backup_attempt($token, $session);
+                $error = esc_html__('Invalid backup code.', 'sucuri-scanner');
+            } else {
+                self::record_failed_attempt($token, $session);
+                $error = $invalid_message;
             }
         }
 
         $message_html = SucuriScanTemplate::getSnippet('login-message', array(
-            'Message' => esc_html__('Enter the 6-digit code from your authenticator app to continue.', 'sucuri-scanner'),
+            'Message' => esc_html__('Enter the 6-digit code from your authenticator app or an 8-character backup code to continue.', 'sucuri-scanner'),
         ));
 
         if (!empty($error)) {
@@ -799,6 +872,34 @@ class SucuriScanTwoFactor extends SucuriScan
     }
 
     /**
+     * Registers/enqueues the shared backup-codes reveal-modal script (Copy /
+     * Download / acknowledge-before-close UI, used by the enable, reset and
+     * regenerate flows).
+     *
+     * @return void
+     */
+    protected static function ensure_backup_codes_script()
+    {
+        if (!function_exists('wp_script_is') || !function_exists('wp_register_script') || !function_exists('wp_enqueue_script')) {
+            return;
+        }
+
+        if (!wp_script_is('sucuriscan-backup-codes', 'registered')) {
+            wp_register_script(
+                'sucuriscan-backup-codes',
+                trailingslashit(SUCURISCAN_URL) . 'inc/js/backup-codes.js',
+                array('sucuriscan'),
+                method_exists('SucuriScan', 'fileVersion') ? SucuriScan::fileVersion('inc/js/backup-codes.js') : false,
+                true
+            );
+        }
+
+        if (!wp_script_is('sucuriscan-backup-codes', 'enqueued')) {
+            wp_enqueue_script('sucuriscan-backup-codes');
+        }
+    }
+
+    /**
      * Retrieve the stored TOTP secret key for a given user.
      */
     public static function get_user_totp_key($user_id)
@@ -919,6 +1020,7 @@ class SucuriScanTwoFactor extends SucuriScan
             'ajax_url' => admin_url('admin-ajax.php'),
             'ajax_nonce' => wp_create_nonce('sucuri_profile_2fa_' . (int) $user_id),
             'user_id' => (int) $user_id,
+            'BackupCodesRemaining' => SucuriScanBackupCodes::remaining_count($user_id),
         ));
     }
 
@@ -940,6 +1042,52 @@ class SucuriScanTwoFactor extends SucuriScan
             'ajax_nonce' => wp_create_nonce('sucuri_profile_2fa_' . (int) $user_id),
             'user_id' => (int) $user_id,
         ));
+    }
+
+    /**
+     * Build the one-time backup-codes reveal snippet (a hidden data element
+     * consumed client-side by inc/js/backup-codes.js).
+     *
+     * @param string[] $codes Plaintext codes.
+     *
+     * @return string HTML.
+     */
+    protected static function backup_codes_reveal_snippet(array $codes, $redirect_to = '')
+    {
+        return SucuriScanTemplate::getSnippet('profile-2fa-backup-codes', array(
+            'CodesJSON' => wp_json_encode(array_values($codes)),
+            'RedirectURL' => wp_json_encode((string) $redirect_to),
+        ));
+    }
+
+    /**
+     * Renders a freshly-generated backup-codes reveal (if one was stashed by
+     * a redirect-based enable flow: classic profile POST or login-time
+     * forced setup) on the very next wp-admin page render, then discards it.
+     * AJAX-driven enable/regenerate flows do not need this — they return
+     * the plaintext codes directly in their JSON response instead.
+     *
+     * @return void
+     */
+    public static function render_backup_codes_reveal_notice()
+    {
+        $user_id = get_current_user_id();
+
+        if (!$user_id) {
+            return;
+        }
+
+        $codes = SucuriScanBackupCodes::consume_reveal($user_id);
+        $redirect_to = SucuriScanBackupCodes::consume_reveal_redirect($user_id);
+
+        if (empty($codes)) {
+            return;
+        }
+
+        self::ensure_backup_codes_script();
+
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        echo self::backup_codes_reveal_snippet($codes, $redirect_to);
     }
 
     /**
@@ -1132,8 +1280,13 @@ class SucuriScanTwoFactor extends SucuriScan
             SucuriScanEvent::reportInfoEvent('Two-factor authentication enabled for user ID ' . (int) $user_id);
         }
 
+        $backup_codes = SucuriScanBackupCodes::maybe_generate_for_user($user_id);
+
         $html = self::profile_status_snippet($user_id);
-        wp_send_json_success(array('html' => $html));
+        wp_send_json_success(array(
+            'html' => $html,
+            'backupCodes' => !empty($backup_codes) ? $backup_codes : array(),
+        ));
     }
 
 
@@ -1155,6 +1308,7 @@ class SucuriScanTwoFactor extends SucuriScan
 
         delete_user_meta($user_id, self::SECRET_META_KEY);
         delete_user_meta($user_id, self::LAST_SUCCESS_META_KEY);
+        SucuriScanBackupCodes::delete_for_user($user_id);
 
         if (class_exists('SucuriScanEvent')) {
             SucuriScanEvent::reportInfoEvent('Two-factor authentication reset for user ID ' . (int) $user_id);
@@ -1179,6 +1333,42 @@ class SucuriScanTwoFactor extends SucuriScan
         wp_send_json_success(array('html' => $html));
     }
 
+    /**
+     * AJAX handler to regenerate (invalidate + replace) a user's backup codes.
+     * Requires an existing Two-Factor secret (backup codes are a fallback for
+     * TOTP, not a standalone method).
+     * Expects POST with: user_id (int, optional), nonce (string, required).
+     *
+     * @return void (sends JSON response and exits)
+     */
+    public static function ajax_profile_backup_regen()
+    {
+        if (!is_user_logged_in()) {
+            wp_send_json_error(array('message' => 'Forbidden'), 403);
+        }
+
+        $resolved = self::resolve_ajax_target_user();
+        $user_id = $resolved['target'];
+
+        $existing_secret = self::get_user_totp_key($user_id);
+
+        if (empty($existing_secret)) {
+            wp_send_json_error(array(
+                'message' => __('Two-Factor must be enabled before generating backup codes.', 'sucuri-scanner'),
+            ), 400);
+        }
+
+        $backup_codes = SucuriScanBackupCodes::generate_for_user($user_id);
+
+        if (class_exists('SucuriScanEvent')) {
+            SucuriScanEvent::reportInfoEvent('Two-factor backup codes regenerated for user ID ' . (int) $user_id);
+        }
+
+        wp_send_json_success(array(
+            'html' => self::profile_status_snippet($user_id),
+            'backupCodes' => $backup_codes,
+        ));
+    }
 
     /**
      * Process and save 2FA settings when a user profile is updated.
@@ -1246,6 +1436,12 @@ class SucuriScanTwoFactor extends SucuriScan
                 SucuriScanEvent::reportInfoEvent('Two-factor authentication enabled for user ID ' . (int) $user_id);
             }
 
+            $backup_codes = SucuriScanBackupCodes::maybe_generate_for_user($user_id);
+
+            if (!empty($backup_codes)) {
+                SucuriScanBackupCodes::stash_reveal($user_id, $backup_codes);
+            }
+
             return;
         }
 
@@ -1259,6 +1455,7 @@ class SucuriScanTwoFactor extends SucuriScan
             }
             delete_user_meta($user_id, self::SECRET_META_KEY);
             delete_user_meta($user_id, self::LAST_SUCCESS_META_KEY);
+            SucuriScanBackupCodes::delete_for_user($user_id);
             if (class_exists('SucuriScanEvent')) {
                 SucuriScanEvent::reportInfoEvent('Two-factor authentication reset for user ID ' . (int) $user_id);
             }
@@ -1878,6 +2075,7 @@ class SucuriScanTwoFactor extends SucuriScan
                 foreach ($selected as $uid) {
                     delete_user_meta($uid, self::SECRET_META_KEY);
                     delete_user_meta($uid, self::LAST_SUCCESS_META_KEY);
+                    SucuriScanBackupCodes::delete_for_user($uid);
                 }
 
                 $result['success'] = true;
@@ -1901,6 +2099,7 @@ class SucuriScanTwoFactor extends SucuriScan
                 foreach ($all_ids as $uid) {
                     delete_user_meta($uid, self::SECRET_META_KEY);
                     delete_user_meta($uid, self::LAST_SUCCESS_META_KEY);
+                    SucuriScanBackupCodes::delete_for_user($uid);
                 }
 
                 $result['success'] = true;
@@ -1918,6 +2117,7 @@ class SucuriScanTwoFactor extends SucuriScan
                 foreach ($all_ids as $uid) {
                     delete_user_meta($uid, self::SECRET_META_KEY);
                     delete_user_meta($uid, self::LAST_SUCCESS_META_KEY);
+                    SucuriScanBackupCodes::delete_for_user($uid);
                 }
                 SucuriScanOption::updateOption(':twofactor_mode', 'disabled');
                 SucuriScanOption::updateOption(':twofactor_users', array());
@@ -1976,6 +2176,8 @@ class SucuriScanTwoFactor extends SucuriScan
         self::store_user_totp_key($user_id, $secret);
         update_user_meta($user_id, self::LAST_SUCCESS_META_KEY, $verified['valid_ts']);
 
+        $backup_codes = SucuriScanBackupCodes::maybe_generate_for_user($user_id);
+
         $enforce_all = false;
         $enforce_all_raw = SucuriScanRequest::post('enforce_all', '[01]');
 
@@ -2002,6 +2204,10 @@ class SucuriScanTwoFactor extends SucuriScan
             SucuriScanOption::updateOption(':twofactor_mode', 'selected_users');
         }
 
-        wp_send_json(array('data' => 'activated', 'error' => ''), 200);
+        wp_send_json(array(
+            'data' => 'activated',
+            'error' => '',
+            'backupCodes' => !empty($backup_codes) ? $backup_codes : array(),
+        ), 200);
     }
 }

--- a/src/topt.lib.php
+++ b/src/topt.lib.php
@@ -1065,12 +1065,21 @@ class SucuriScanTwoFactor extends SucuriScan
      * Build the one-time backup-codes reveal snippet (a hidden data element
      * consumed client-side by inc/js/backup-codes.js).
      *
+     * The destination is re-validated here even though the login flow already
+     * ran it through wp_validate_redirect() before stashing it: the value
+     * travels through a transient and ends up in window.location.assign(), so
+     * the guard is kept next to the sink rather than only at the entry point.
+     * wp_validate_redirect() is idempotent, and an empty fallback makes the
+     * client skip the redirect entirely rather than sending it somewhere else.
+     *
      * @param string[] $codes Plaintext codes.
      *
      * @return string HTML.
      */
     protected static function backup_codes_reveal_snippet(array $codes, $redirect_to = '')
     {
+        $redirect_to = wp_validate_redirect((string) $redirect_to, '');
+
         return SucuriScanTemplate::getSnippet('profile-2fa-backup-codes', array(
             'CodesJSON' => wp_json_encode(array_values($codes)),
             'RedirectURL' => wp_json_encode((string) $redirect_to),

--- a/src/topt.lib.php
+++ b/src/topt.lib.php
@@ -231,7 +231,7 @@ class SucuriScanTwoFactor extends SucuriScan
 
         if ($is_profile_context) {
             if ($hook === 'profile.php') {
-                $target_user = get_current_user_id();
+                $target_user = (int) get_current_user_id();
             } elseif ($hook === 'user-edit.php') {
                 $req_user = SucuriScanRequest::get('user_id', '[0-9]+');
 
@@ -240,7 +240,7 @@ class SucuriScanTwoFactor extends SucuriScan
                 }
             }
         } else {
-            $target_user = get_current_user_id();
+            $target_user = (int) get_current_user_id();
         }
 
         if (!self::is_enforced_for_user($target_user) && !$is_plugin_twofactor_page) {
@@ -929,9 +929,13 @@ class SucuriScanTwoFactor extends SucuriScan
      */
     protected static function resolve_ajax_target_user()
     {
-        $current = get_current_user_id();
+        // Caller identity always comes from the session, never from the
+        // request; the POSTed user_id below is only ever a target. Cast so the
+        // strict comparison against the (int) target does not depend on the
+        // return type of get_current_user_id().
+        $current = (int) get_current_user_id();
 
-        if (!$current || $current <= 0) {
+        if ($current <= 0) {
             wp_send_json_error(array('message' => 'Forbidden'), 403);
         }
 
@@ -1010,17 +1014,30 @@ class SucuriScanTwoFactor extends SucuriScan
     /**
      * Build status snippet HTML (enabled state actions) for a user.
      *
+     * The backup-codes row is only included when the viewer is the account
+     * owner, because regeneration reveals the plaintext codes to whoever clicks
+     * the button. See ajax_profile_backup_regen().
+     *
      * @param int $user_id
+     * @param bool $is_self Whether the current user owns this account.
      *
      * @return string
      */
-    protected static function profile_status_snippet($user_id)
+    protected static function profile_status_snippet($user_id, $is_self = true)
     {
+        $backup_row_html = '';
+
+        if ($is_self) {
+            $backup_row_html = SucuriScanTemplate::getSnippet('profile-2fa-backup-row', array(
+                'BackupCodesRemaining' => SucuriScanBackupCodes::remaining_count($user_id),
+            ));
+        }
+
         return SucuriScanTemplate::getSnippet('profile-2fa-status', array(
             'ajax_url' => admin_url('admin-ajax.php'),
             'ajax_nonce' => wp_create_nonce('sucuri_profile_2fa_' . (int) $user_id),
             'user_id' => (int) $user_id,
-            'BackupCodesRemaining' => SucuriScanBackupCodes::remaining_count($user_id),
+            'BackupCodesRowHTML' => $backup_row_html,
         ));
     }
 
@@ -1071,9 +1088,9 @@ class SucuriScanTwoFactor extends SucuriScan
      */
     public static function render_backup_codes_reveal_notice()
     {
-        $user_id = get_current_user_id();
+        $user_id = (int) get_current_user_id();
 
-        if (!$user_id) {
+        if ($user_id <= 0) {
             return;
         }
 
@@ -1200,8 +1217,8 @@ class SucuriScanTwoFactor extends SucuriScan
             return;
         }
 
-        $current_id = get_current_user_id();
-        $is_self = ((int) $user->ID === (int) $current_id);
+        $current_id = (int) get_current_user_id();
+        $is_self = ((int) $user->ID === $current_id);
         $can_manage_users = SucuriScanPermissions::canEditUsers();
 
         if (!self::is_enforced_for_user((int) $user->ID)) {
@@ -1219,7 +1236,7 @@ class SucuriScanTwoFactor extends SucuriScan
         $uid = (int) $user->ID;
 
         if ($enabled) {
-            $actions_html = self::profile_status_snippet($uid);
+            $actions_html = self::profile_status_snippet($uid, $is_self);
         } else {
             $actions_html = '';
 
@@ -1337,6 +1354,15 @@ class SucuriScanTwoFactor extends SucuriScan
      * AJAX handler to regenerate (invalidate + replace) a user's backup codes.
      * Requires an existing Two-Factor secret (backup codes are a fallback for
      * TOTP, not a standalone method).
+     *
+     * Self-only, even for users with edit_users: this endpoint returns the
+     * plaintext codes to the caller, and a backup code is a full substitute for
+     * the TOTP second factor at login. Letting an administrator regenerate for
+     * someone else would hand them usable credentials for that account while
+     * leaving the target with no signal that anything changed (their
+     * authenticator keeps working). Administrators recovering a locked-out user
+     * should reset Two-Factor instead; re-enrollment issues a fresh set.
+     *
      * Expects POST with: user_id (int, optional), nonce (string, required).
      *
      * @return void (sends JSON response and exits)
@@ -1349,6 +1375,10 @@ class SucuriScanTwoFactor extends SucuriScan
 
         $resolved = self::resolve_ajax_target_user();
         $user_id = $resolved['target'];
+
+        if (!$resolved['is_self']) {
+            wp_send_json_error(array('message' => __('You can only regenerate backup codes for your own account.', 'sucuri-scanner')), 403);
+        }
 
         $existing_secret = self::get_user_totp_key($user_id);
 
@@ -1398,8 +1428,8 @@ class SucuriScanTwoFactor extends SucuriScan
             return;
         }
 
-        $current_id = get_current_user_id();
-        $is_self = ($current_id && (int) $current_id === $user_id);
+        $current_id = (int) get_current_user_id();
+        $is_self = ($current_id > 0 && $current_id === $user_id);
 
         if ($action === 'enable') {
             if (!$is_self) {
@@ -1474,13 +1504,13 @@ class SucuriScanTwoFactor extends SucuriScan
             return SucuriScanInterface::error(__('Incorrect nonce.', 'sucuri-scanner'));
         }
 
-        $user = wp_get_current_user();
+        $user_id = (int) get_current_user_id();
 
-        if (!$user->ID) {
+        if ($user_id <= 0) {
             return SucuriScanInterface::error(__('Incorrect user.', 'sucuri-scanner'));
         }
 
-        $existing = self::get_user_totp_key((int) $user->ID);
+        $existing = self::get_user_totp_key($user_id);
 
         if (!empty($existing)) {
             return SucuriScanTemplate::getSnippet('2fa-current-user-status', array(
@@ -1488,7 +1518,7 @@ class SucuriScanTwoFactor extends SucuriScan
             ));
         }
 
-        $data = self::generate_setup_key_and_otpauth((int) $user->ID);
+        $data = self::generate_setup_key_and_otpauth($user_id);
 
         if (empty($data)) {
             return SucuriScanInterface::error(__('Unable to generate secret.', 'sucuri-scanner'));
@@ -1514,13 +1544,13 @@ class SucuriScanTwoFactor extends SucuriScan
      */
     public static function current_user_block()
     {
-        $user = wp_get_current_user();
+        $user_id = (int) get_current_user_id();
 
-        if (!$user || !$user->ID) {
+        if ($user_id <= 0) {
             return SucuriScanInterface::error(__('Incorrect user.', 'sucuri-scanner'));
         }
 
-        $existing = self::get_user_totp_key((int) $user->ID);
+        $existing = self::get_user_totp_key($user_id);
 
         if (!empty($existing)) {
             return SucuriScanTemplate::getSnippet('2fa-current-user-status', array(
@@ -1528,7 +1558,7 @@ class SucuriScanTwoFactor extends SucuriScan
             ));
         }
 
-        $data = self::generate_setup_key_and_otpauth((int) $user->ID);
+        $data = self::generate_setup_key_and_otpauth($user_id);
 
         if (empty($data)) {
             return SucuriScanInterface::error(__('Unable to generate secret.', 'sucuri-scanner'));
@@ -2154,13 +2184,12 @@ class SucuriScanTwoFactor extends SucuriScan
             return SucuriScanInterface::error(__('Incorrect nonce.', 'sucuri-scanner'));
         }
 
-        $user = wp_get_current_user();
+        $user_id = (int) get_current_user_id();
 
-        if (!$user || !$user->ID) {
+        if ($user_id <= 0) {
             return SucuriScanInterface::error(__('Incorrect user.', 'sucuri-scanner'));
         }
 
-        $user_id = (int) $user->ID;
         $existingKey = self::get_user_totp_key($user_id);
         $code_raw = SucuriScanRequest::post('topt_code', '[0-9 ]+');
         $code = $code_raw ? preg_replace('/\D+/', '', $code_raw) : '';

--- a/sucuri.php
+++ b/sucuri.php
@@ -234,6 +234,7 @@ require_once 'src/cachecontrol.lib.php';
 require_once 'src/csp.lib.php';
 require_once 'src/cors.lib.php';
 require_once 'src/totp.core.php';
+require_once 'src/backupcodes.lib.php';
 require_once 'src/topt.lib.php';
 
 /* Load page and ajax handlers */

--- a/tests/BackupCodesRevealRedirectTest.php
+++ b/tests/BackupCodesRevealRedirectTest.php
@@ -1,0 +1,230 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+
+require_once __DIR__ . '/autoload.php';
+
+/**
+ * Tests for the post-reveal redirect carried by the backup-codes reveal
+ * element (SucuriScanTwoFactor::backup_codes_reveal_snippet).
+ *
+ * The destination originates as the wp-login.php "redirect_to" request
+ * parameter, survives a transient, and is finally handed to
+ * window.location.assign() by inc/js/backup-codes.js. Because location.assign()
+ * executes "javascript:" URLs in the site's own origin, an unvalidated value
+ * reaching the element would be stored XSS rather than merely an open redirect.
+ * The login flow validates it once on the way in; these tests pin the second
+ * check that keeps the guard next to the sink.
+ */
+final class BackupCodesRevealRedirectTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when('__')->returnArg(1);
+        Functions\when('esc_html__')->returnArg(1);
+        Functions\when('esc_html')->returnArg(1);
+        Functions\when('wp_strip_all_tags')->returnArg(1);
+        Functions\when('get_site_url')->justReturn('https://example.com');
+        Functions\when('site_url')->justReturn('https://example.com');
+        Functions\when('get_bloginfo')->justReturn('6.0');
+        Functions\when('get_home_path')->justReturn('/');
+        Functions\when('sucuriscan_lastlogins_datastore_exists')->justReturn(true);
+        Functions\when('wp_json_encode')->alias('json_encode');
+
+        Functions\when('wp_cache_get')->justReturn(false);
+        Functions\when('wp_cache_set')->justReturn(true);
+        Functions\when('wp_cache_delete')->justReturn(true);
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    /**
+     * Stand-in for wp_validate_redirect() mirroring the two core rules this
+     * code depends on: only http/https schemes survive, and only the site's own
+     * host survives. Anything else collapses to the fallback.
+     *
+     * @return void
+     */
+    private function stubValidateRedirect(): void
+    {
+        Functions\when('wp_validate_redirect')->alias(function ($location, $fallback = '') {
+            $location = (string) $location;
+
+            if ($location === '') {
+                return $fallback;
+            }
+
+            // Core resolves protocol-relative URLs before parsing them.
+            if (strpos($location, '//') === 0) {
+                $location = 'http:' . $location;
+            }
+
+            $parts = parse_url($location);
+
+            if ($parts === false) {
+                return $fallback;
+            }
+
+            if (isset($parts['scheme'])
+                && !in_array(strtolower($parts['scheme']), array('http', 'https'), true)
+            ) {
+                return $fallback;
+            }
+
+            if (isset($parts['host']) && strtolower($parts['host']) !== 'example.com') {
+                return $fallback;
+            }
+
+            return $location;
+        });
+    }
+
+    /**
+     * @param string $redirect_to
+     * @return string Rendered snippet HTML.
+     */
+    private function render(string $redirect_to): string
+    {
+        $ref = new ReflectionClass(SucuriScanTwoFactor::class);
+        $method = $ref->getMethod('backup_codes_reveal_snippet');
+        $method->setAccessible(true);
+
+        return (string) $method->invoke(null, array('AAAA-BBBB'), $redirect_to);
+    }
+
+    /**
+     * Pull data-redirect-url back out of the markup the way the browser does:
+     * decode the HTML attribute, then JSON.parse it.
+     *
+     * @param string $html
+     * @return mixed
+     */
+    private function decodeRedirectAttribute(string $html)
+    {
+        $this->assertSame(
+            1,
+            preg_match('/data-redirect-url="([^"]*)"/', $html, $matches),
+            'the reveal element must carry exactly one data-redirect-url attribute'
+        );
+
+        return json_decode(html_entity_decode($matches[1], ENT_QUOTES, 'UTF-8'), true);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public function hostileRedirectProvider(): array
+    {
+        return array(
+            'javascript scheme' => array('javascript:alert(document.cookie)'),
+            'mixed case javascript scheme' => array('JaVaScRiPt:alert(1)'),
+            'data scheme' => array('data:text/html,<script>alert(1)</script>'),
+            'protocol relative offsite' => array('//evil.example.net/phish'),
+            'absolute offsite' => array('https://evil.example.net/phish'),
+            'userinfo confusion' => array('https://example.com@evil.example.net/'),
+        );
+    }
+
+    /**
+     * @dataProvider hostileRedirectProvider
+     *
+     * @param string $redirect_to
+     * @return void
+     */
+    public function testHostileRedirectNeverReachesTheRevealElement(string $redirect_to): void
+    {
+        $this->stubValidateRedirect();
+
+        $html = $this->render($redirect_to);
+
+        $this->assertSame(
+            '',
+            $this->decodeRedirectAttribute($html),
+            'a rejected destination must render as an empty string so the client skips the redirect'
+        );
+
+        // Also assert the raw payload is nowhere in the markup, in case a future
+        // change renders it into some other attribute.
+        $this->assertStringNotContainsString('evil.example.net', $html);
+        $this->assertStringNotContainsString('alert(', $html);
+    }
+
+    public function testSameOriginRedirectSurvives(): void
+    {
+        $this->stubValidateRedirect();
+
+        $html = $this->render('https://example.com/account');
+
+        $this->assertSame('https://example.com/account', $this->decodeRedirectAttribute($html));
+    }
+
+    public function testRelativeRedirectSurvives(): void
+    {
+        $this->stubValidateRedirect();
+
+        $html = $this->render('/wp-admin/profile.php');
+
+        $this->assertSame('/wp-admin/profile.php', $this->decodeRedirectAttribute($html));
+    }
+
+    /**
+     * The assertions above depend on the stub above behaving like core. This one
+     * does not: it fails if the render path stops delegating to
+     * wp_validate_redirect() at all, whatever that function happens to return.
+     */
+    public function testRevealSnippetDelegatesToWpValidateRedirect(): void
+    {
+        Functions\expect('wp_validate_redirect')
+            ->once()
+            ->with('javascript:alert(1)', '')
+            ->andReturn('');
+
+        $html = $this->render('javascript:alert(1)');
+
+        $this->assertSame('', $this->decodeRedirectAttribute($html));
+    }
+
+    /**
+     * The server-side guard is one of two; this pins the client-side half, which
+     * is the one that does not depend on every future caller of stash_reveal()
+     * remembering to validate. Asserted against the source because the plugin
+     * ships no JavaScript test runner (same approach as TwoFactorTest).
+     */
+    public function testRevealScriptResolvesRedirectToASameOriginUrl(): void
+    {
+        $script = file_get_contents(BASE_DIR . '/inc/js/backup-codes.js');
+
+        $this->assertNotFalse($script);
+
+        // The parsed value must pass through the guard, not go straight to the
+        // sink. Matched with a whitespace-tolerant pattern so Prettier is free
+        // to reflow the call across lines.
+        $this->assertMatchesRegularExpression(
+            '/sameOriginURL\(\s*JSON\.parse\(\s*revealData\.dataset\.redirectUrl/',
+            $script
+        );
+        $this->assertStringContainsString('target.origin !== window.location.origin', $script);
+        $this->assertStringContainsString('target.protocol !== "http:"', $script);
+
+        // location.assign() must have exactly one call site, so the guard cannot
+        // be sidestepped by a second one. Comments are stripped first: the
+        // rationale above the guard names the sink, and that mention must not
+        // count as a call site.
+        $code = preg_replace('~/\*.*?\*/~s', '', $script);
+
+        $this->assertSame(
+            1,
+            substr_count($code, 'window.location.assign('),
+            'window.location.assign() must have a single call site'
+        );
+    }
+}

--- a/tests/BackupCodesTest.php
+++ b/tests/BackupCodesTest.php
@@ -1,0 +1,254 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+
+require_once __DIR__ . '/autoload.php';
+
+if (!class_exists('SucuriScanBackupCodes')) {
+    require BASE_DIR . '/src/backupcodes.lib.php';
+}
+
+/**
+ * Tests focused on SucuriScanBackupCodes generation, storage, normalization,
+ * validation/consumption and one-time reveal semantics.
+ */
+final class BackupCodesTest extends TestCase
+{
+    /** @var array<int, array<string, mixed>> */
+    private $userMeta = [];
+
+    /** @var array<string, mixed> */
+    private $transients = [];
+
+    /** @var string|false */
+    private $auditQueueSnapshot = false;
+
+    /** @var bool */
+    private $failConditionalUpdate = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        // validate_and_consume() triggers real SucuriScanEvent logging,
+        // which appends to this fixture file on disk; snapshot it so
+        // tearDown() can restore it and these tests don't leave the
+        // checked-in fixture dirty.
+        $auditQueuePath = BASE_DIR . '/tests/fixtures/sucuri-auditqueue.php';
+
+        if (file_exists($auditQueuePath)) {
+            $this->auditQueueSnapshot = file_get_contents($auditQueuePath);
+        }
+
+        $this->userMeta = [];
+        $this->transients = [];
+        $this->failConditionalUpdate = false;
+
+        // Deterministic stand-ins for WP's real hashing so tests don't
+        // depend on bcrypt/phpass being available in this environment.
+        Functions\when('wp_hash_password')->alias(function ($password) {
+            return 'HASH:' . $password;
+        });
+
+        Functions\when('wp_check_password')->alias(function ($password, $hash, $user_id = '') {
+            return $hash === 'HASH:' . $password;
+        });
+
+        Functions\when('get_user_meta')->alias(function ($user_id, $key, $single = false) {
+            return isset($this->userMeta[$user_id][$key]) ? $this->userMeta[$user_id][$key] : '';
+        });
+
+        Functions\when('update_user_meta')->alias(function ($user_id, $key, $value, $previous = null) {
+            if (func_num_args() === 4) {
+                if ($this->failConditionalUpdate || !isset($this->userMeta[$user_id][$key]) || $this->userMeta[$user_id][$key] !== $previous) {
+                    return false;
+                }
+            }
+
+            $this->userMeta[$user_id][$key] = $value;
+            return true;
+        });
+
+        Functions\when('delete_user_meta')->alias(function ($user_id, $key) {
+            unset($this->userMeta[$user_id][$key]);
+            return true;
+        });
+
+        Functions\when('set_transient')->alias(function ($key, $value, $ttl = 0) {
+            $this->transients[$key] = $value;
+            return true;
+        });
+
+        Functions\when('get_transient')->alias(function ($key) {
+            return isset($this->transients[$key]) ? $this->transients[$key] : false;
+        });
+
+        Functions\when('delete_transient')->alias(function ($key) {
+            unset($this->transients[$key]);
+            return true;
+        });
+
+        // validate_and_consume() logs via SucuriScanEvent, which cascades
+        // into SucuriScanOption's cache-backed option reads and i18n calls.
+        Functions\when('wp_cache_get')->justReturn(false);
+        Functions\when('wp_cache_set')->justReturn(true);
+        Functions\when('wp_cache_delete')->justReturn(true);
+        Functions\when('__')->returnArg(1);
+        Functions\when('wp_strip_all_tags')->alias(function ($text) {
+            return trim(strip_tags((string) $text));
+        });
+
+        // validate_and_consume() logging cascades into the plugin's local
+        // audit-log queue (SucuriScanEvent::sendLogToQueue()); neutralize
+        // its filesystem/hardening side effects for these unit tests.
+        Functions\when('sucuriscan_lastlogins_datastore_exists')->justReturn(true);
+        Functions\when('get_home_path')->justReturn('/');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->auditQueueSnapshot !== false) {
+            file_put_contents(BASE_DIR . '/tests/fixtures/sucuri-auditqueue.php', $this->auditQueueSnapshot);
+        }
+
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function testGenerateForUserReturnsTenUniqueFormattedCodes(): void
+    {
+        $codes = SucuriScanBackupCodes::generate_for_user(101);
+
+        $this->assertCount(10, $codes);
+        $this->assertCount(10, array_unique($codes), 'codes should be unique');
+
+        foreach ($codes as $code) {
+            $this->assertMatchesRegularExpression('/^[23456789A-HJ-KM-NP-Z]{4}-[23456789A-HJ-KM-NP-Z]{4}$/', $code);
+        }
+    }
+
+    public function testGenerateForUserStoresHashesNotPlaintext(): void
+    {
+        $codes = SucuriScanBackupCodes::generate_for_user(101);
+
+        $stored = $this->userMeta[101][SucuriScanBackupCodes::META_KEY];
+
+        $this->assertCount(10, $stored);
+
+        foreach ($codes as $index => $code) {
+            $this->assertNotSame($code, $stored[$index]);
+            $this->assertStringStartsWith('HASH:', $stored[$index]);
+        }
+    }
+
+    public function testMaybeGenerateForUserIsIdempotent(): void
+    {
+        $first = SucuriScanBackupCodes::maybe_generate_for_user(202);
+        $this->assertCount(10, $first);
+
+        $second = SucuriScanBackupCodes::maybe_generate_for_user(202);
+        $this->assertNull($second, 'must not regenerate when a set already exists');
+
+        // Confirm the originally stored hashes were not overwritten.
+        $stored = $this->userMeta[202][SucuriScanBackupCodes::META_KEY];
+        $this->assertTrue(SucuriScanBackupCodes::validate_and_consume(202, $first[0]));
+        unset($stored);
+    }
+
+    public function testHasCodesReflectsGenerationState(): void
+    {
+        $this->assertFalse(SucuriScanBackupCodes::has_codes(303));
+
+        SucuriScanBackupCodes::generate_for_user(303);
+
+        $this->assertTrue(SucuriScanBackupCodes::has_codes(303));
+    }
+
+    public function testDeleteForUserClearsStoredCodes(): void
+    {
+        SucuriScanBackupCodes::generate_for_user(404);
+        $this->assertTrue(SucuriScanBackupCodes::has_codes(404));
+
+        SucuriScanBackupCodes::delete_for_user(404);
+
+        $this->assertFalse(SucuriScanBackupCodes::has_codes(404));
+    }
+
+    public function testRemainingCountDecrementsOnConsumption(): void
+    {
+        $codes = SucuriScanBackupCodes::generate_for_user(505);
+        $this->assertSame(10, SucuriScanBackupCodes::remaining_count(505));
+
+        SucuriScanBackupCodes::validate_and_consume(505, $codes[0]);
+
+        $this->assertSame(9, SucuriScanBackupCodes::remaining_count(505));
+    }
+
+    public function testValidateAndConsumeAcceptsCodeOnlyOnce(): void
+    {
+        $codes = SucuriScanBackupCodes::generate_for_user(606);
+
+        $this->assertTrue(SucuriScanBackupCodes::validate_and_consume(606, $codes[3]));
+        $this->assertFalse(SucuriScanBackupCodes::validate_and_consume(606, $codes[3]), 'a code must be single-use');
+    }
+
+    public function testValidateAndConsumeRejectsCodeWhenConditionalUpdateFails(): void
+    {
+        $codes = SucuriScanBackupCodes::generate_for_user(607);
+        $this->failConditionalUpdate = true;
+
+        $this->assertFalse(SucuriScanBackupCodes::validate_and_consume(607, $codes[0]));
+        $this->assertSame(10, SucuriScanBackupCodes::remaining_count(607));
+    }
+
+    public function testValidateAndConsumeNormalizesCaseSpacingAndDashes(): void
+    {
+        $codes = SucuriScanBackupCodes::generate_for_user(707);
+        $raw = $codes[0]; // formatted as XXXX-XXXX
+
+        $messy = ' ' . strtolower(str_replace('-', ' ', $raw)) . ' ';
+
+        $this->assertTrue(SucuriScanBackupCodes::validate_and_consume(707, $messy));
+    }
+
+    public function testValidateAndConsumeRejectsUnknownOrMalformedCode(): void
+    {
+        SucuriScanBackupCodes::generate_for_user(808);
+
+        $this->assertFalse(SucuriScanBackupCodes::validate_and_consume(808, 'ZZZZ-ZZZZ'));
+        $this->assertFalse(SucuriScanBackupCodes::validate_and_consume(808, 'short'));
+        $this->assertFalse(SucuriScanBackupCodes::validate_and_consume(808, ''));
+    }
+
+    public function testStashAndConsumeRevealIsSingleRead(): void
+    {
+        $codes = ['AAAA-1111', 'BBBB-2222'];
+
+        SucuriScanBackupCodes::stash_reveal(909, $codes);
+
+        $first = SucuriScanBackupCodes::consume_reveal(909);
+        $this->assertSame($codes, $first);
+
+        $second = SucuriScanBackupCodes::consume_reveal(909);
+        $this->assertSame([], $second, 'a stashed reveal must not be readable twice');
+    }
+
+    public function testStashAndConsumeRevealRedirectIsSingleRead(): void
+    {
+        $redirect = 'https://example.com/after-login';
+
+        SucuriScanBackupCodes::stash_reveal(910, array('AAAA-1111'), $redirect);
+
+        $this->assertSame($redirect, SucuriScanBackupCodes::consume_reveal_redirect(910));
+        $this->assertSame('', SucuriScanBackupCodes::consume_reveal_redirect(910));
+    }
+
+    public function testNormalizeCodeUppercasesAndStripsInvalidCharacters(): void
+    {
+        $this->assertSame('ABCD2345', SucuriScanBackupCodes::normalize_code(' abcd-2345 '));
+        $this->assertSame('', SucuriScanBackupCodes::normalize_code('01IlOo'));
+    }
+}

--- a/tests/TwoFactorBackupRegenTest.php
+++ b/tests/TwoFactorBackupRegenTest.php
@@ -1,0 +1,278 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+
+require_once __DIR__ . '/autoload.php';
+
+/**
+ * Exception used to capture wp_send_json_error()/wp_send_json_success()
+ * payloads in tests (mirrors the way WordPress halts execution after
+ * emitting JSON).
+ */
+class BackupRegenSendJsonStop extends \RuntimeException
+{
+    /** @var bool */
+    public $success;
+
+    /** @var mixed */
+    public $payload;
+
+    /** @var int|null */
+    public $status;
+
+    public function __construct($success, $payload, $status = null)
+    {
+        parent::__construct('wp_send_json');
+
+        $this->success = (bool) $success;
+        $this->payload = $payload;
+        $this->status = $status;
+    }
+}
+
+/**
+ * Tests for the authorization boundary on backup-code regeneration
+ * (SucuriScanTwoFactor::ajax_profile_backup_regen).
+ *
+ * Regeneration is deliberately self-only, even for users holding edit_users:
+ * the endpoint returns the plaintext codes to the caller, and a backup code is
+ * a full substitute for the TOTP second factor at login. An administrator who
+ * could regenerate for someone else would obtain usable credentials for that
+ * account while the target keeps a working authenticator and therefore has no
+ * signal that anything changed.
+ */
+final class TwoFactorBackupRegenTest extends TestCase
+{
+    /** @var array<int, array<string, mixed>> */
+    private $userMeta = [];
+
+    /** @var array<string, string> */
+    private $fixtureSnapshots = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        // Regeneration reports an audit event and these tests set the
+        // enforcement mode, both of which write to these fixture files on disk;
+        // snapshot them so tearDown() restores them and the checked-in fixtures
+        // are not left dirty.
+        foreach (['sucuri-auditqueue.php', 'sucuri-settings.php'] as $fixture) {
+            $path = BASE_DIR . '/tests/fixtures/' . $fixture;
+
+            if (file_exists($path)) {
+                $this->fixtureSnapshots[$path] = file_get_contents($path);
+            }
+        }
+
+        $this->userMeta = [];
+
+        Functions\when('__')->returnArg(1);
+        Functions\when('esc_html__')->returnArg(1);
+        Functions\when('esc_html')->returnArg(1);
+        Functions\when('is_user_logged_in')->justReturn(true);
+        Functions\when('wp_verify_nonce')->justReturn(true);
+
+        Functions\when('wp_hash_password')->alias(fn($password) => 'HASH:' . $password);
+
+        Functions\when('wp_cache_get')->justReturn(false);
+        Functions\when('wp_cache_set')->justReturn(true);
+        Functions\when('wp_cache_delete')->justReturn(true);
+
+        // Needed by SucuriScanEvent (audit reporting) and by the template
+        // engine's shared params when a snippet is rendered.
+        Functions\when('wp_strip_all_tags')->returnArg(1);
+        Functions\when('get_site_url')->justReturn('https://example.com');
+        Functions\when('get_bloginfo')->justReturn('6.0');
+        Functions\when('site_url')->justReturn('https://example.com');
+        Functions\when('sucuriscan_lastlogins_datastore_exists')->justReturn(true);
+        Functions\when('get_home_path')->justReturn('/');
+
+        Functions\when('get_user_meta')->alias(function ($user_id, $key, $single = false) {
+            return isset($this->userMeta[$user_id][$key]) ? $this->userMeta[$user_id][$key] : '';
+        });
+
+        Functions\when('update_user_meta')->alias(function ($user_id, $key, $value) {
+            $this->userMeta[$user_id][$key] = $value;
+
+            return true;
+        });
+
+        Functions\when('delete_user_meta')->alias(function ($user_id, $key) {
+            unset($this->userMeta[$user_id][$key]);
+
+            return true;
+        });
+
+        Functions\when('wp_send_json_error')->alias(function ($payload, $status = null) {
+            throw new BackupRegenSendJsonStop(false, $payload, $status);
+        });
+
+        Functions\when('wp_send_json_success')->alias(function ($payload, $status = null) {
+            throw new BackupRegenSendJsonStop(true, $payload, $status);
+        });
+
+        // Two-Factor must be enforced for the target, otherwise
+        // resolve_ajax_target_user() bails before the self-only check.
+        SucuriScanOption::updateOption(':twofactor_mode', 'all_users');
+
+        $_POST = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_POST = [];
+
+        unset($GLOBALS['__test_current_user_can']);
+
+        foreach ($this->fixtureSnapshots as $path => $contents) {
+            file_put_contents($path, $contents);
+        }
+
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    /**
+     * Give a user an existing TOTP secret so regeneration gets past the
+     * "Two-Factor must be enabled" precondition.
+     *
+     * @param int $user_id
+     * @return void
+     */
+    private function enableTotpFor(int $user_id): void
+    {
+        $this->userMeta[$user_id][SucuriScanTwoFactor::SECRET_META_KEY] = 'JBSWY3DPEHPK3PXP';
+    }
+
+    /**
+     * @param string $name Protected/static method name.
+     * @return ReflectionMethod
+     */
+    private function method(string $name): ReflectionMethod
+    {
+        $ref = new ReflectionClass(SucuriScanTwoFactor::class);
+        $m = $ref->getMethod($name);
+        $m->setAccessible(true);
+
+        return $m;
+    }
+
+    public function testRegenDeniedForAnotherUserEvenWithEditUsers(): void
+    {
+        // An administrator (edit_users granted) targeting somebody else.
+        $GLOBALS['__test_current_user_can'] = true;
+        Functions\when('get_current_user_id')->justReturn(1);
+
+        $this->enableTotpFor(99);
+
+        $_POST['user_id'] = '99';
+        $_POST['nonce'] = 'nonce';
+
+        try {
+            SucuriScanTwoFactor::ajax_profile_backup_regen();
+            $this->fail('Expected wp_send_json_error to halt execution');
+        } catch (BackupRegenSendJsonStop $e) {
+            $this->assertFalse($e->success, 'regenerating for another user must not succeed');
+            $this->assertSame(403, $e->status);
+            $this->assertStringContainsString('your own account', $e->payload['message']);
+        }
+
+        // Crucially, no codes may be minted for the target as a side effect.
+        $this->assertArrayNotHasKey(
+            SucuriScanBackupCodes::META_KEY,
+            $this->userMeta[99],
+            'no backup codes may be generated for a non-self target'
+        );
+    }
+
+    public function testRegenAllowedForSelf(): void
+    {
+        $GLOBALS['__test_current_user_can'] = false; // no edit_users needed for self
+        Functions\when('get_current_user_id')->justReturn(7);
+
+        $this->enableTotpFor(7);
+
+        $_POST['user_id'] = '7';
+        $_POST['nonce'] = 'nonce';
+
+        try {
+            SucuriScanTwoFactor::ajax_profile_backup_regen();
+            $this->fail('Expected wp_send_json_success to halt execution');
+        } catch (BackupRegenSendJsonStop $e) {
+            $this->assertTrue($e->success, 'self regeneration must succeed');
+            $this->assertCount(SucuriScanBackupCodes::CODE_COUNT, $e->payload['backupCodes']);
+        }
+
+        $this->assertArrayHasKey(SucuriScanBackupCodes::META_KEY, $this->userMeta[7]);
+    }
+
+    /**
+     * resolve_ajax_target_user() casts get_current_user_id() before comparing
+     * it to the (int) target, so self-detection does not silently depend on
+     * core's return type. Without the cast the strict comparison would go
+     * false and this legitimate self-request would be denied.
+     */
+    public function testSelfDetectionSurvivesNumericStringCurrentUserId(): void
+    {
+        $GLOBALS['__test_current_user_can'] = false;
+        Functions\when('get_current_user_id')->justReturn('7');
+
+        $this->enableTotpFor(7);
+
+        $_POST['user_id'] = '7';
+        $_POST['nonce'] = 'nonce';
+
+        try {
+            SucuriScanTwoFactor::ajax_profile_backup_regen();
+            $this->fail('Expected wp_send_json_success to halt execution');
+        } catch (BackupRegenSendJsonStop $e) {
+            $this->assertTrue($e->success, 'a numeric-string user id must still resolve as self');
+            $this->assertCount(SucuriScanBackupCodes::CODE_COUNT, $e->payload['backupCodes']);
+        }
+    }
+
+    public function testRegenRequiresAnExistingSecret(): void
+    {
+        Functions\when('get_current_user_id')->justReturn(7);
+
+        // No secret stored for user 7.
+        $_POST['user_id'] = '7';
+        $_POST['nonce'] = 'nonce';
+
+        try {
+            SucuriScanTwoFactor::ajax_profile_backup_regen();
+            $this->fail('Expected wp_send_json_error to halt execution');
+        } catch (BackupRegenSendJsonStop $e) {
+            $this->assertFalse($e->success);
+            $this->assertSame(400, $e->status);
+        }
+    }
+
+    public function testStatusSnippetOmitsRegenControlForOtherUsers(): void
+    {
+        $html = $this->method('profile_status_snippet')->invoke(null, 42, false);
+
+        $this->assertNotSame('', $html, 'the status snippet itself must still render');
+        // Assert on the markup, not the bare id: the inline script keeps a
+        // '#sucuri-2fa-backup-regen-btn' selector either way (it no-ops when
+        // the control is absent).
+        $this->assertStringNotContainsString('id="sucuri-2fa-backup-regen-btn"', $html);
+        $this->assertStringNotContainsString('data-cy="sucuriscan-2fa-backup-regen-btn"', $html);
+        $this->assertStringNotContainsString('backup code(s) remaining', $html);
+        // The reset control remains available to administrators.
+        $this->assertStringContainsString('id="sucuri-2fa-reset-btn"', $html);
+    }
+
+    public function testStatusSnippetIncludesRegenControlForSelf(): void
+    {
+        $html = $this->method('profile_status_snippet')->invoke(null, 42, true);
+
+        $this->assertStringContainsString('id="sucuri-2fa-backup-regen-btn"', $html);
+        $this->assertStringContainsString('data-cy="sucuriscan-2fa-backup-regen-btn"', $html);
+        $this->assertStringContainsString('backup code(s) remaining', $html);
+    }
+}

--- a/tests/TwoFactorBackupRegenTest.php
+++ b/tests/TwoFactorBackupRegenTest.php
@@ -45,6 +45,16 @@ class BackupRegenSendJsonStop extends \RuntimeException
  */
 final class TwoFactorBackupRegenTest extends TestCase
 {
+    /**
+     * Markup the regeneration control is identified by. Shared between the
+     * "omits" and "includes" snippet tests on purpose: the omission test can
+     * only assert absence, which would rot silently if the template renamed
+     * these, so it is paired with a presence test over the same literals.
+     */
+    private const REGEN_BTN_ID = 'id="sucuri-2fa-backup-regen-btn"';
+    private const REGEN_BTN_CY = 'data-cy="sucuriscan-2fa-backup-regen-btn"';
+    private const REGEN_BTN_LABEL = 'backup code(s) remaining';
+
     /** @var array<int, array<string, mixed>> */
     private $userMeta = [];
 
@@ -149,6 +159,56 @@ final class TwoFactorBackupRegenTest extends TestCase
     }
 
     /**
+     * Run an endpoint that is expected to terminate the request via
+     * wp_send_json_*() and hand back the captured response.
+     *
+     * The stubs throw because the real functions die(): without that, execution
+     * would fall through a branch that is terminal in production and the
+     * side-effect assertions below would be meaningless.
+     *
+     * @param callable $fn
+     * @return BackupRegenSendJsonStop
+     */
+    private function captureJsonStop(callable $fn): BackupRegenSendJsonStop
+    {
+        try {
+            $fn();
+        } catch (BackupRegenSendJsonStop $e) {
+            return $e;
+        }
+
+        $this->fail('Expected wp_send_json_* to halt execution');
+    }
+
+    /**
+     * Assert that the request minted no backup codes for the given user.
+     *
+     * @param int $user_id
+     * @param string $message
+     * @return void
+     */
+    private function assertNoCodesMintedFor(int $user_id, string $message): void
+    {
+        $this->assertArrayNotHasKey(
+            SucuriScanBackupCodes::META_KEY,
+            isset($this->userMeta[$user_id]) ? $this->userMeta[$user_id] : [],
+            $message
+        );
+    }
+
+    /**
+     * Read back the local audit queue the plugin writes events into.
+     *
+     * @return string
+     */
+    private function auditQueueContents(): string
+    {
+        $path = BASE_DIR . '/tests/fixtures/sucuri-auditqueue.php';
+
+        return file_exists($path) ? file_get_contents($path) : '';
+    }
+
+    /**
      * @param string $name Protected/static method name.
      * @return ReflectionMethod
      */
@@ -172,21 +232,14 @@ final class TwoFactorBackupRegenTest extends TestCase
         $_POST['user_id'] = '99';
         $_POST['nonce'] = 'nonce';
 
-        try {
-            SucuriScanTwoFactor::ajax_profile_backup_regen();
-            $this->fail('Expected wp_send_json_error to halt execution');
-        } catch (BackupRegenSendJsonStop $e) {
-            $this->assertFalse($e->success, 'regenerating for another user must not succeed');
-            $this->assertSame(403, $e->status);
-            $this->assertStringContainsString('your own account', $e->payload['message']);
-        }
+        $e = $this->captureJsonStop([SucuriScanTwoFactor::class, 'ajax_profile_backup_regen']);
+
+        $this->assertFalse($e->success, 'regenerating for another user must not succeed');
+        $this->assertSame(403, $e->status);
+        $this->assertStringContainsString('your own account', $e->payload['message']);
 
         // Crucially, no codes may be minted for the target as a side effect.
-        $this->assertArrayNotHasKey(
-            SucuriScanBackupCodes::META_KEY,
-            $this->userMeta[99],
-            'no backup codes may be generated for a non-self target'
-        );
+        $this->assertNoCodesMintedFor(99, 'no backup codes may be generated for a non-self target');
     }
 
     public function testRegenAllowedForSelf(): void
@@ -199,15 +252,40 @@ final class TwoFactorBackupRegenTest extends TestCase
         $_POST['user_id'] = '7';
         $_POST['nonce'] = 'nonce';
 
-        try {
-            SucuriScanTwoFactor::ajax_profile_backup_regen();
-            $this->fail('Expected wp_send_json_success to halt execution');
-        } catch (BackupRegenSendJsonStop $e) {
-            $this->assertTrue($e->success, 'self regeneration must succeed');
-            $this->assertCount(SucuriScanBackupCodes::CODE_COUNT, $e->payload['backupCodes']);
-        }
+        $e = $this->captureJsonStop([SucuriScanTwoFactor::class, 'ajax_profile_backup_regen']);
+
+        $this->assertTrue($e->success, 'self regeneration must succeed');
+        $this->assertCount(SucuriScanBackupCodes::CODE_COUNT, $e->payload['backupCodes']);
 
         $this->assertArrayHasKey(SucuriScanBackupCodes::META_KEY, $this->userMeta[7]);
+    }
+
+    /**
+     * Regeneration silently replaces a set of credentials that are a full
+     * substitute for the second factor, so the audit trail is the account
+     * owner's only signal that it happened.
+     */
+    public function testSuccessfulRegenIsRecordedInTheAuditLog(): void
+    {
+        Functions\when('get_current_user_id')->justReturn(7);
+
+        $this->enableTotpFor(7);
+
+        $_POST['user_id'] = '7';
+        $_POST['nonce'] = 'nonce';
+
+        $before = $this->auditQueueContents();
+
+        $e = $this->captureJsonStop([SucuriScanTwoFactor::class, 'ajax_profile_backup_regen']);
+        $this->assertTrue($e->success);
+
+        $after = $this->auditQueueContents();
+
+        $this->assertNotSame($before, $after, 'the audit queue must have been appended to');
+        $this->assertStringContainsString(
+            'Two-factor backup codes regenerated for user ID 7',
+            $after
+        );
     }
 
     /**
@@ -226,13 +304,10 @@ final class TwoFactorBackupRegenTest extends TestCase
         $_POST['user_id'] = '7';
         $_POST['nonce'] = 'nonce';
 
-        try {
-            SucuriScanTwoFactor::ajax_profile_backup_regen();
-            $this->fail('Expected wp_send_json_success to halt execution');
-        } catch (BackupRegenSendJsonStop $e) {
-            $this->assertTrue($e->success, 'a numeric-string user id must still resolve as self');
-            $this->assertCount(SucuriScanBackupCodes::CODE_COUNT, $e->payload['backupCodes']);
-        }
+        $e = $this->captureJsonStop([SucuriScanTwoFactor::class, 'ajax_profile_backup_regen']);
+
+        $this->assertTrue($e->success, 'a numeric-string user id must still resolve as self');
+        $this->assertCount(SucuriScanBackupCodes::CODE_COUNT, $e->payload['backupCodes']);
     }
 
     public function testRegenRequiresAnExistingSecret(): void
@@ -243,13 +318,64 @@ final class TwoFactorBackupRegenTest extends TestCase
         $_POST['user_id'] = '7';
         $_POST['nonce'] = 'nonce';
 
-        try {
-            SucuriScanTwoFactor::ajax_profile_backup_regen();
-            $this->fail('Expected wp_send_json_error to halt execution');
-        } catch (BackupRegenSendJsonStop $e) {
-            $this->assertFalse($e->success);
-            $this->assertSame(400, $e->status);
-        }
+        $e = $this->captureJsonStop([SucuriScanTwoFactor::class, 'ajax_profile_backup_regen']);
+
+        $this->assertFalse($e->success);
+        $this->assertSame(400, $e->status);
+        // Assert the message, not just the status: "Invalid user." and
+        // "Two-Factor not enforced for this user" are also 400s on this path, so
+        // a status-only assertion stays green even when the request never
+        // reaches the secret check.
+        $this->assertStringContainsString('Two-Factor must be enabled', $e->payload['message']);
+
+        $this->assertNoCodesMintedFor(7, 'no codes may be minted without an existing secret');
+    }
+
+    /**
+     * The endpoint is reachable by any logged-in user, so the nonce is what
+     * stops a third-party page from spending a victim's session to mint codes
+     * and read them back out of the response.
+     */
+    public function testRegenRejectsAnInvalidNonce(): void
+    {
+        Functions\when('get_current_user_id')->justReturn(7);
+        Functions\when('wp_verify_nonce')->justReturn(false);
+
+        $this->enableTotpFor(7);
+
+        $_POST['user_id'] = '7';
+        $_POST['nonce'] = 'forged';
+
+        $e = $this->captureJsonStop([SucuriScanTwoFactor::class, 'ajax_profile_backup_regen']);
+
+        $this->assertFalse($e->success);
+        $this->assertSame(403, $e->status);
+        $this->assertStringContainsString('Invalid security token', $e->payload['message']);
+
+        $this->assertNoCodesMintedFor(7, 'a rejected nonce must not mint codes');
+    }
+
+    /**
+     * get_current_user_id() stays valid here on purpose: the identical
+     * 403/"Forbidden" is also returned when the session resolves to user 0, so
+     * leaving a real id in place is what pins this test to the logged-in guard.
+     */
+    public function testRegenDeniedWhenNotLoggedIn(): void
+    {
+        Functions\when('is_user_logged_in')->justReturn(false);
+        Functions\when('get_current_user_id')->justReturn(7);
+
+        $this->enableTotpFor(7);
+
+        $_POST['user_id'] = '7';
+        $_POST['nonce'] = 'nonce';
+
+        $e = $this->captureJsonStop([SucuriScanTwoFactor::class, 'ajax_profile_backup_regen']);
+
+        $this->assertFalse($e->success);
+        $this->assertSame(403, $e->status);
+
+        $this->assertNoCodesMintedFor(7, 'a logged-out request must not mint codes');
     }
 
     public function testStatusSnippetOmitsRegenControlForOtherUsers(): void
@@ -260,19 +386,25 @@ final class TwoFactorBackupRegenTest extends TestCase
         // Assert on the markup, not the bare id: the inline script keeps a
         // '#sucuri-2fa-backup-regen-btn' selector either way (it no-ops when
         // the control is absent).
-        $this->assertStringNotContainsString('id="sucuri-2fa-backup-regen-btn"', $html);
-        $this->assertStringNotContainsString('data-cy="sucuriscan-2fa-backup-regen-btn"', $html);
-        $this->assertStringNotContainsString('backup code(s) remaining', $html);
+        $this->assertStringNotContainsString(self::REGEN_BTN_ID, $html);
+        $this->assertStringNotContainsString(self::REGEN_BTN_CY, $html);
+        $this->assertStringNotContainsString(self::REGEN_BTN_LABEL, $html);
         // The reset control remains available to administrators.
         $this->assertStringContainsString('id="sucuri-2fa-reset-btn"', $html);
     }
 
+    /**
+     * Counterpart to the test above. These two must stay together: the omission
+     * test is all negative assertions, which would keep passing if the template
+     * renamed the control, and this one is what turns such a rename into a
+     * failure.
+     */
     public function testStatusSnippetIncludesRegenControlForSelf(): void
     {
         $html = $this->method('profile_status_snippet')->invoke(null, 42, true);
 
-        $this->assertStringContainsString('id="sucuri-2fa-backup-regen-btn"', $html);
-        $this->assertStringContainsString('data-cy="sucuriscan-2fa-backup-regen-btn"', $html);
-        $this->assertStringContainsString('backup code(s) remaining', $html);
+        $this->assertStringContainsString(self::REGEN_BTN_ID, $html);
+        $this->assertStringContainsString(self::REGEN_BTN_CY, $html);
+        $this->assertStringContainsString(self::REGEN_BTN_LABEL, $html);
     }
 }

--- a/tests/TwoFactorTest.php
+++ b/tests/TwoFactorTest.php
@@ -26,10 +26,25 @@ if (!class_exists('WP_User')) {
  */
 final class TwoFactorTest extends TestCase
 {
+    /** @var array<string, string> */
+    private $fixtureSnapshots = [];
+
     protected function setUp(): void
     {
         parent::setUp();
         Monkey\setUp();
+
+        // A backup-code login triggers real SucuriScanOption/SucuriScanEvent
+        // reads+writes, which touch these fixture files on disk; snapshot
+        // them so tearDown() can restore them and tests don't leave the
+        // checked-in fixtures dirty.
+        foreach (['sucuri-auditqueue.php', 'sucuri-settings.php'] as $fixture) {
+            $path = BASE_DIR . '/tests/fixtures/' . $fixture;
+
+            if (file_exists($path)) {
+                $this->fixtureSnapshots[$path] = file_get_contents($path);
+            }
+        }
 
         Functions\when('wp_validate_redirect')->returnArg(1);
         Functions\when('wp_login_url')->justReturn('https://example.com/wp-login.php');
@@ -80,6 +95,12 @@ final class TwoFactorTest extends TestCase
 
     protected function tearDown(): void
     {
+        unset($_GET['token'], $_POST['token'], $_REQUEST['token'], $_POST['sucuriscan_totp_code'], $_SERVER['REQUEST_METHOD'], $_SERVER['HTTP_USER_AGENT']);
+
+        foreach ($this->fixtureSnapshots as $path => $contents) {
+            file_put_contents($path, $contents);
+        }
+
         Monkey\tearDown();
         parent::tearDown();
     }
@@ -161,5 +182,244 @@ final class TwoFactorTest extends TestCase
             $this->assertStringStartsWith('REDIRECT:', $msg);
             $this->assertStringContainsString('action=sucuri-2fa-setup', $msg);
         }
+    }
+
+    /**
+     * Regression test: extract_submitted_login_credential() must not run a
+     * TOTP submission through SucuriScanBackupCodes::normalize_code(), since
+     * that filter strips digits ("0"/"1") that are excluded from the
+     * backup-code alphabet but are perfectly valid in a 6-digit TOTP code.
+     */
+    public function testExtractSubmittedLoginCredentialPreservesTotpDigits(): void
+    {
+        $_POST['sucuriscan_totp_code'] = '013456';
+
+        $ref = new ReflectionClass(SucuriScanTwoFactor::class);
+        $method = $ref->getMethod('extract_submitted_login_credential');
+        $method->setAccessible(true);
+
+        $this->assertSame('013456', $method->invoke(null, 'sucuriscan_totp_code'));
+    }
+
+    public function testExtractSubmittedLoginCredentialNormalizesBackupCode(): void
+    {
+        $_POST['sucuriscan_totp_code'] = ' aaaa-1111 ';
+
+        $ref = new ReflectionClass(SucuriScanTwoFactor::class);
+        $method = $ref->getMethod('extract_submitted_login_credential');
+        $method->setAccessible(true);
+
+        $this->assertSame('AAAA1111', $method->invoke(null, 'sucuriscan_totp_code'));
+    }
+
+    public function testLoginTemplateAllowsBackupCodeEntryWithoutJavaScript(): void
+    {
+        $template = file_get_contents(BASE_DIR . '/inc/tpl/login-2fa.html.tpl');
+
+        $this->assertNotFalse($template);
+        $this->assertStringContainsString('maxlength="9"', $template);
+        $this->assertStringContainsString('inputmode="text"', $template);
+        $this->assertStringNotContainsString('pattern="[0-9]{6}"', $template);
+        $this->assertStringNotContainsString('<script', $template);
+    }
+
+    public function testBackupCodeModalUsesSharedThemeVariables(): void
+    {
+        $styles = file_get_contents(BASE_DIR . '/inc/css/shared.css');
+        $script = file_get_contents(BASE_DIR . '/inc/js/backup-codes.js');
+
+        $this->assertNotFalse($styles);
+        $this->assertNotFalse($script);
+        $this->assertStringContainsString('.sucuriscan-backup-codes-modal', $styles);
+        $this->assertStringContainsString('background: var(--sucuri-surface-card-bg)', $styles);
+        $this->assertStringContainsString('color: var(--sucuri-color-text-main)', $styles);
+        $this->assertStringNotContainsString('sucuriscan-backup-codes-style', $script);
+    }
+
+    public function testBackupCodeModalLocksAndRestoresDocumentScroll(): void
+    {
+        $styles = file_get_contents(BASE_DIR . '/inc/css/shared.css');
+        $script = file_get_contents(BASE_DIR . '/inc/js/backup-codes.js');
+
+        $this->assertNotFalse($styles);
+        $this->assertNotFalse($script);
+        $this->assertStringContainsString('body.sucuriscan-backup-codes-modal-open', $styles);
+        $this->assertStringContainsString('overflow: hidden', $styles);
+        $this->assertStringContainsString('document.documentElement.classList.toggle', $script);
+        $this->assertStringContainsString('document.body.classList.toggle', $script);
+        $this->assertStringContainsString('document.querySelector(overlaySelector)', $script);
+    }
+
+    public function testBackupCodeDownloadUsesSharedTextDownloadUtility(): void
+    {
+        $sharedScript = file_get_contents(BASE_DIR . '/inc/js/scripts.js');
+        $backupCodesScript = file_get_contents(BASE_DIR . '/inc/js/backup-codes.js');
+        $twoFactor = file_get_contents(BASE_DIR . '/src/topt.lib.php');
+
+        $this->assertNotFalse($sharedScript);
+        $this->assertNotFalse($backupCodesScript);
+        $this->assertNotFalse($twoFactor);
+        $this->assertStringContainsString('window.sucuriscanDownloadTextFile', $sharedScript);
+        $this->assertStringContainsString('window.sucuriscanDownloadTextFile(', $backupCodesScript);
+        $this->assertStringContainsString('"sucuri-backup-codes.txt"', $backupCodesScript);
+        $this->assertStringNotContainsString('createObjectURL', $backupCodesScript);
+        $this->assertStringContainsString("array('sucuriscan')", $twoFactor);
+    }
+
+    public function testBackupCodeRevealAndProfileEnableFinishAfterModalClose(): void
+    {
+        $revealTemplate = file_get_contents(BASE_DIR . '/inc/tpl/profile-2fa-backup-codes.snippet.tpl');
+        $backupCodesScript = file_get_contents(BASE_DIR . '/inc/js/backup-codes.js');
+        $setupTemplate = file_get_contents(BASE_DIR . '/inc/tpl/profile-2fa-setup.snippet.tpl');
+        $statusTemplate = file_get_contents(BASE_DIR . '/inc/tpl/profile-2fa-status.snippet.tpl');
+
+        $this->assertNotFalse($revealTemplate);
+        $this->assertNotFalse($backupCodesScript);
+        $this->assertNotFalse($setupTemplate);
+        $this->assertNotFalse($statusTemplate);
+        $this->assertStringNotContainsString('<script', $revealTemplate);
+        $this->assertStringContainsString('sucuriscan-backup-codes-reveal-data', $backupCodesScript);
+        $this->assertStringContainsString('window.location.assign(redirectURL)', $backupCodesScript);
+        $this->assertStringContainsString('window.location.reload()', $setupTemplate);
+        $this->assertStringContainsString('window.location.reload()', $statusTemplate);
+    }
+
+    public function testSuccessfulSetupShowsBackupCodesBeforeOriginalRedirect(): void
+    {
+        SucuriScanOption::updateOption(':twofactor_mode', 'all_users');
+
+        $transients = array();
+
+        Functions\when('wp_hash_password')->alias(function ($password) {
+            return 'HASH:' . $password;
+        });
+        Functions\when('set_transient')->alias(function ($key, $value, $ttl) use (&$transients) {
+            $transients[$key] = $value;
+            return true;
+        });
+        Functions\when('wp_safe_redirect')->alias(function ($url) {
+            throw new RuntimeException('REDIRECT:' . $url);
+        });
+
+        $method = (new ReflectionClass(SucuriScanTwoFactor::class))->getMethod('process_successful_setup');
+        $method->setAccessible(true);
+
+        try {
+            $method->invoke(null, 55, 'TESTSECRET', 123, false, 'https://example.com/account', 'token1234567890');
+            $this->fail('Expected redirect after successful setup');
+        } catch (RuntimeException $e) {
+            $this->assertSame('REDIRECT:https://example.com/wp-admin/profile.php', $e->getMessage());
+        }
+
+        $this->assertContains('https://example.com/account', $transients);
+    }
+
+    public function testBackupCodeCopyUsesOnlyModernClipboardApi(): void
+    {
+        $backupCodesScript = file_get_contents(BASE_DIR . '/inc/js/backup-codes.js');
+
+        $this->assertNotFalse($backupCodesScript);
+        $this->assertStringContainsString('navigator.clipboard?.writeText', $backupCodesScript);
+        $this->assertStringContainsString('Copy unavailable', $backupCodesScript);
+        $this->assertStringNotContainsString('execCommand', $backupCodesScript);
+        $this->assertStringNotContainsString('jQuery', $backupCodesScript);
+    }
+
+    public function testRecordFailedBackupAttemptUsesStricterLimitThanTotp(): void
+    {
+        $ref = new ReflectionClass(SucuriScanTwoFactor::class);
+        $method = $ref->getMethod('record_failed_backup_attempt');
+        $method->setAccessible(true);
+
+        Functions\when('wp_safe_redirect')->alias(function ($url) {
+            throw new RuntimeException('REDIRECT:' . $url);
+        });
+
+        $session = ['attempts' => 0];
+        $token = 'sometoken1234567890';
+
+        $method->invokeArgs(null, [$token, &$session]);
+        $this->assertSame(1, $session['backup_attempts']);
+
+        $method->invokeArgs(null, [$token, &$session]);
+        $this->assertSame(2, $session['backup_attempts']);
+
+        // BACKUP_TOKEN_MAX_ATTEMPTS = 3, stricter than LOGIN_TOKEN_MAX_ATTEMPTS = 5.
+        $this->expectException(RuntimeException::class);
+        $method->invokeArgs(null, [$token, &$session]);
+    }
+
+    public function testLoginFormAcceptsValidBackupCodeConsumesItAndLogsIn(): void
+    {
+        SucuriScanOption::updateOption(':twofactor_mode', 'all_users');
+
+        Functions\when('wp_unslash')->returnArg(1);
+
+        // Backup-code consumption logs via SucuriScanEvent, which cascades
+        // into the local audit-log queue's filesystem/hardening machinery.
+        Functions\when('wp_strip_all_tags')->alias(function ($text) {
+            return trim(strip_tags((string) $text));
+        });
+        Functions\when('sucuriscan_lastlogins_datastore_exists')->justReturn(true);
+        Functions\when('get_home_path')->justReturn('/');
+
+        $userId = 77;
+        $token = 'BACKUPCODELOGINTOKEN123';
+
+        Functions\when('get_transient')->alias(function ($key) use ($token, $userId) {
+            if (strpos($key, $token) !== false) {
+                return array(
+                    'user_id' => $userId,
+                    'remember' => false,
+                    'redirect' => 'https://example.com/wp-admin/',
+                    'secret' => '',
+                    'created' => time(),
+                    'attempts' => 0,
+                    'ua' => '',
+                );
+            }
+
+            return false;
+        });
+
+        Functions\when('wp_hash_password')->alias(function ($password) {
+            return 'HASH:' . $password;
+        });
+        Functions\when('wp_check_password')->alias(function ($password, $hash, $user_id = '') {
+            return $hash === 'HASH:' . $password;
+        });
+
+        $meta = array();
+        Functions\when('get_user_meta')->alias(function ($uid, $key, $single = false) use (&$meta) {
+            return isset($meta[$uid][$key]) ? $meta[$uid][$key] : '';
+        });
+        Functions\when('update_user_meta')->alias(function ($uid, $key, $value) use (&$meta) {
+            $meta[$uid][$key] = $value;
+            return true;
+        });
+
+        $codes = SucuriScanBackupCodes::generate_for_user($userId);
+        $validCode = $codes[0];
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_REQUEST['token'] = $token;
+        $_POST['sucuriscan_totp_code'] = $validCode;
+
+        Functions\when('wp_safe_redirect')->alias(function ($url) {
+            throw new RuntimeException('REDIRECT:' . $url);
+        });
+
+        try {
+            SucuriScanTwoFactor::login_form_2fa();
+            $this->fail('Expected redirect on successful backup-code login did not occur');
+        } catch (RuntimeException $e) {
+            $this->assertStringStartsWith('REDIRECT:', $e->getMessage());
+        }
+
+        $this->assertSame(9, SucuriScanBackupCodes::remaining_count($userId), 'the used code must be consumed');
+        $this->assertFalse(
+            SucuriScanBackupCodes::validate_and_consume($userId, $validCode),
+            'a consumed backup code must not validate again'
+        );
     }
 }

--- a/tests/TwoFactorTest.php
+++ b/tests/TwoFactorTest.php
@@ -212,76 +212,81 @@ final class TwoFactorTest extends TestCase
         $this->assertSame('AAAA1111', $method->invoke(null, 'sucuriscan_totp_code'));
     }
 
-    public function testLoginTemplateAllowsBackupCodeEntryWithoutJavaScript(): void
+    /**
+     * The login field has to accept both credential shapes the server accepts:
+     * a 6-digit TOTP code and a 9-character formatted backup code (AAAA-BBBB).
+     * A numeric-only pattern here would lock every user out of backup-code
+     * login, so the constraints are asserted against the parsed input element
+     * rather than by matching text anywhere in the file.
+     */
+    public function testLoginFormAcceptsBothCredentialShapesWithoutJavaScript(): void
     {
         $template = file_get_contents(BASE_DIR . '/inc/tpl/login-2fa.html.tpl');
 
         $this->assertNotFalse($template);
-        $this->assertStringContainsString('maxlength="9"', $template);
-        $this->assertStringContainsString('inputmode="text"', $template);
-        $this->assertStringNotContainsString('pattern="[0-9]{6}"', $template);
-        $this->assertStringNotContainsString('<script', $template);
+
+        $dom = new DOMDocument();
+        libxml_use_internal_errors(true);
+        $dom->loadHTML((string) $template);
+        libxml_clear_errors();
+
+        $xpath = new DOMXPath($dom);
+        $input = $xpath->query('//input[@name="sucuriscan_totp_code"]')->item(0);
+
+        $this->assertInstanceOf(DOMElement::class, $input, 'the code input must exist');
+        $this->assertSame('9', $input->getAttribute('maxlength'), 'must fit a 9-char formatted backup code');
+        $this->assertSame('text', $input->getAttribute('inputmode'), 'backup codes are not numeric');
+        $this->assertFalse(
+            $input->hasAttribute('pattern'),
+            'a pattern attribute would reject one of the two accepted credential shapes'
+        );
+
+        // The 2FA challenge must survive with scripting unavailable.
+        $this->assertSame(0, $xpath->query('//script')->length, 'the login step must not depend on JS');
     }
 
-    public function testBackupCodeModalUsesSharedThemeVariables(): void
+    /**
+     * backup-codes.js calls window.sucuriscanDownloadTextFile(), which is
+     * defined by inc/js/scripts.js (handle: sucuriscan). Without the dependency
+     * the two can load in either order and Download silently does nothing, so
+     * the registration is exercised instead of grepped for.
+     */
+    public function testBackupCodesScriptDependsOnTheSharedScript(): void
     {
-        $styles = file_get_contents(BASE_DIR . '/inc/css/shared.css');
-        $script = file_get_contents(BASE_DIR . '/inc/js/backup-codes.js');
+        $registered = array();
 
-        $this->assertNotFalse($styles);
-        $this->assertNotFalse($script);
-        $this->assertStringContainsString('.sucuriscan-backup-codes-modal', $styles);
-        $this->assertStringContainsString('background: var(--sucuri-surface-card-bg)', $styles);
-        $this->assertStringContainsString('color: var(--sucuri-color-text-main)', $styles);
-        $this->assertStringNotContainsString('sucuriscan-backup-codes-style', $script);
+        Functions\when('wp_register_script')->alias(
+            function ($handle, $src, $deps = array(), $ver = false, $footer = false) use (&$registered) {
+                $registered[$handle] = array('src' => $src, 'deps' => $deps);
+
+                return true;
+            }
+        );
+
+        $method = (new ReflectionClass(SucuriScanTwoFactor::class))->getMethod('ensure_backup_codes_script');
+        $method->setAccessible(true);
+        $method->invoke(null);
+
+        $this->assertArrayHasKey('sucuriscan-backup-codes', $registered);
+        $this->assertStringContainsString('inc/js/backup-codes.js', $registered['sucuriscan-backup-codes']['src']);
+        $this->assertContains(
+            'sucuriscan',
+            $registered['sucuriscan-backup-codes']['deps'],
+            'the download helper lives in the shared script and must load first'
+        );
     }
 
-    public function testBackupCodeModalLocksAndRestoresDocumentScroll(): void
-    {
-        $styles = file_get_contents(BASE_DIR . '/inc/css/shared.css');
-        $script = file_get_contents(BASE_DIR . '/inc/js/backup-codes.js');
-
-        $this->assertNotFalse($styles);
-        $this->assertNotFalse($script);
-        $this->assertStringContainsString('body.sucuriscan-backup-codes-modal-open', $styles);
-        $this->assertStringContainsString('overflow: hidden', $styles);
-        $this->assertStringContainsString('document.documentElement.classList.toggle', $script);
-        $this->assertStringContainsString('document.body.classList.toggle', $script);
-        $this->assertStringContainsString('document.querySelector(overlaySelector)', $script);
-    }
-
-    public function testBackupCodeDownloadUsesSharedTextDownloadUtility(): void
-    {
-        $sharedScript = file_get_contents(BASE_DIR . '/inc/js/scripts.js');
-        $backupCodesScript = file_get_contents(BASE_DIR . '/inc/js/backup-codes.js');
-        $twoFactor = file_get_contents(BASE_DIR . '/src/topt.lib.php');
-
-        $this->assertNotFalse($sharedScript);
-        $this->assertNotFalse($backupCodesScript);
-        $this->assertNotFalse($twoFactor);
-        $this->assertStringContainsString('window.sucuriscanDownloadTextFile', $sharedScript);
-        $this->assertStringContainsString('window.sucuriscanDownloadTextFile(', $backupCodesScript);
-        $this->assertStringContainsString('"sucuri-backup-codes.txt"', $backupCodesScript);
-        $this->assertStringNotContainsString('createObjectURL', $backupCodesScript);
-        $this->assertStringContainsString("array('sucuriscan')", $twoFactor);
-    }
-
-    public function testBackupCodeRevealAndProfileEnableFinishAfterModalClose(): void
+    /**
+     * The reveal element is a data-only <div> consumed by the enqueued script.
+     * Keeping markup and behaviour separated is what lets the plugin ship
+     * without inline script on a page that renders plaintext backup codes.
+     */
+    public function testRevealTemplateShipsNoInlineScript(): void
     {
         $revealTemplate = file_get_contents(BASE_DIR . '/inc/tpl/profile-2fa-backup-codes.snippet.tpl');
-        $backupCodesScript = file_get_contents(BASE_DIR . '/inc/js/backup-codes.js');
-        $setupTemplate = file_get_contents(BASE_DIR . '/inc/tpl/profile-2fa-setup.snippet.tpl');
-        $statusTemplate = file_get_contents(BASE_DIR . '/inc/tpl/profile-2fa-status.snippet.tpl');
 
         $this->assertNotFalse($revealTemplate);
-        $this->assertNotFalse($backupCodesScript);
-        $this->assertNotFalse($setupTemplate);
-        $this->assertNotFalse($statusTemplate);
         $this->assertStringNotContainsString('<script', $revealTemplate);
-        $this->assertStringContainsString('sucuriscan-backup-codes-reveal-data', $backupCodesScript);
-        $this->assertStringContainsString('window.location.assign(redirectURL)', $backupCodesScript);
-        $this->assertStringContainsString('window.location.reload()', $setupTemplate);
-        $this->assertStringContainsString('window.location.reload()', $statusTemplate);
     }
 
     public function testSuccessfulSetupShowsBackupCodesBeforeOriginalRedirect(): void
@@ -312,17 +317,6 @@ final class TwoFactorTest extends TestCase
         }
 
         $this->assertContains('https://example.com/account', $transients);
-    }
-
-    public function testBackupCodeCopyUsesOnlyModernClipboardApi(): void
-    {
-        $backupCodesScript = file_get_contents(BASE_DIR . '/inc/js/backup-codes.js');
-
-        $this->assertNotFalse($backupCodesScript);
-        $this->assertStringContainsString('navigator.clipboard?.writeText', $backupCodesScript);
-        $this->assertStringContainsString('Copy unavailable', $backupCodesScript);
-        $this->assertStringNotContainsString('execCommand', $backupCodesScript);
-        $this->assertStringNotContainsString('jQuery', $backupCodesScript);
     }
 
     public function testRecordFailedBackupAttemptUsesStricterLimitThanTotp(): void

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -136,4 +136,5 @@ require BASE_DIR . '/src/integrity.lib.php';
 require BASE_DIR . '/src/firewall.lib.php';
 require BASE_DIR . '/src/installer-skin.lib.php';
 require BASE_DIR . '/src/cachecontrol.lib.php';
+require BASE_DIR . '/src/backupcodes.lib.php';
 require BASE_DIR . '/src/topt.lib.php';


### PR DESCRIPTION
This PR adds one-time backup codes as a recovery method for Two-Factor Authentication.

## Changes

- Generate ten backup codes when 2FA is enabled.
- Store only hashed codes and consume each code atomically after successful use.
- Accept backup codes on the WordPress 2FA login screen.
- Add copy/download, acknowledgement, theme-aware styling, and background scroll locking to the code reveal modal.
- Allow users to regenerate backup codes from their profile.
- Route newly configured users through a code reveal before returning them to their original destination.
- Add a reusable browser-side text-download helper in a separate commit.

## Security

- Backup codes are single-use and stored as password hashes.
- Conditional metadata updates prevent concurrent reuse of one code.
- Failed clipboard writes are reported rather than treated as successful copies.