### PR TITLE
Audit trail: search, filters, CSV export

### DIFF
--- a/cypress/e2e/sucuri-scanner.cy.js
+++ b/cypress/e2e/sucuri-scanner.cy.js
@@ -1378,6 +1378,65 @@ describe("Run e2e tests", () => {
         // cy.get('.sucuriscan-auditlog-entry').should('have.length.greaterThan', 0);
     });
 
+    it('can search audit trails', () => {
+        cy.visit('/wp-admin/admin.php?page=sucuriscan_events_reporting#auditlogs');
+
+        cy.get('.sucuriscan-auditlog-entry').should('have.length.greaterThan', 0);
+        cy.get('[data-cy=sucuriscan_auditlogs_search]').type('Plugin activated{enter}');
+
+        cy.get('.sucuriscan-auditlog-entry').each(($row) => {
+            cy.wrap($row).find('.sucuriscan-auditlog-entry-title').should('contain.text', 'Plugin activated');
+        });
+
+        cy.get('[data-cy=sucuriscan_auditlogs_clear_filter_button]').click();
+
+        cy.wait(200);
+
+        cy.get('[data-cy=sucuriscan_auditlogs_search]').should('have.value', '');
+    });
+
+    it('can download every stored audit trail as CSV', () => {
+        cy.visit('/wp-admin/admin.php?page=sucuriscan_events_reporting#auditlogs');
+
+        // The export is a plain nonced link, so no JavaScript is involved.
+        cy.get('[data-cy=sucuriscan_auditlogs_download_link]')
+            .should('have.attr', 'href')
+            .then((href) => {
+                const url = new URL(href, Cypress.config('baseUrl'));
+
+                expect(url.pathname).to.equal('/wp-admin/admin-post.php');
+                expect(url.searchParams.get('action')).to.equal('sucuriscan_download_audit_logs');
+                expect(url.searchParams.get('sucuriscan_page_nonce')).to.match(/^[a-z0-9]{10}$/);
+
+                return cy.request(url.toString());
+            })
+            .then((response) => {
+                expect(response.headers['content-type']).to.include('text/csv');
+                expect(response.headers['content-disposition']).to.include('attachment;');
+
+                const lines = response.body.split('\r\n').filter((line) => line !== '');
+
+                expect(lines[0]).to.equal(
+                    '"Date","Time","Severity","Username","IP Address","Message","Details"',
+                );
+                expect(lines.length).to.be.greaterThan(1);
+
+                // The queue is a PHP file; its guard block is not data.
+                expect(response.body).to.not.contain('<?php');
+                expect(response.body).to.not.contain('exit(0)');
+            });
+
+        // A forged nonce must never produce a CSV.
+        cy.request({
+            url: '/wp-admin/admin-post.php?action=sucuriscan_download_audit_logs'
+                + '&sucuriscan_page_nonce=aaaaaaaaaa',
+            failOnStatusCode: false,
+        }).then((response) => {
+            expect(response.status).to.equal(403);
+            expect(response.headers['content-type']).to.not.include('text/csv');
+        });
+    });
+
     it("Toggling enforce checkbox enables/disables inputs interactively", () => {
         cy.visit("/wp-admin/admin.php?page=sucuriscan_headers_management");
 

--- a/inc/css/shared.css
+++ b/inc/css/shared.css
@@ -1662,6 +1662,10 @@ body.sucuri-security_page_sucuriscan_firewall .sucuriscan-panel {
     margin-right: 7px;
 }
 
+.filter-container input[type="search"] {
+    min-width: 220px;
+}
+
 .filter-container .button-secondary {
     margin-left: 8px;
 }

--- a/inc/tpl/auditlogs-filter.snippet.tpl
+++ b/inc/tpl/auditlogs-filter.snippet.tpl
@@ -1,3 +1,3 @@
-<select id="%%SUCURI.AuditLog.FilterName%%" name="%%SUCURI.AuditLog.FilterName%%">
+<select id="%%SUCURI.AuditLog.FilterName%%" name="%%SUCURI.AuditLog.FilterName%%" aria-label="%%SUCURI.AuditLog.FilterLabel%%">
     %%%SUCURI.AuditLog.FilterOptions%%%
 </select>

--- a/inc/tpl/auditlogs-filters.snippet.tpl
+++ b/inc/tpl/auditlogs-filters.snippet.tpl
@@ -1,12 +1,16 @@
 <div class="filter-container">
+    <input id="auditlog-search" name="search" type="search" value="%%SUCURI.AuditLog.Search%%"
+           placeholder="{{Search audit trails}}" aria-label="{{Search audit trails}}"
+           data-cy="sucuriscan_auditlogs_search">
+
     %%%SUCURI.AuditLog.Filters%%%
 
     <button id="filter-button" type="submit" class="button button-primary" data-cy="sucuriscan_auditlogs_filter_button">
-        Filter
+        {{Filter}}
     </button>
 
     <button id="clear-filter-button" type="submit" class="button button-secondary"
             data-cy="sucuriscan_auditlogs_clear_filter_button">
-        Clear Filter
+        {{Clear Filters}}
     </button>
 </div>

--- a/inc/tpl/auditlogs.html.tpl
+++ b/inc/tpl/auditlogs.html.tpl
@@ -51,7 +51,13 @@
 
                 writeQueueSize(data.queueSize, data.status != 'API is not available; using local queue');
 
-                $('.sucuriscan-auditlog-status').html(data.status);
+                var status = data.status;
+
+                if (data.limited) {
+                    status += (status ? ' &mdash; ' : '') + '{{Results are limited to the latest audit trails available.}}';
+                }
+
+                $('.sucuriscan-auditlog-status').html(status);
                 $('.sucuriscan-auditlog-footer').removeClass('sucuriscan-hidden');
 
                 if (data.filters !== undefined) {
@@ -100,14 +106,14 @@
             var url = new URL(event.target.href);
             var page = url.searchParams.get('paged');
 
-            var filters = {
-                time: url.searchParams.get('time'),
-                posts: url.searchParams.get('posts'),
-                logins: url.searchParams.get('logins'),
-                users: url.searchParams.get('users'),
-                plugins: url.searchParams.get('plugins'),
-                files: url.searchParams.get('files'),
-            };
+            var filters = {};
+
+            ['time', 'posts', 'logins', 'users', 'plugins', 'themes', 'files', 'events', 'search']
+                .forEach(function (filter) {
+                    if (url.searchParams.get(filter) !== null) {
+                        filters[filter] = url.searchParams.get(filter);
+                    }
+                });
 
             if (url.searchParams.get('startDate') !== null) {
                 filters.startDate = url.searchParams.get('startDate');
@@ -156,19 +162,25 @@
             if (e.target.id == 'filter-button') {
                 var filters = {};
 
+                var search = $('#auditlog-search').val().trim();
                 var time = $('#time').val();
                 var posts = $('#posts').val();
                 var logins = $('#logins').val();
                 var users = $('#users').val();
                 var plugins = $('#plugins').val();
+                var themes = $('#themes').val();
                 var files = $('#files').val();
+                var events = $('#events').val();
 
+                if (search !== '') filters.search = search;
                 if (time !== 'all time') filters.time = time;
                 if (posts !== 'all posts') filters.posts = posts;
                 if (logins !== 'all logins') filters.logins = logins;
                 if (users !== 'all users') filters.users = users;
                 if (plugins !== 'all plugins') filters.plugins = plugins;
+                if (themes !== 'all themes') filters.themes = themes;
                 if (files !== 'all files') filters.files = files;
+                if (events !== 'all events') filters.events = events;
 
                 if (time === 'custom') {
                     var startDate = $('#startDate').val();
@@ -181,20 +193,16 @@
                 sucuriscanLoadAuditLogs(0, filters);
             }
 
-            document.body.addEventListener('click', function (e) {
-                if (e.target.id == 'clear-filter-button') {
-                    sucuriscanLoadAuditLogs(0);
+            if (e.target.id == 'clear-filter-button') {
+                sucuriscanLoadAuditLogs(0);
+            }
+        });
 
-                    $('#time').val('all time');
-                    $('#posts').val('all posts');
-                    $('#logins').val('all logins');
-                    $('#users').val('all users');
-                    $('#plugins').val('all plugins');
-                    $('#files').val('all files');
-                    $('#startDate').val('');
-                    $('#endDate').val('');
-                }
-            });
+        document.body.addEventListener('keydown', function (e) {
+            if (e.target.id === 'auditlog-search' && e.key === 'Enter') {
+                e.preventDefault();
+                $('#filter-button').trigger('click');
+            }
         });
 
         document.body.addEventListener('change', function (e) {

--- a/inc/tpl/auditlogs.html.tpl
+++ b/inc/tpl/auditlogs.html.tpl
@@ -223,6 +223,14 @@
     <div class="sucuriscan-auditlog-table">
         <div id="sucuriscan-filters"></div>
 
+        <div class="sucuriscan-hstatus sucuriscan-hstatus-2">
+            <p>
+                {{The CSV contains all audit trails currently stored on this website.}}
+                <a id="download-auditlogs-link" href="%%SUCURI.AuditLogs.DownloadURL%%"
+                   data-cy="sucuriscan_auditlogs_download_link">{{Download CSV}}</a>
+            </p>
+        </div>
+
         <div class="sucuriscan-auditlog-response" data-cy="sucuriscan_auditlog_response_loading">
             <em>{{Loading...}}</em>
         </div>

--- a/lang/sucuri-scanner.pot
+++ b/lang/sucuri-scanner.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-27T23:27:12+00:00\n"
+"POT-Creation-Date: 2026-07-27T23:41:26+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: sucuri-scanner\n"
@@ -82,7 +82,7 @@ msgid "All Time"
 msgstr ""
 
 #: src/api.lib.php:534
-#: src/auditlogs.lib.php:673
+#: src/auditlogs.lib.php:801
 msgid "Today"
 msgstr ""
 
@@ -271,12 +271,17 @@ msgstr ""
 msgid "status has been changed"
 msgstr ""
 
-#: src/auditlogs.lib.php:411
+#: src/auditlogs.lib.php:412
 msgid "The audit trail download link is invalid or expired."
 msgstr ""
 
-#: src/auditlogs.lib.php:412
+#: src/auditlogs.lib.php:413
+#: src/auditlogs.lib.php:434
 msgid "Audit trail export"
+msgstr ""
+
+#: src/auditlogs.lib.php:433
+msgid "The audit trails could not be read. No CSV was downloaded."
 msgstr ""
 
 #: src/base.lib.php:61

--- a/lang/sucuri-scanner.pot
+++ b/lang/sucuri-scanner.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-27T19:41:45+00:00\n"
+"POT-Creation-Date: 2026-07-27T21:11:51+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: sucuri-scanner\n"
@@ -82,7 +82,7 @@ msgid "All Time"
 msgstr ""
 
 #: src/api.lib.php:534
-#: src/auditlogs.lib.php:595
+#: src/auditlogs.lib.php:619
 msgid "Today"
 msgstr ""
 
@@ -245,37 +245,37 @@ msgstr ""
 msgid "WordPress version is not supported anymore"
 msgstr ""
 
-#: src/auditlogs.lib.php:89
+#: src/auditlogs.lib.php:94
 msgid "Start Date"
 msgstr ""
 
-#: src/auditlogs.lib.php:90
+#: src/auditlogs.lib.php:95
 msgid "End Date"
 msgstr ""
 
-#: src/auditlogs.lib.php:200
+#: src/auditlogs.lib.php:205
 msgid "API is not available; using local queue"
 msgstr ""
 
 #. translators: %s: number of seconds
-#: src/auditlogs.lib.php:203
+#: src/auditlogs.lib.php:208
 #, php-format
 msgid "API %s secs"
 msgstr ""
 
-#: src/auditlogs.lib.php:306
+#: src/auditlogs.lib.php:311
 msgid "There are no logs."
 msgstr ""
 
-#: src/auditlogs.lib.php:357
+#: src/auditlogs.lib.php:362
 msgid "status has been changed"
 msgstr ""
 
-#: src/auditlogs.lib.php:405
+#: src/auditlogs.lib.php:410
 msgid "The audit trail download link is invalid or expired."
 msgstr ""
 
-#: src/auditlogs.lib.php:406
+#: src/auditlogs.lib.php:411
 msgid "Audit trail export"
 msgstr ""
 
@@ -307,52 +307,52 @@ msgid "Automatic update of security keys failed. Something went wrong!"
 msgstr ""
 
 #. translators: %1$s: display name, %2$d: time interval
-#: src/event.lib.php:198
+#: src/event.lib.php:234
 #, php-format
 msgid "%1$s (every %2$d seconds)"
 msgstr ""
 
-#: src/event.lib.php:204
+#: src/event.lib.php:240
 msgid "Never (no execution)"
 msgstr ""
 
-#: src/event.lib.php:256
+#: src/event.lib.php:292
 msgid "Weekly"
 msgstr ""
 
-#: src/event.lib.php:262
+#: src/event.lib.php:298
 msgid "Monthly"
 msgstr ""
 
-#: src/event.lib.php:268
+#: src/event.lib.php:304
 msgid "Quarterly"
 msgstr ""
 
-#: src/event.lib.php:323
-#: src/event.lib.php:374
+#: src/event.lib.php:359
+#: src/event.lib.php:410
 msgid "API key is not available"
 msgstr ""
 
-#: src/event.lib.php:331
+#: src/event.lib.php:367
 msgid "WordPress version was already reported"
 msgstr ""
 
 #. translators: %s: WordPress version
-#: src/event.lib.php:335
+#: src/event.lib.php:371
 #, php-format
 msgid "WordPress version detected %s"
 msgstr ""
 
-#: src/event.lib.php:378
+#: src/event.lib.php:414
 msgid "Scanner ran a couple of minutes ago"
 msgstr ""
 
-#: src/event.lib.php:410
+#: src/event.lib.php:446
 msgid "Event identifier cannot be empty"
 msgstr ""
 
 #. translators: %1$s: settings url, %2$s: settings url
-#: src/event.lib.php:743
+#: src/event.lib.php:784
 #, php-format
 msgid ""
 "<br><br>\n"
@@ -365,24 +365,24 @@ msgid ""
 ""
 msgstr ""
 
-#: src/event.lib.php:892
+#: src/event.lib.php:933
 msgid "Password Change"
 msgstr ""
 
 #. translators: %s: file path
-#: src/event.lib.php:1068
+#: src/event.lib.php:1109
 #, php-format
 msgid "%s cannot be deleted."
 msgstr ""
 
 #. translators: %s: comma-separated list of filenames
-#: src/event.lib.php:1080
+#: src/event.lib.php:1121
 #, php-format
 msgid "%s log files were deleted."
 msgstr ""
 
 #. translators: %s: filename
-#: src/event.lib.php:1082
+#: src/event.lib.php:1123
 #, php-format
 msgid "%s log file was deleted."
 msgstr ""

--- a/lang/sucuri-scanner.pot
+++ b/lang/sucuri-scanner.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-27T21:11:51+00:00\n"
+"POT-Creation-Date: 2026-07-27T21:30:05+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: sucuri-scanner\n"
@@ -82,7 +82,7 @@ msgid "All Time"
 msgstr ""
 
 #: src/api.lib.php:534
-#: src/auditlogs.lib.php:619
+#: src/auditlogs.lib.php:654
 msgid "Today"
 msgstr ""
 
@@ -267,15 +267,15 @@ msgstr ""
 msgid "There are no logs."
 msgstr ""
 
-#: src/auditlogs.lib.php:362
+#: src/auditlogs.lib.php:363
 msgid "status has been changed"
 msgstr ""
 
-#: src/auditlogs.lib.php:410
+#: src/auditlogs.lib.php:411
 msgid "The audit trail download link is invalid or expired."
 msgstr ""
 
-#: src/auditlogs.lib.php:411
+#: src/auditlogs.lib.php:412
 msgid "Audit trail export"
 msgstr ""
 

--- a/lang/sucuri-scanner.pot
+++ b/lang/sucuri-scanner.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-27T19:37:05+00:00\n"
+"POT-Creation-Date: 2026-07-27T19:41:45+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: sucuri-scanner\n"
@@ -235,13 +235,13 @@ msgid "Debug"
 msgstr ""
 
 #. translators: %1$s: plugin or theme name, %2$d: unique post or page identifier
-#: src/api.lib.php:1088
+#: src/api.lib.php:1090
 #, php-format
 msgid "WP Engine PHP Compatibility Checker: %1$s (created post #%2$d as cache)"
 msgstr ""
 
-#: src/api.lib.php:1431
-#: src/api.lib.php:1436
+#: src/api.lib.php:1433
+#: src/api.lib.php:1438
 msgid "WordPress version is not supported anymore"
 msgstr ""
 
@@ -307,52 +307,52 @@ msgid "Automatic update of security keys failed. Something went wrong!"
 msgstr ""
 
 #. translators: %1$s: display name, %2$d: time interval
-#: src/event.lib.php:90
+#: src/event.lib.php:198
 #, php-format
 msgid "%1$s (every %2$d seconds)"
 msgstr ""
 
-#: src/event.lib.php:96
+#: src/event.lib.php:204
 msgid "Never (no execution)"
 msgstr ""
 
-#: src/event.lib.php:148
+#: src/event.lib.php:256
 msgid "Weekly"
 msgstr ""
 
-#: src/event.lib.php:154
+#: src/event.lib.php:262
 msgid "Monthly"
 msgstr ""
 
-#: src/event.lib.php:160
+#: src/event.lib.php:268
 msgid "Quarterly"
 msgstr ""
 
-#: src/event.lib.php:215
-#: src/event.lib.php:266
+#: src/event.lib.php:323
+#: src/event.lib.php:374
 msgid "API key is not available"
 msgstr ""
 
-#: src/event.lib.php:223
+#: src/event.lib.php:331
 msgid "WordPress version was already reported"
 msgstr ""
 
 #. translators: %s: WordPress version
-#: src/event.lib.php:227
+#: src/event.lib.php:335
 #, php-format
 msgid "WordPress version detected %s"
 msgstr ""
 
-#: src/event.lib.php:270
+#: src/event.lib.php:378
 msgid "Scanner ran a couple of minutes ago"
 msgstr ""
 
-#: src/event.lib.php:302
+#: src/event.lib.php:410
 msgid "Event identifier cannot be empty"
 msgstr ""
 
 #. translators: %1$s: settings url, %2$s: settings url
-#: src/event.lib.php:623
+#: src/event.lib.php:743
 #, php-format
 msgid ""
 "<br><br>\n"
@@ -365,24 +365,24 @@ msgid ""
 ""
 msgstr ""
 
-#: src/event.lib.php:772
+#: src/event.lib.php:892
 msgid "Password Change"
 msgstr ""
 
 #. translators: %s: file path
-#: src/event.lib.php:948
+#: src/event.lib.php:1068
 #, php-format
 msgid "%s cannot be deleted."
 msgstr ""
 
 #. translators: %s: comma-separated list of filenames
-#: src/event.lib.php:960
+#: src/event.lib.php:1080
 #, php-format
 msgid "%s log files were deleted."
 msgstr ""
 
 #. translators: %s: filename
-#: src/event.lib.php:962
+#: src/event.lib.php:1082
 #, php-format
 msgid "%s log file was deleted."
 msgstr ""

--- a/lang/sucuri-scanner.pot
+++ b/lang/sucuri-scanner.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-27T21:30:05+00:00\n"
+"POT-Creation-Date: 2026-07-27T23:27:12+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: sucuri-scanner\n"
@@ -82,7 +82,7 @@ msgid "All Time"
 msgstr ""
 
 #: src/api.lib.php:534
-#: src/auditlogs.lib.php:654
+#: src/auditlogs.lib.php:673
 msgid "Today"
 msgstr ""
 
@@ -307,52 +307,52 @@ msgid "Automatic update of security keys failed. Something went wrong!"
 msgstr ""
 
 #. translators: %1$s: display name, %2$d: time interval
-#: src/event.lib.php:234
+#: src/event.lib.php:242
 #, php-format
 msgid "%1$s (every %2$d seconds)"
 msgstr ""
 
-#: src/event.lib.php:240
+#: src/event.lib.php:248
 msgid "Never (no execution)"
 msgstr ""
 
-#: src/event.lib.php:292
+#: src/event.lib.php:300
 msgid "Weekly"
 msgstr ""
 
-#: src/event.lib.php:298
+#: src/event.lib.php:306
 msgid "Monthly"
 msgstr ""
 
-#: src/event.lib.php:304
+#: src/event.lib.php:312
 msgid "Quarterly"
 msgstr ""
 
-#: src/event.lib.php:359
-#: src/event.lib.php:410
+#: src/event.lib.php:367
+#: src/event.lib.php:418
 msgid "API key is not available"
 msgstr ""
 
-#: src/event.lib.php:367
+#: src/event.lib.php:375
 msgid "WordPress version was already reported"
 msgstr ""
 
 #. translators: %s: WordPress version
-#: src/event.lib.php:371
+#: src/event.lib.php:379
 #, php-format
 msgid "WordPress version detected %s"
 msgstr ""
 
-#: src/event.lib.php:414
+#: src/event.lib.php:422
 msgid "Scanner ran a couple of minutes ago"
 msgstr ""
 
-#: src/event.lib.php:446
+#: src/event.lib.php:454
 msgid "Event identifier cannot be empty"
 msgstr ""
 
 #. translators: %1$s: settings url, %2$s: settings url
-#: src/event.lib.php:784
+#: src/event.lib.php:792
 #, php-format
 msgid ""
 "<br><br>\n"
@@ -365,24 +365,24 @@ msgid ""
 ""
 msgstr ""
 
-#: src/event.lib.php:933
+#: src/event.lib.php:941
 msgid "Password Change"
 msgstr ""
 
 #. translators: %s: file path
-#: src/event.lib.php:1109
+#: src/event.lib.php:1117
 #, php-format
 msgid "%s cannot be deleted."
 msgstr ""
 
 #. translators: %s: comma-separated list of filenames
-#: src/event.lib.php:1121
+#: src/event.lib.php:1129
 #, php-format
 msgid "%s log files were deleted."
 msgstr ""
 
 #. translators: %s: filename
-#: src/event.lib.php:1123
+#: src/event.lib.php:1131
 #, php-format
 msgid "%s log file was deleted."
 msgstr ""

--- a/lang/sucuri-scanner.pot
+++ b/lang/sucuri-scanner.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-22T04:25:17+00:00\n"
+"POT-Creation-Date: 2026-07-27T19:37:05+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: sucuri-scanner\n"
@@ -55,174 +55,228 @@ msgstr ""
 msgid "API key was successfully set."
 msgstr ""
 
-#: src/api.lib.php:285
+#: src/api.lib.php:290
 msgid "Unknown error, there is no information"
 msgstr ""
 
-#: src/api.lib.php:325
+#: src/api.lib.php:330
 msgid "Invalid email format or the host is missing MX records."
 msgstr ""
 
-#: src/api.lib.php:360
+#: src/api.lib.php:380
 msgid "API key was generated and set"
 msgstr ""
 
-#: src/api.lib.php:362
+#: src/api.lib.php:382
 msgid "API key successfully generated and saved."
 msgstr ""
 
 #. translators: %s: domain name
-#: src/api.lib.php:391
+#: src/api.lib.php:411
 #, php-format
 msgid "API key recovery for domain: %s"
 msgstr ""
 
-#: src/api.lib.php:495
+#: src/api.lib.php:530
 msgid "All Time"
 msgstr ""
 
-#: src/api.lib.php:499
-#: src/auditlogs.lib.php:403
+#: src/api.lib.php:534
+#: src/auditlogs.lib.php:595
 msgid "Today"
 msgstr ""
 
-#: src/api.lib.php:503
+#: src/api.lib.php:538
 msgid "Yesterday"
 msgstr ""
 
-#: src/api.lib.php:507
+#: src/api.lib.php:542
 msgid "This Week"
 msgstr ""
 
-#: src/api.lib.php:511
+#: src/api.lib.php:546
 msgid "Last 7 Days"
 msgstr ""
 
-#: src/api.lib.php:515
+#: src/api.lib.php:550
 msgid "Last Week"
 msgstr ""
 
-#: src/api.lib.php:519
+#: src/api.lib.php:554
 msgid "Last 14 Days"
 msgstr ""
 
-#: src/api.lib.php:523
+#: src/api.lib.php:558
 msgid "This Month"
 msgstr ""
 
-#: src/api.lib.php:527
+#: src/api.lib.php:562
 msgid "Last 30 Days"
 msgstr ""
 
-#: src/api.lib.php:531
+#: src/api.lib.php:566
 msgid "Last Month"
 msgstr ""
 
-#: src/api.lib.php:535
+#: src/api.lib.php:570
 msgid "This Year"
 msgstr ""
 
-#: src/api.lib.php:539
+#: src/api.lib.php:574
 msgid "Last Year"
 msgstr ""
 
-#: src/api.lib.php:543
+#: src/api.lib.php:578
 msgid "Custom"
 msgstr ""
 
-#: src/api.lib.php:551
+#: src/api.lib.php:586
 msgid "All Posts"
 msgstr ""
 
-#: src/api.lib.php:555
-#: src/api.lib.php:587
+#: src/api.lib.php:590
+#: src/api.lib.php:622
 msgid "Created"
 msgstr ""
 
-#: src/api.lib.php:559
+#: src/api.lib.php:594
+#: src/api.lib.php:652
+#: src/api.lib.php:674
 msgid "Updated"
 msgstr ""
 
-#: src/api.lib.php:563
-#: src/api.lib.php:595
+#: src/api.lib.php:598
+#: src/api.lib.php:630
+#: src/api.lib.php:656
+#: src/api.lib.php:678
 msgid "Deleted"
 msgstr ""
 
-#: src/api.lib.php:569
+#: src/api.lib.php:604
 msgid "All Logins"
 msgstr ""
 
-#: src/api.lib.php:573
+#: src/api.lib.php:608
 msgid "Failed"
 msgstr ""
 
-#: src/api.lib.php:577
+#: src/api.lib.php:612
 msgid "Succeeded"
 msgstr ""
 
-#: src/api.lib.php:583
-#: src/strings.php:205
+#: src/api.lib.php:618
+#: src/strings.php:211
 msgid "All Users"
 msgstr ""
 
-#: src/api.lib.php:591
+#: src/api.lib.php:626
 msgid "Edited"
 msgstr ""
 
-#: src/api.lib.php:601
+#: src/api.lib.php:636
 msgid "All Plugins"
 msgstr ""
 
-#: src/api.lib.php:605
+#: src/api.lib.php:640
+#: src/api.lib.php:666
 msgid "Installed"
 msgstr ""
 
-#: src/api.lib.php:609
+#: src/api.lib.php:644
+#: src/api.lib.php:670
 #: src/topt.lib.php:1561
 msgid "Activated"
 msgstr ""
 
-#: src/api.lib.php:613
+#: src/api.lib.php:648
 #: src/topt.lib.php:1565
 #: src/topt.lib.php:1617
 msgid "Deactivated"
 msgstr ""
 
-#: src/api.lib.php:619
+#: src/api.lib.php:662
+msgid "All Themes"
+msgstr ""
+
+#: src/api.lib.php:684
 msgid "All Files"
 msgstr ""
 
-#: src/api.lib.php:623
+#: src/api.lib.php:688
 msgid "Added"
 msgstr ""
 
+#: src/api.lib.php:694
+msgid "All Severities"
+msgstr ""
+
+#: src/api.lib.php:698
+msgid "Critical"
+msgstr ""
+
+#: src/api.lib.php:702
+msgid "Error"
+msgstr ""
+
+#: src/api.lib.php:706
+msgid "Warning"
+msgstr ""
+
+#: src/api.lib.php:710
+msgid "Notice"
+msgstr ""
+
+#: src/api.lib.php:714
+msgid "Info"
+msgstr ""
+
+#: src/api.lib.php:718
+msgid "Debug"
+msgstr ""
+
 #. translators: %1$s: plugin or theme name, %2$d: unique post or page identifier
-#: src/api.lib.php:944
+#: src/api.lib.php:1088
 #, php-format
 msgid "WP Engine PHP Compatibility Checker: %1$s (created post #%2$d as cache)"
 msgstr ""
 
-#: src/api.lib.php:1287
-#: src/api.lib.php:1292
+#: src/api.lib.php:1431
+#: src/api.lib.php:1436
 msgid "WordPress version is not supported anymore"
 msgstr ""
 
-#: src/auditlogs.lib.php:191
+#: src/auditlogs.lib.php:89
+msgid "Start Date"
+msgstr ""
+
+#: src/auditlogs.lib.php:90
+msgid "End Date"
+msgstr ""
+
+#: src/auditlogs.lib.php:200
 msgid "API is not available; using local queue"
 msgstr ""
 
 #. translators: %s: number of seconds
-#: src/auditlogs.lib.php:194
+#: src/auditlogs.lib.php:203
 #, php-format
 msgid "API %s secs"
 msgstr ""
 
-#: src/auditlogs.lib.php:240
+#: src/auditlogs.lib.php:306
 msgid "There are no logs."
 msgstr ""
 
-#: src/auditlogs.lib.php:296
+#: src/auditlogs.lib.php:357
 msgid "status has been changed"
+msgstr ""
+
+#: src/auditlogs.lib.php:405
+msgid "The audit trail download link is invalid or expired."
+msgstr ""
+
+#: src/auditlogs.lib.php:406
+msgid "Audit trail export"
 msgstr ""
 
 #: src/base.lib.php:61
@@ -297,33 +351,8 @@ msgstr ""
 msgid "Event identifier cannot be empty"
 msgstr ""
 
-#: src/event.lib.php:470
-#: src/event.lib.php:477
-msgid "Info"
-msgstr ""
-
-#: src/event.lib.php:473
-msgid "Debug"
-msgstr ""
-
-#: src/event.lib.php:475
-msgid "Notice"
-msgstr ""
-
-#: src/event.lib.php:479
-msgid "Warning"
-msgstr ""
-
-#: src/event.lib.php:481
-msgid "Error"
-msgstr ""
-
-#: src/event.lib.php:483
-msgid "Critical"
-msgstr ""
-
 #. translators: %1$s: settings url, %2$s: settings url
-#: src/event.lib.php:614
+#: src/event.lib.php:623
 #, php-format
 msgid ""
 "<br><br>\n"
@@ -336,24 +365,24 @@ msgid ""
 ""
 msgstr ""
 
-#: src/event.lib.php:763
+#: src/event.lib.php:772
 msgid "Password Change"
 msgstr ""
 
 #. translators: %s: file path
-#: src/event.lib.php:939
+#: src/event.lib.php:948
 #, php-format
 msgid "%s cannot be deleted."
 msgstr ""
 
 #. translators: %s: comma-separated list of filenames
-#: src/event.lib.php:951
+#: src/event.lib.php:960
 #, php-format
 msgid "%s log files were deleted."
 msgstr ""
 
 #. translators: %s: filename
-#: src/event.lib.php:953
+#: src/event.lib.php:962
 #, php-format
 msgid "%s log file was deleted."
 msgstr ""
@@ -483,54 +512,54 @@ msgstr ""
 msgid "Invalid firewall API key format. Please verify the key is in the form k/s."
 msgstr ""
 
-#: src/firewall.lib.php:781
+#: src/firewall.lib.php:782
 msgid "Failure connecting to the Firewall API service; try again."
 msgstr ""
 
-#: src/globals.php:91
+#: src/globals.php:101
 msgid "Vulnerability Scanning"
 msgstr ""
 
-#: src/globals.php:92
+#: src/globals.php:102
 msgid "Firewall Management"
 msgstr ""
 
-#: src/globals.php:93
-#: src/strings.php:819
+#: src/globals.php:103
+#: src/strings.php:825
 #: src/topt.lib.php:661
 msgid "Two-Factor Authentication"
 msgstr ""
 
-#: src/globals.php:94
+#: src/globals.php:104
 msgid "Events Reporting"
 msgstr ""
 
-#: src/globals.php:95
+#: src/globals.php:105
 msgid "Headers Management"
 msgstr ""
 
-#: src/globals.php:96
+#: src/globals.php:106
 msgid "Hardening & Prevention"
 msgstr ""
 
-#: src/globals.php:97
+#: src/globals.php:107
 msgid "Post-Hack Actions"
 msgstr ""
 
-#: src/globals.php:98
+#: src/globals.php:108
 msgid "Last Logins"
 msgstr ""
 
-#: src/globals.php:99
-#: src/strings.php:41
-#: src/strings.php:124
-#: src/strings.php:400
+#: src/globals.php:109
+#: src/strings.php:47
+#: src/strings.php:130
+#: src/strings.php:406
 msgid "Settings"
 msgstr ""
 
-#: src/globals.php:120
-#: src/globals.php:121
-#: src/strings.php:35
+#: src/globals.php:130
+#: src/globals.php:131
+#: src/strings.php:41
 msgid "Sucuri Security"
 msgstr ""
 
@@ -919,8 +948,8 @@ msgid "The plugin has no permission to restore this file because its directory i
 msgstr ""
 
 #: src/integrity.lib.php:634
-#: src/strings.php:662
-#: src/strings.php:667
+#: src/strings.php:668
+#: src/strings.php:673
 msgid "WordPress Integrity Diff Utility"
 msgstr ""
 
@@ -958,11 +987,11 @@ msgstr ""
 
 #: src/lastlogins-failed.php:349
 #: src/lastlogins-failed.php:373
-#: src/strings.php:213
-#: src/strings.php:226
-#: src/strings.php:242
-#: src/strings.php:254
-#: src/strings.php:563
+#: src/strings.php:219
+#: src/strings.php:232
+#: src/strings.php:248
+#: src/strings.php:260
+#: src/strings.php:569
 msgid "Username"
 msgstr ""
 
@@ -973,12 +1002,12 @@ msgstr ""
 
 #: src/lastlogins-failed.php:351
 #: src/lastlogins-failed.php:375
-#: src/strings.php:101
-#: src/strings.php:219
-#: src/strings.php:227
-#: src/strings.php:243
-#: src/strings.php:257
-#: src/strings.php:372
+#: src/strings.php:107
+#: src/strings.php:225
+#: src/strings.php:233
+#: src/strings.php:249
+#: src/strings.php:263
+#: src/strings.php:378
 msgid "IP Address"
 msgstr ""
 
@@ -1026,380 +1055,380 @@ msgstr ""
 msgid "Sucuri Alert"
 msgstr ""
 
-#: src/option.lib.php:123
+#: src/option.lib.php:124
 msgid "Front Page"
 msgstr ""
 
-#: src/option.lib.php:134
+#: src/option.lib.php:135
 msgid "Posts"
 msgstr ""
 
-#: src/option.lib.php:145
+#: src/option.lib.php:146
 msgid "Pages"
 msgstr ""
 
-#: src/option.lib.php:156
+#: src/option.lib.php:157
 msgid "Main Index"
 msgstr ""
 
-#: src/option.lib.php:167
+#: src/option.lib.php:168
 msgid "Categories"
 msgstr ""
 
-#: src/option.lib.php:178
+#: src/option.lib.php:179
 msgid "Tags"
 msgstr ""
 
-#: src/option.lib.php:189
+#: src/option.lib.php:190
 msgid "Authors"
 msgstr ""
 
-#: src/option.lib.php:200
+#: src/option.lib.php:201
 msgid "Archives"
 msgstr ""
 
-#: src/option.lib.php:211
+#: src/option.lib.php:212
 msgid "Feeds"
 msgstr ""
 
-#: src/option.lib.php:222
+#: src/option.lib.php:223
 msgid "Attachment Pages"
 msgstr ""
 
-#: src/option.lib.php:233
+#: src/option.lib.php:234
 msgid "Search Results"
 msgstr ""
 
-#: src/option.lib.php:244
+#: src/option.lib.php:245
 msgid "404 Not Found"
 msgstr ""
 
-#: src/option.lib.php:255
+#: src/option.lib.php:256
 msgid "Redirects"
 msgstr ""
 
-#: src/option.lib.php:266
+#: src/option.lib.php:267
 msgid "Woocommerce Products"
 msgstr ""
 
-#: src/option.lib.php:277
+#: src/option.lib.php:278
 msgid "Woocommerce Categories"
 msgstr ""
 
-#: src/option.lib.php:290
+#: src/option.lib.php:291
 msgid "Base URI"
 msgstr ""
 
-#: src/option.lib.php:293
+#: src/option.lib.php:294
 msgid "Restricts the URLs that can appear in the document’s <base> element. Commonly 'self'."
 msgstr ""
 
-#: src/option.lib.php:301
+#: src/option.lib.php:302
 msgid "Child Source"
 msgstr ""
 
-#: src/option.lib.php:304
+#: src/option.lib.php:305
 msgid "Allowed sources for frames and nested browsing contexts."
 msgstr ""
 
-#: src/option.lib.php:309
+#: src/option.lib.php:310
 msgid "Connect Source"
 msgstr ""
 
-#: src/option.lib.php:312
+#: src/option.lib.php:313
 msgid "Allowed endpoints for fetch/XHR/WebSocket connections."
 msgstr ""
 
-#: src/option.lib.php:317
+#: src/option.lib.php:318
 msgid "Default Source"
 msgstr ""
 
-#: src/option.lib.php:320
+#: src/option.lib.php:321
 msgid "Fallback policy for resources if no other directive is defined."
 msgstr ""
 
-#: src/option.lib.php:328
+#: src/option.lib.php:329
 msgid "Font Source"
 msgstr ""
 
-#: src/option.lib.php:331
+#: src/option.lib.php:332
 msgid "Allowed font sources (e.g. self or font CDNs)."
 msgstr ""
 
-#: src/option.lib.php:336
+#: src/option.lib.php:337
 msgid "Form Action"
 msgstr ""
 
-#: src/option.lib.php:339
+#: src/option.lib.php:340
 msgid "Restricts the URLs to which forms can be submitted."
 msgstr ""
 
-#: src/option.lib.php:344
+#: src/option.lib.php:345
 msgid "Frame Ancestors"
 msgstr ""
 
-#: src/option.lib.php:347
+#: src/option.lib.php:348
 msgid "Restricts which sites can embed this page in a frame."
 msgstr ""
 
-#: src/option.lib.php:352
+#: src/option.lib.php:353
 msgid "Image Source"
 msgstr ""
 
-#: src/option.lib.php:355
+#: src/option.lib.php:356
 msgid "Allowed image sources. Often includes self and possibly data: URIs."
 msgstr ""
 
-#: src/option.lib.php:363
+#: src/option.lib.php:364
 msgid "Manifest Source"
 msgstr ""
 
-#: src/option.lib.php:366
+#: src/option.lib.php:367
 msgid "Allowed sources for web app manifests."
 msgstr ""
 
-#: src/option.lib.php:371
+#: src/option.lib.php:372
 msgid "Media Source"
 msgstr ""
 
-#: src/option.lib.php:374
+#: src/option.lib.php:375
 msgid "Allowed sources for audio and video content."
 msgstr ""
 
-#: src/option.lib.php:379
+#: src/option.lib.php:380
 msgid "Navigate To"
 msgstr ""
 
-#: src/option.lib.php:382
+#: src/option.lib.php:383
 msgid "Restricts which URLs the document can navigate to (e.g., links)."
 msgstr ""
 
-#: src/option.lib.php:390
+#: src/option.lib.php:391
 msgid "Object Source"
 msgstr ""
 
-#: src/option.lib.php:393
+#: src/option.lib.php:394
 msgid "Allowed sources for <object>, <embed>, or <applet>. Usually 'none'."
 msgstr ""
 
-#: src/option.lib.php:401
+#: src/option.lib.php:402
 msgid "Script Source"
 msgstr ""
 
-#: src/option.lib.php:404
+#: src/option.lib.php:405
 msgid "Allowed script sources. Avoid 'unsafe-inline'; consider nonces."
 msgstr ""
 
-#: src/option.lib.php:412
+#: src/option.lib.php:413
 msgid "Script Source Attribute"
 msgstr ""
 
-#: src/option.lib.php:415
+#: src/option.lib.php:416
 msgid "Allowed sources for inline event handlers."
 msgstr ""
 
-#: src/option.lib.php:423
+#: src/option.lib.php:424
 msgid "Script Source Element"
 msgstr ""
 
-#: src/option.lib.php:426
+#: src/option.lib.php:427
 msgid "Allowed sources for <script> elements. Falls back to script-src if missing."
 msgstr ""
 
-#: src/option.lib.php:434
+#: src/option.lib.php:435
 msgid "Style Source"
 msgstr ""
 
-#: src/option.lib.php:437
+#: src/option.lib.php:438
 msgid "Allowed style sources. Avoid 'unsafe-inline'; consider nonces."
 msgstr ""
 
-#: src/option.lib.php:445
+#: src/option.lib.php:446
 msgid "Style Source Attribute"
 msgstr ""
 
-#: src/option.lib.php:448
+#: src/option.lib.php:449
 msgid "Allowed sources for inline style attributes."
 msgstr ""
 
-#: src/option.lib.php:453
+#: src/option.lib.php:454
 msgid "Style Source Element"
 msgstr ""
 
-#: src/option.lib.php:456
+#: src/option.lib.php:457
 msgid "Allowed sources for <style> and <link> elements."
 msgstr ""
 
-#: src/option.lib.php:461
+#: src/option.lib.php:462
 msgid "Worker Source"
 msgstr ""
 
-#: src/option.lib.php:464
+#: src/option.lib.php:465
 msgid "Allowed sources for web and service workers."
 msgstr ""
 
-#: src/option.lib.php:469
+#: src/option.lib.php:470
 msgid "Sandbox"
 msgstr ""
 
-#: src/option.lib.php:473
+#: src/option.lib.php:474
 msgid "Allow Downloads"
 msgstr ""
 
-#: src/option.lib.php:477
+#: src/option.lib.php:478
 msgid "Allow Forms"
 msgstr ""
 
-#: src/option.lib.php:481
+#: src/option.lib.php:482
 msgid "Allow Modals"
 msgstr ""
 
-#: src/option.lib.php:485
+#: src/option.lib.php:486
 msgid "Allow Orientation Lock"
 msgstr ""
 
-#: src/option.lib.php:489
+#: src/option.lib.php:490
 msgid "Allow Pointer Lock"
 msgstr ""
 
-#: src/option.lib.php:493
+#: src/option.lib.php:494
 msgid "Allow Popups"
 msgstr ""
 
-#: src/option.lib.php:497
+#: src/option.lib.php:498
 msgid "Allow Popups to Escape Sandbox"
 msgstr ""
 
-#: src/option.lib.php:501
+#: src/option.lib.php:502
 msgid "Allow Presentation"
 msgstr ""
 
-#: src/option.lib.php:505
+#: src/option.lib.php:506
 msgid "Allow Same Origin"
 msgstr ""
 
-#: src/option.lib.php:509
+#: src/option.lib.php:510
 msgid "Allow Scripts"
 msgstr ""
 
-#: src/option.lib.php:513
+#: src/option.lib.php:514
 msgid "Allow Top Navigation"
 msgstr ""
 
-#: src/option.lib.php:517
+#: src/option.lib.php:518
 msgid "Applies a sandbox to the page. Select tokens to allow exceptions."
 msgstr ""
 
-#: src/option.lib.php:525
-#: src/option.lib.php:529
+#: src/option.lib.php:526
+#: src/option.lib.php:530
 msgid "Upgrade Insecure Requests"
 msgstr ""
 
-#: src/option.lib.php:533
+#: src/option.lib.php:534
 msgid "Upgrade insecure requests to HTTPS. This is a security feature that prevents mixed content."
 msgstr ""
 
-#: src/option.lib.php:544
+#: src/option.lib.php:545
 msgid "Access-Control-Allow-Origin"
 msgstr ""
 
-#: src/option.lib.php:547
+#: src/option.lib.php:548
 msgid "Specifies the origin that is allowed to access the resource."
 msgstr ""
 
-#: src/option.lib.php:555
+#: src/option.lib.php:556
 msgid "Access-Control-Expose-Headers"
 msgstr ""
 
-#: src/option.lib.php:558
+#: src/option.lib.php:559
 msgid "Specifies the headers that can be exposed when accessing the resource."
 msgstr ""
 
-#: src/option.lib.php:566
+#: src/option.lib.php:567
 msgid "Access-Control-Allow-Methods"
 msgstr ""
 
-#: src/option.lib.php:569
+#: src/option.lib.php:570
 msgid "Allow GET method"
 msgstr ""
 
-#: src/option.lib.php:573
+#: src/option.lib.php:574
 msgid "Allow POST method"
 msgstr ""
 
-#: src/option.lib.php:577
+#: src/option.lib.php:578
 msgid "Allow PUT method"
 msgstr ""
 
-#: src/option.lib.php:581
+#: src/option.lib.php:582
 msgid "Allow DELETE method"
 msgstr ""
 
-#: src/option.lib.php:585
+#: src/option.lib.php:586
 msgid "Allow OPTIONS method"
 msgstr ""
 
-#: src/option.lib.php:589
+#: src/option.lib.php:590
 msgid "Allow PATCH method"
 msgstr ""
 
-#: src/option.lib.php:593
+#: src/option.lib.php:594
 msgid "Allow HEAD method"
 msgstr ""
 
-#: src/option.lib.php:597
+#: src/option.lib.php:598
 msgid "Allow TRACE method"
 msgstr ""
 
-#: src/option.lib.php:601
+#: src/option.lib.php:602
 msgid "Allow CONNECT method"
 msgstr ""
 
-#: src/option.lib.php:606
+#: src/option.lib.php:607
 msgid "Specifies the methods allowed when accessing the resource."
 msgstr ""
 
-#: src/option.lib.php:614
+#: src/option.lib.php:615
 msgid "Access-Control-Allow-Headers"
 msgstr ""
 
-#: src/option.lib.php:617
+#: src/option.lib.php:618
 msgid "Specifies the headers allowed when accessing the resource."
 msgstr ""
 
-#: src/option.lib.php:625
+#: src/option.lib.php:626
 msgid "Access-Control-Allow-Credentials"
 msgstr ""
 
-#: src/option.lib.php:629
+#: src/option.lib.php:630
 msgid "Allow Credentials"
 msgstr ""
 
-#: src/option.lib.php:633
+#: src/option.lib.php:634
 msgid "Specifies whether credentials are allowed when accessing the resource."
 msgstr ""
 
-#: src/option.lib.php:641
+#: src/option.lib.php:642
 msgid "Access-Control-Max-Age"
 msgstr ""
 
-#: src/option.lib.php:644
+#: src/option.lib.php:645
 msgid "Specifies how long the results of a preflight request can be cached."
 msgstr ""
 
 #. translators: %s: error message
-#: src/option.lib.php:1319
+#: src/option.lib.php:1320
 #, php-format
 msgid "Firewall API key decryption failed: %s"
 msgstr ""
 
-#: src/option.lib.php:1372
+#: src/option.lib.php:1373
 msgid "The Sucuri WAF API key could not be decrypted. Please re-save the key in the Firewall settings to restore functionality."
 msgstr ""
 
 #. translators: %1$s: domain, %2$s: event, %3$s: remote address
 #. translators: %1$s: specific info like domain, event, etc
-#: src/option.lib.php:1639
+#: src/option.lib.php:1640
 #: src/settings-alerts.php:243
 #: src/settings-alerts.php:245
 #: src/settings-alerts.php:247
@@ -1423,23 +1452,23 @@ msgstr ""
 #: src/pagehandler.php:172
 #: src/pagehandler.php:173
 #: src/strings.php:26
-#: src/strings.php:57
-#: src/strings.php:69
-#: src/strings.php:89
-#: src/strings.php:143
-#: src/strings.php:202
-#: src/strings.php:544
-#: src/strings.php:557
-#: src/strings.php:571
-#: src/strings.php:630
+#: src/strings.php:63
+#: src/strings.php:75
+#: src/strings.php:95
+#: src/strings.php:149
+#: src/strings.php:208
+#: src/strings.php:550
+#: src/strings.php:563
+#: src/strings.php:577
+#: src/strings.php:636
 msgid "Loading..."
 msgstr ""
 
-#: src/pagehandler.php:357
+#: src/pagehandler.php:358
 msgid "Last-Logins logs were successfully reset."
 msgstr ""
 
-#: src/pagehandler.php:359
+#: src/pagehandler.php:360
 msgid "Could not reset the last-logins data file."
 msgstr ""
 
@@ -1762,13 +1791,13 @@ msgstr ""
 #: src/settings-alerts.php:634
 #: src/settings-scanner.php:187
 #: src/settings-scanner.php:248
-#: src/strings.php:47
-#: src/strings.php:218
-#: src/strings.php:230
-#: src/strings.php:246
-#: src/strings.php:375
-#: src/strings.php:521
-#: src/strings.php:658
+#: src/strings.php:53
+#: src/strings.php:224
+#: src/strings.php:236
+#: src/strings.php:252
+#: src/strings.php:381
+#: src/strings.php:527
+#: src/strings.php:664
 msgid "no data available"
 msgstr ""
 
@@ -1794,7 +1823,7 @@ msgstr ""
 #: src/settings-headers.php:396
 #: src/settings-headers.php:439
 #: src/settings-integrity.php:82
-#: src/strings.php:772
+#: src/strings.php:778
 #: src/topt.lib.php:1067
 msgid "Enabled"
 msgstr ""
@@ -1816,7 +1845,7 @@ msgstr ""
 #: src/settings-headers.php:361
 #: src/settings-headers.php:395
 #: src/settings-headers.php:439
-#: src/strings.php:773
+#: src/strings.php:779
 #: src/topt.lib.php:1068
 msgid "Disabled"
 msgstr ""
@@ -1945,7 +1974,7 @@ msgid "Exists"
 msgstr ""
 
 #: src/settings-general.php:154
-#: src/strings.php:448
+#: src/strings.php:454
 msgid "Writable"
 msgstr ""
 
@@ -2035,6 +2064,7 @@ msgstr ""
 #: src/settings-hardening.php:521
 #: src/settings-hardening.php:639
 #: src/settings-hardening.php:693
+#: src/settings-hardening.php:764
 msgid "Apply Hardening"
 msgstr ""
 
@@ -2050,6 +2080,7 @@ msgstr ""
 #: src/settings-hardening.php:517
 #: src/settings-hardening.php:635
 #: src/settings-hardening.php:698
+#: src/settings-hardening.php:760
 msgid "Revert Hardening"
 msgstr ""
 
@@ -2222,6 +2253,8 @@ msgstr ""
 
 #: src/settings-hardening.php:668
 #: src/settings-hardening.php:678
+#: src/settings-hardening.php:725
+#: src/settings-hardening.php:734
 #: src/settings-posthack.php:151
 #: src/settings-posthack.php:162
 msgid "Something went wrong."
@@ -2242,19 +2275,49 @@ msgstr ""
 msgid "Changing the Secret Keys will invalidate all existing cookies, forcing all logged in users to login again. Doing this frequently will decrease the chances of misuse of sessions left open on unprotected devices."
 msgstr ""
 
-#: src/settings-hardening.php:742
+#: src/settings-hardening.php:722
+msgid "XML-RPC was disabled"
+msgstr ""
+
+#: src/settings-hardening.php:723
+msgid "XML-RPC (xmlrpc.php) has been disabled."
+msgstr ""
+
+#: src/settings-hardening.php:731
+msgid "XML-RPC was re-enabled"
+msgstr ""
+
+#: src/settings-hardening.php:732
+msgid "XML-RPC (xmlrpc.php) has been re-enabled."
+msgstr ""
+
+#: src/settings-hardening.php:738
+msgid "Disable XML-RPC"
+msgstr ""
+
+#: src/settings-hardening.php:740
+msgid "XML-RPC (xmlrpc.php) is a legacy remote API with almost no legitimate use on modern WordPress sites. It is one of the most common vectors for brute-force login attempts and pingback-based DDoS amplification attacks. Disabling it closes this attack surface."
+msgstr ""
+
+#. translators: %s: comma-separated list of active plugin names, e.g. "Jetpack".
+#: src/settings-hardening.php:750
+#, php-format
+msgid "Warning: the following active plugin(s) may rely on XML-RPC and could stop working correctly if you disable it: %s."
+msgstr ""
+
+#: src/settings-hardening.php:808
 msgid "The file has been allowed"
 msgstr ""
 
-#: src/settings-hardening.php:747
+#: src/settings-hardening.php:813
 msgid "Specified folder is not hardened by this plugin"
 msgstr ""
 
-#: src/settings-hardening.php:774
+#: src/settings-hardening.php:840
 msgid "Some files could not be removed"
 msgstr ""
 
-#: src/settings-hardening.php:776
+#: src/settings-hardening.php:842
 msgid "Selected files have been removed"
 msgstr ""
 
@@ -2566,1227 +2629,1251 @@ msgstr ""
 msgid "Send Logs"
 msgstr ""
 
+#: src/strings.php:33
+msgid "Search audit trails"
+msgstr ""
+
+#: src/strings.php:34
+msgid "Results are limited to the latest audit trails available."
+msgstr ""
+
+#: src/strings.php:35
+msgid "Filter"
+msgstr ""
+
 #: src/strings.php:36
-msgid "WP Plugin"
+msgid "Clear Filters"
 msgstr ""
 
 #: src/strings.php:37
-msgid "Review"
+msgid "The CSV contains all audit trails currently stored on this website."
 msgstr ""
 
 #: src/strings.php:38
-msgid "Generate API Key"
-msgstr ""
-
-#: src/strings.php:39
-#: src/strings.php:399
-msgid "Dashboard"
-msgstr ""
-
-#: src/strings.php:40
-msgid "Firewall (WAF)"
+msgid "Download CSV"
 msgstr ""
 
 #: src/strings.php:42
-msgid "Copyright"
+msgid "WP Plugin"
 msgstr ""
 
 #: src/strings.php:43
-msgid "Sucuri Inc. All Rights Reserved."
+msgid "Review"
 msgstr ""
 
 #: src/strings.php:44
-msgid "Help & More"
+msgid "Generate API Key"
+msgstr ""
+
+#: src/strings.php:45
+#: src/strings.php:405
+msgid "Dashboard"
+msgstr ""
+
+#: src/strings.php:46
+msgid "Firewall (WAF)"
 msgstr ""
 
 #: src/strings.php:48
-#: src/strings.php:125
+msgid "Copyright"
+msgstr ""
+
+#: src/strings.php:49
+msgid "Sucuri Inc. All Rights Reserved."
+msgstr ""
+
+#: src/strings.php:50
+msgid "Help & More"
+msgstr ""
+
+#: src/strings.php:54
+#: src/strings.php:131
 msgid "Audit Logs"
 msgstr ""
 
-#: src/strings.php:51
+#: src/strings.php:57
 msgid "Firewall Audit Logs"
 msgstr ""
 
-#: src/strings.php:52
+#: src/strings.php:58
 msgid "The firewall logs every request involved in an attack and separates them from the legitimate requests. You can analyze the data from the latest entries in the logs using this tool and take action either enabling the advanced features of the IDS <em>(Intrusion Detection System)</em> from the <a href=\"https://waf.sucuri.net/?settings\" target=\"_blank\" rel=\"noopener\">Firewall Dashboard</a> and/or blocking IP addresses and URL paths directly from the <a href=\"https://waf.sucuri.net/?audit\" target=\"_blank\" rel=\"noopener\">Firewall Audit Trails</a> page."
 msgstr ""
 
-#: src/strings.php:56
+#: src/strings.php:62
 msgid "Non-blocked requests are hidden from the logs, this is intentional."
 msgstr ""
 
-#: src/strings.php:58
-#: src/strings.php:88
-#: src/strings.php:175
-#: src/strings.php:289
-#: src/strings.php:298
-#: src/strings.php:308
-#: src/strings.php:322
-#: src/strings.php:337
-#: src/strings.php:347
-#: src/strings.php:360
-#: src/strings.php:370
-#: src/strings.php:388
-#: src/strings.php:410
-#: src/strings.php:458
-#: src/strings.php:482
-#: src/strings.php:498
-#: src/strings.php:507
-#: src/strings.php:516
-#: src/strings.php:567
-#: src/strings.php:589
-#: src/strings.php:609
-#: src/strings.php:632
-#: src/strings.php:642
-#: src/strings.php:738
-#: src/strings.php:799
-#: src/strings.php:816
+#: src/strings.php:64
+#: src/strings.php:94
+#: src/strings.php:181
+#: src/strings.php:295
+#: src/strings.php:304
+#: src/strings.php:314
+#: src/strings.php:328
+#: src/strings.php:343
+#: src/strings.php:353
+#: src/strings.php:366
+#: src/strings.php:376
+#: src/strings.php:394
+#: src/strings.php:416
+#: src/strings.php:464
+#: src/strings.php:488
+#: src/strings.php:504
+#: src/strings.php:513
+#: src/strings.php:522
+#: src/strings.php:573
+#: src/strings.php:595
+#: src/strings.php:615
+#: src/strings.php:638
+#: src/strings.php:648
+#: src/strings.php:744
+#: src/strings.php:805
+#: src/strings.php:822
 msgid "Submit"
 msgstr ""
 
-#: src/strings.php:61
-#: src/strings.php:264
+#: src/strings.php:67
+#: src/strings.php:270
 msgid "Date/Time:"
 msgstr ""
 
-#: src/strings.php:62
+#: src/strings.php:68
 msgid "Signature:"
 msgstr ""
 
-#: src/strings.php:63
+#: src/strings.php:69
 msgid "Request:"
 msgstr ""
 
-#: src/strings.php:64
+#: src/strings.php:70
 msgid "U-Agent:"
 msgstr ""
 
-#: src/strings.php:65
+#: src/strings.php:71
 msgid "Target:"
 msgstr ""
 
-#: src/strings.php:66
+#: src/strings.php:72
 msgid "Referer:"
 msgstr ""
 
-#: src/strings.php:70
+#: src/strings.php:76
 msgid "Clear cache when a post or page is updated (Loading...)"
 msgstr ""
 
-#: src/strings.php:71
+#: src/strings.php:77
 msgid "Clear cache when a post or page is updated"
 msgstr ""
 
-#: src/strings.php:72
-#: src/strings.php:127
+#: src/strings.php:78
+#: src/strings.php:133
 msgid "Clear Cache"
 msgstr ""
 
-#: src/strings.php:73
+#: src/strings.php:79
 msgid "The firewall offers multiple options to configure the cache level applied to your website. You can either enable the full cache which is the recommended setting, or you can set the cache level to minimal which will keep the pages static for a couple of minutes, or force the usage of the website headers <em>(only for advanced users)</em>, or in extreme cases where you do not need the cache you can simply disable it. Find more information about it in the <a href=\"https://docs.sucuri.net/website-firewall/performance/caching-options/\" target=\"_blank\" rel=\"noopener\">Sucuri Knowledge Base</a> website."
 msgstr ""
 
-#: src/strings.php:77
+#: src/strings.php:83
 msgid "Note that the firewall has <a href=\"https://docs.sucuri.net/website-firewall/performance/cache-exceptions/\" target=\"_blank\" rel=\"noopener\">special caching rules</a> for Images, CSS, PDF, TXT, JavaScript, media files and a few more extensions that are stored on our <a href=\"https://en.wikipedia.org/wiki/Edge_device\" target=\"_blank\" rel=\"noopener\">edge</a>. The only way to flush the cache for these files is by clearing the firewall’s cache completely <em>(for the whole website)</em>. Due to our caching of JavaScript and CSS files, often, as is best practice, the use of versioning during development will ensure updates going live as expected. This is done by adding a query string such as <code>?ver=1.2.3</code> and incrementing on each update."
 msgstr ""
 
-#: src/strings.php:81
+#: src/strings.php:87
 msgid "A web cache (or HTTP cache) is an information technology for the temporary storage (caching) of web documents, such as HTML pages and images, to reduce bandwidth usage, server load, and perceived lag. A web cache system stores copies of documents passing through it; subsequent requests may be satisfied from the cache if certain conditions are met. A web cache system can refer either to an appliance, or to a computer program. &mdash; <a href=\"https://en.wikipedia.org/wiki/Web_cache\" target=\"_blank\" rel=\"noopener\">WikiPedia - Web Cache</a>"
 msgstr ""
 
-#: src/strings.php:87
-#: src/strings.php:114
-#: src/strings.php:350
-#: src/strings.php:376
-#: src/strings.php:449
-#: src/strings.php:522
+#: src/strings.php:93
+#: src/strings.php:120
+#: src/strings.php:356
+#: src/strings.php:382
+#: src/strings.php:455
+#: src/strings.php:528
 msgid "Delete"
 msgstr ""
 
-#: src/strings.php:90
+#: src/strings.php:96
 msgid "IP Address Access"
 msgstr ""
 
-#: src/strings.php:91
+#: src/strings.php:97
 msgid "This tool allows you to add one or more IP addresses to the blocklist and stop them from accessing your website."
 msgstr ""
 
-#: src/strings.php:95
+#: src/strings.php:101
 msgid "To delete an IP from the blocklist you can use the form below or you can log into the Firewall dashboard."
 msgstr ""
 
-#: src/strings.php:99
+#: src/strings.php:105
 msgid "Add IP to the Blocklist:"
 msgstr ""
 
-#: src/strings.php:100
+#: src/strings.php:106
 msgid "e.g. 192.168.1.54"
 msgstr ""
 
-#: src/strings.php:104
+#: src/strings.php:110
 msgid "Firewall Settings"
 msgstr ""
 
-#: src/strings.php:105
+#: src/strings.php:111
 msgid "A powerful Web Application Firewall and <b>Intrusion Detection System</b> for any WordPress user and many other platforms. This page will help you to configure and monitor your site through the <b>Sucuri Firewall</b>. Once enabled, our firewall will act as a shield, protecting your site from attacks and preventing malware infections and reinfections. It will block SQL injection attempts, brute force attacks, XSS, RFI, backdoors and many other threats against your site."
 msgstr ""
 
-#: src/strings.php:109
+#: src/strings.php:115
 msgid "Add your <a href=\"https://waf.sucuri.net/?settings&panel=api\" target=\"_blank\" rel=\"noopener\">Firewall API key</a> in the form below to start communicating with the firewall API service."
 msgstr ""
 
-#: src/strings.php:113
+#: src/strings.php:119
 msgid "Firewall API Key:"
 msgstr ""
 
-#: src/strings.php:115
+#: src/strings.php:121
 msgid "Save"
 msgstr ""
 
-#: src/strings.php:116
-#: src/strings.php:529
-#: src/strings.php:540
-#: src/strings.php:585
-#: src/strings.php:599
-#: src/strings.php:626
+#: src/strings.php:122
+#: src/strings.php:535
+#: src/strings.php:546
+#: src/strings.php:591
+#: src/strings.php:605
+#: src/strings.php:632
 msgid "Name"
 msgstr ""
 
-#: src/strings.php:117
-#: src/strings.php:600
+#: src/strings.php:123
+#: src/strings.php:606
 msgid "Value"
 msgstr ""
 
-#: src/strings.php:118
+#: src/strings.php:124
 msgid "<em>[1]</em> More information about the <a href=\"https://sucuri.net/website-firewall/\" target=\"_blank\" rel=\"noopener\">Sucuri Firewall</a>, features and pricing.<br><em>[2]</em> Instructions and videos in the official <a href=\"https://docs.sucuri.net/website-firewall/website-firewall/\" target=\"_blank\" rel=\"noopener\">Knowledge Base</a> site.<br><em>[3]</em> <a href=\"https://sucuri.net/website-security-platform/signup/\" target=\"_blank\" rel=\"noopener\">Sign up</a> for a new account and start protecting your site."
 msgstr ""
 
-#: src/strings.php:126
+#: src/strings.php:132
 msgid "IP Access"
 msgstr ""
 
-#: src/strings.php:130
-#: src/strings.php:150
-#: src/strings.php:197
+#: src/strings.php:136
+#: src/strings.php:156
+#: src/strings.php:203
 msgid "WordPress Integrity"
 msgstr ""
 
-#: src/strings.php:131
-#: src/strings.php:151
-#: src/strings.php:198
+#: src/strings.php:137
+#: src/strings.php:157
+#: src/strings.php:204
 msgid "We inspect your WordPress installation and look for modifications on the core files as provided by WordPress.org. Files located in the root directory, wp-admin and wp-includes will be compared against the files distributed with v%%SUCURI.WordPressVersion%%; all files with inconsistencies will be listed here. Any changes might indicate a hack."
 msgstr ""
 
-#: src/strings.php:135
+#: src/strings.php:141
 msgid "All Core WordPress Files Are Correct"
 msgstr ""
 
-#: src/strings.php:136
+#: src/strings.php:142
 msgid "We have not identified additional files, deleted files, or relevant changes to the core files in your WordPress installation. If you are experiencing other malware issues, please use a <a href=\"https://sucuri.net/website-security/malware-removal\" target=\"_blank\" rel=\"noopener\">Server Side Scanner</a>."
 msgstr ""
 
-#: src/strings.php:140
-#: src/strings.php:160
+#: src/strings.php:146
+#: src/strings.php:166
 msgid "Review False Positives"
 msgstr ""
 
-#: src/strings.php:144
+#: src/strings.php:150
 msgid "Lines with a <b>minus</b> sign as the prefix <em>(here in red)</em> show the original code. Lines with a <b>plus</b> sign as the prefix <em>(here in green)</em> show the modified code. You can read more about the DIFF format from the WikiPedia article about the <a target=\"_blank\" href=\"https://en.wikipedia.org/wiki/Diff_utility\" rel=\"noopener\">Unix Diff Utility</a>."
 msgstr ""
 
-#: src/strings.php:155
+#: src/strings.php:161
 msgid "Core WordPress Files Were Modified"
 msgstr ""
 
-#: src/strings.php:156
-#: src/strings.php:182
+#: src/strings.php:162
+#: src/strings.php:188
 msgid "We identified that some of your WordPress core files were modified. That might indicate a hack or a broken file on your installation. If you are experiencing other malware issues, please use a <a href=\"https://sucuri.net/website-security/malware-removal\" target=\"_blank\" rel=\"noopener\">Server Side Scanner</a>."
 msgstr ""
 
-#: src/strings.php:161
-#: src/strings.php:186
+#: src/strings.php:167
+#: src/strings.php:192
 msgid "WordPress Integrity (%%SUCURI.Integrity.ListCount%%)"
 msgstr ""
 
-#: src/strings.php:162
+#: src/strings.php:168
 msgid "The Unix Diff Utility is enabled. You can click the files in the table to see the differences detected by the scanner. If you consider the differences to be harmless you can mark the file as fixed, otherwise it is advised to restore the original content immediately."
 msgstr ""
 
-#: src/strings.php:166
-#: src/strings.php:306
-#: src/strings.php:325
-#: src/strings.php:348
-#: src/strings.php:371
-#: src/strings.php:444
-#: src/strings.php:517
-#: src/strings.php:562
-#: src/strings.php:584
-#: src/strings.php:625
-#: src/strings.php:643
-#: src/strings.php:654
+#: src/strings.php:172
+#: src/strings.php:312
+#: src/strings.php:331
+#: src/strings.php:354
+#: src/strings.php:377
+#: src/strings.php:450
+#: src/strings.php:523
+#: src/strings.php:568
+#: src/strings.php:590
+#: src/strings.php:631
+#: src/strings.php:649
+#: src/strings.php:660
 msgid "Select All"
 msgstr ""
 
-#: src/strings.php:167
-#: src/strings.php:188
-#: src/strings.php:446
+#: src/strings.php:173
+#: src/strings.php:194
+#: src/strings.php:452
 msgid "File Size"
 msgstr ""
 
-#: src/strings.php:168
-#: src/strings.php:189
+#: src/strings.php:174
+#: src/strings.php:195
 msgid "Modified At"
 msgstr ""
 
-#: src/strings.php:169
-#: src/strings.php:190
-#: src/strings.php:445
-#: src/strings.php:518
-#: src/strings.php:644
-#: src/strings.php:657
+#: src/strings.php:175
+#: src/strings.php:196
+#: src/strings.php:451
+#: src/strings.php:524
+#: src/strings.php:650
+#: src/strings.php:663
 msgid "File Path"
 msgstr ""
 
-#: src/strings.php:170
-#: src/strings.php:457
-#: src/strings.php:481
-#: src/strings.php:601
+#: src/strings.php:176
+#: src/strings.php:463
+#: src/strings.php:487
+#: src/strings.php:607
 msgid "I understand that this operation cannot be reverted."
 msgstr ""
 
-#: src/strings.php:171
-#: src/strings.php:631
+#: src/strings.php:177
+#: src/strings.php:637
 msgid "Action:"
 msgstr ""
 
-#: src/strings.php:172
+#: src/strings.php:178
 msgid "Mark as Fixed"
 msgstr ""
 
-#: src/strings.php:173
+#: src/strings.php:179
 msgid "Restore File"
 msgstr ""
 
-#: src/strings.php:174
+#: src/strings.php:180
 msgid "Delete File"
 msgstr ""
 
-#: src/strings.php:176
-#: src/strings.php:191
+#: src/strings.php:182
+#: src/strings.php:197
 msgid "Marking one or more files as fixed will force the plugin to ignore them during the next scan, very useful when you find false positives. Additionally you can restore the original content of the core files that appear as modified or deleted, this will tell the plugin to download a copy of the original files from the official WordPress repository. Deleting a file is an irreversible action, be careful."
 msgstr ""
 
-#: src/strings.php:187
-#: src/strings.php:447
-#: src/strings.php:588
-#: src/strings.php:598
-#: src/strings.php:645
+#: src/strings.php:193
+#: src/strings.php:453
+#: src/strings.php:594
+#: src/strings.php:604
+#: src/strings.php:651
 msgid "Status"
 msgstr ""
 
-#: src/strings.php:206
+#: src/strings.php:212
 msgid "Admins"
 msgstr ""
 
-#: src/strings.php:207
+#: src/strings.php:213
 msgid "Logged-in Users"
 msgstr ""
 
-#: src/strings.php:208
+#: src/strings.php:214
 msgid "Failed Logins"
 msgstr ""
 
-#: src/strings.php:211
+#: src/strings.php:217
 msgid "Successful Logins (admins)"
 msgstr ""
 
-#: src/strings.php:212
+#: src/strings.php:218
 msgid "Here you can see a list of all the successful logins of accounts with admin privileges."
 msgstr ""
 
-#: src/strings.php:214
+#: src/strings.php:220
 msgid "Registration"
 msgstr ""
 
-#: src/strings.php:215
+#: src/strings.php:221
 msgid "Newest To Oldest"
 msgstr ""
 
-#: src/strings.php:220
-#: src/strings.php:229
-#: src/strings.php:244
+#: src/strings.php:226
+#: src/strings.php:235
+#: src/strings.php:250
 msgid "Date/Time"
 msgstr ""
 
-#: src/strings.php:221
-#: src/strings.php:260
+#: src/strings.php:227
+#: src/strings.php:266
 msgid "Edit User Profile"
 msgstr ""
 
-#: src/strings.php:224
+#: src/strings.php:230
 msgid "Successful Logins (all)"
 msgstr ""
 
-#: src/strings.php:225
+#: src/strings.php:231
 msgid "Here you can see a list of all the successful user logins."
 msgstr ""
 
-#: src/strings.php:228
+#: src/strings.php:234
 msgid "Hostname"
 msgstr ""
 
-#: src/strings.php:231
+#: src/strings.php:237
 msgid "Delete All Successful Logins"
 msgstr ""
 
-#: src/strings.php:234
-#: src/strings.php:776
-#: src/strings.php:783
+#: src/strings.php:240
+#: src/strings.php:782
+#: src/strings.php:789
 msgid "Edit"
 msgstr ""
 
-#: src/strings.php:237
+#: src/strings.php:243
 msgid "Failed logins"
 msgstr ""
 
-#: src/strings.php:238
+#: src/strings.php:244
 msgid "This information will be used to determine if your site is being victim of <a href=\"https://docs.sucuri.net/definitions/attacks/brute-force/password-guessing-brute-force-attacks/\" target=\"_blank\" rel=\"noopener\">Password Guessing Brute Force Attacks</a>. These logs will be accumulated and the plugin will send a report via email if there are more than <code>%%SUCURI.FailedLogins.MaxFailedLogins%%</code> failed login attempts during the same hour, you can change this number from <a href=\"%%SUCURI.URL.Settings%%#alerts\">here</a>. <b>NOTE:</b> Some <em>\"Two-Factor Authentication\"</em> plugins do not follow the same rules that WordPress have to report failed login attempts, so you may not see all the attempts in this panel if you have one of these plugins installed."
 msgstr ""
 
-#: src/strings.php:245
+#: src/strings.php:251
 msgid "Web Browser"
 msgstr ""
 
-#: src/strings.php:247
+#: src/strings.php:253
 msgid "Block"
 msgstr ""
 
-#: src/strings.php:248
+#: src/strings.php:254
 msgid "Delete All Failed Logins"
 msgstr ""
 
-#: src/strings.php:251
+#: src/strings.php:257
 msgid "Logged-in Users}"
 msgstr ""
 
-#: src/strings.php:252
+#: src/strings.php:258
 msgid "Here you can see a list of the users that are currently logged-in."
 msgstr ""
 
-#: src/strings.php:253
+#: src/strings.php:259
 msgid "ID"
 msgstr ""
 
-#: src/strings.php:255
+#: src/strings.php:261
 msgid "Last Activity"
 msgstr ""
 
-#: src/strings.php:256
-#: src/strings.php:565
+#: src/strings.php:262
+#: src/strings.php:571
 msgid "Registered"
 msgstr ""
 
-#: src/strings.php:261
-#: src/strings.php:276
-#: src/strings.php:469
+#: src/strings.php:267
+#: src/strings.php:282
+#: src/strings.php:475
 msgid "Website:"
 msgstr ""
 
-#: src/strings.php:262
-#: src/strings.php:368
+#: src/strings.php:268
+#: src/strings.php:374
 msgid "IP Address:"
 msgstr ""
 
-#: src/strings.php:263
+#: src/strings.php:269
 msgid "Reverse IP:"
 msgstr ""
 
-#: src/strings.php:265
+#: src/strings.php:271
 msgid "Message:"
 msgstr ""
 
-#: src/strings.php:268
+#: src/strings.php:274
 msgid "An API key is required to activate some additional tools available in this plugin. The keys are free and you can virtually generate an unlimited number of them as long as the domain name and email address are unique. The key is used to authenticate the HTTP requests sent by the plugin to an API service managed by Sucuri Inc."
 msgstr ""
 
-#: src/strings.php:272
+#: src/strings.php:278
 msgid "If you experience issues generating the API key you can request one by sending the domain name and email address that you want to use to <a href=\"mailto:info@sucuri.net\">info@sucuri.net</a>. Note that generating a key for a website that is not facing the Internet is not possible because the API service needs to validate that the domain name exists."
 msgstr ""
 
-#: src/strings.php:277
-#: src/strings.php:345
+#: src/strings.php:283
+#: src/strings.php:351
 msgid "E-mail:"
 msgstr ""
 
-#: src/strings.php:278
+#: src/strings.php:284
 msgid "DNS Lookups"
 msgstr ""
 
-#: src/strings.php:279
+#: src/strings.php:285
 msgid "Check the box if your website is behind a known firewall service, this guarantees that the IP address of your visitors will be detected correctly for the security logs. You can change this later from the settings."
 msgstr ""
 
-#: src/strings.php:283
+#: src/strings.php:289
 msgid "Enable DNS Lookups On Startup"
 msgstr ""
 
-#: src/strings.php:284
+#: src/strings.php:290
 msgid "I agree to the <a target=\"_blank\" href=\"https://sucuri.net/terms\">Terms of Service</a>."
 msgstr ""
 
-#: src/strings.php:285
+#: src/strings.php:291
 msgid "I have read and understand the <a target=\"_blank\" href=\"https://sucuri.net/privacy\">Privacy Policy</a>."
 msgstr ""
 
-#: src/strings.php:292
+#: src/strings.php:298
 msgid "Password Guessing Brute Force Attacks"
 msgstr ""
 
-#: src/strings.php:293
+#: src/strings.php:299
 msgid "<a href=\"https://docs.sucuri.net/definitions/attacks/brute-force/password-guessing-brute-force-attacks/\" target=\"_blank\" rel=\"noopener\">Password guessing brute force attacks</a> are very common against web sites and web servers. They are one of the most common vectors used to compromise web sites. The process is very simple and the attackers basically try multiple combinations of usernames and passwords until they find one that works. Once they get in, they can compromise the web site with malware, spam , phishing or anything else they want."
 msgstr ""
 
-#: src/strings.php:297
+#: src/strings.php:303
 msgid "Consider Brute-Force Attack After:"
 msgstr ""
 
-#: src/strings.php:301
+#: src/strings.php:307
 msgid "Security Alerts"
 msgstr ""
 
-#: src/strings.php:302
+#: src/strings.php:308
 msgid "You have installed a plugin or theme that is not fully compatible with our plugin, some of the security alerts (like the successful and failed logins) will not be sent to you. To prevent an infinite loop while detecting these changes in the website and sending the email alerts via a custom SMTP plugin, we have decided to stop any attempt to send the emails to prevent fatal errors."
 msgstr ""
 
-#: src/strings.php:307
+#: src/strings.php:313
 msgid "Event"
 msgstr ""
 
-#: src/strings.php:311
+#: src/strings.php:317
 msgid "Post-Type Alerts"
 msgstr ""
 
-#: src/strings.php:312
+#: src/strings.php:318
 msgid "It seems that you disabled the email alerts for <b>new site content</b>, this panel is intended to provide a way to ignore specific events in your site and with that the alerts reported to your email. Since you have deactivated the <b>new site content</b> alerts, this panel will be disabled too."
 msgstr ""
 
-#: src/strings.php:316
+#: src/strings.php:322
 msgid "This is a list of registered <a href=\"https://codex.wordpress.org/Post_Types\" target=\"_blank\" rel=\"noopener\">Post Types</a>. You will receive an email alert when a custom page or post associated to any of these types is created or updated. If you don’t want to receive one or more of these alerts, feel free to uncheck the boxes in the table below. If you are receiving alerts for post types that are not listed in this table, it may be because there is an add-on that that is generating a custom post-type on runtime, you will have to find out by yourself what is the unique ID of that post-type and type it in the form below. The plugin will do its best to ignore these alerts as long as the unique ID is valid."
 msgstr ""
 
-#: src/strings.php:320
+#: src/strings.php:326
 msgid "Stop Alerts For This Post-Type:"
 msgstr ""
 
-#: src/strings.php:321
+#: src/strings.php:327
 msgid "e.g. unique_post_type_id"
 msgstr ""
 
-#: src/strings.php:323
+#: src/strings.php:329
 msgid "Show Post-Types Table"
 msgstr ""
 
-#: src/strings.php:324
+#: src/strings.php:330
 msgid "Hide Post-Types Table"
 msgstr ""
 
-#: src/strings.php:326
+#: src/strings.php:332
 msgid "Post Type"
 msgstr ""
 
-#: src/strings.php:327
+#: src/strings.php:333
 msgid "Post Type ID"
 msgstr ""
 
-#: src/strings.php:328
+#: src/strings.php:334
 msgid "Ignored At (optional)"
 msgstr ""
 
-#: src/strings.php:331
+#: src/strings.php:337
 msgid "Alerts Per Hour"
 msgstr ""
 
-#: src/strings.php:332
+#: src/strings.php:338
 msgid "Configure the maximum number of email alerts per hour. If the number is exceeded and the plugin detects more events during the same hour, it will still log the events into the audit logs but will not send the email alerts. Be careful with this as you will miss important information."
 msgstr ""
 
-#: src/strings.php:336
+#: src/strings.php:342
 msgid "Maximum Alerts Per Hour:"
 msgstr ""
 
-#: src/strings.php:340
+#: src/strings.php:346
 msgid "Alerts Recipient"
 msgstr ""
 
-#: src/strings.php:341
+#: src/strings.php:347
 msgid "By default, the plugin will send the email alerts to the primary admin account, the same account created during the installation of WordPress in your web server. You can add more people to the list, they will receive a copy of the same security alerts."
 msgstr ""
 
-#: src/strings.php:346
+#: src/strings.php:352
 msgid "e.g. user@example.com"
 msgstr ""
 
-#: src/strings.php:349
-#: src/strings.php:564
+#: src/strings.php:355
+#: src/strings.php:570
 msgid "E-mail"
 msgstr ""
 
-#: src/strings.php:351
+#: src/strings.php:357
 msgid "Test Alerts"
 msgstr ""
 
-#: src/strings.php:354
+#: src/strings.php:360
 msgid "Alert Subject"
 msgstr ""
 
-#: src/strings.php:355
+#: src/strings.php:361
 msgid "Format of the subject for the email alerts, by default the plugin will use the website name and the event identifier that is being reported, you can use this panel to include the IP address of the user that triggered the event and some additional data. You can create filters in your email client creating a custom email subject using the pseudo-tags shown below."
 msgstr ""
 
-#: src/strings.php:359
+#: src/strings.php:365
 msgid "Custom Format"
 msgstr ""
 
-#: src/strings.php:363
+#: src/strings.php:369
 msgid "Trusted IP Addresses"
 msgstr ""
 
-#: src/strings.php:364
+#: src/strings.php:370
 msgid "If you are working in a LAN <em>(Local Area Network)</em> you may want to include the IP addresses of all the nodes in the subnet, this will force the plugin to stop sending email alerts about actions executed from trusted IP addresses. Use the CIDR <em>(Classless Inter Domain Routing)</em> format to specify ranges of IP addresses <em>(only 8, 16, and 24)</em>."
 msgstr ""
 
-#: src/strings.php:369
+#: src/strings.php:375
 msgid "e.g. 182.120.56.0/24"
 msgstr ""
 
-#: src/strings.php:373
+#: src/strings.php:379
 msgid "CIDR Format"
 msgstr ""
 
-#: src/strings.php:374
+#: src/strings.php:380
 msgid "IP Added At"
 msgstr ""
 
-#: src/strings.php:379
+#: src/strings.php:385
 msgid "If this operation was successful you will receive a message in the email used during the registration of the API key <em>(usually the email of the main admin user)</em>. This message contains the key in plain text, copy and paste the key in the form field below. The plugin will verify the authenticity of the key sending an initial HTTP request to the API service, if this fails the key will be removed automatically and you will have to start the process all over again."
 msgstr ""
 
-#: src/strings.php:383
+#: src/strings.php:389
 msgid "There are cases where this operation may fail, an example would be when the email address is not associated with the domain anymore, this happens when the base URL changes <em>(from www to none or viceversa)</em>. If you are having issues recovering the key please send an email explaining the situation to <a href=\"mailto:info@sucuri.net\">info@sucuri.net</a>"
 msgstr ""
 
-#: src/strings.php:387
+#: src/strings.php:393
 msgid "API Key:"
 msgstr ""
 
-#: src/strings.php:391
+#: src/strings.php:397
 msgid "Congratulations! The rest of the features available in the plugin have been enabled. This product is designed to supplement existing security products. It’s not a silver bullet for your security needs, but it’ll give you greater security awareness and better posture, all with the intent of reducing risk."
 msgstr ""
 
-#: src/strings.php:395
+#: src/strings.php:401
 msgid "Your website has been granted a new API key and it was associated to the email address that you chose during the registration process. You can use the same email to recover the key if you happen to lose it sometime. We encourage you to check the rest of the settings page and configure the plugin to your own needs."
 msgstr ""
 
-#: src/strings.php:403
-#: src/strings.php:408
+#: src/strings.php:409
+#: src/strings.php:414
 msgid "WordPress Checksums API"
 msgstr ""
 
-#: src/strings.php:404
+#: src/strings.php:410
 msgid "The WordPress integrity tool uses a remote API service maintained by the WordPress organization to determine which files in the installation were added, removed or modified. The API returns a list of files with their respective checksums, this information guarantees that the installation is not corrupt. You can, however, point the integrity tool to a GitHub repository in case that you are using a custom version of WordPress like the <a href=\"https://github.com/WordPress/WordPress\" target=\"_blank\" rel=\"noopener\">development version of the code</a>."
 msgstr ""
 
-#: src/strings.php:409
+#: src/strings.php:415
 msgid "e.g. URL — or — user/repo"
 msgstr ""
 
-#: src/strings.php:413
+#: src/strings.php:419
 msgid "API Communication via Proxy"
 msgstr ""
 
-#: src/strings.php:414
+#: src/strings.php:420
 msgid "All the HTTP requests used to communicate with the API service are being sent using the WordPress built-in functions, so (almost) all its official features are inherited, this is useful if you need to pass these HTTP requests through a proxy. According to the <a href=\"https://developer.wordpress.org/reference/classes/wp_http_proxy/\" target=\"_blank\" rel=\"noopener\">official documentation</a> you have to add some constants to the main configuration file: <em>WP_PROXY_HOST, WP_PROXY_PORT, WP_PROXY_USERNAME, WP_PROXY_PASSWORD</em>."
 msgstr ""
 
-#: src/strings.php:418
+#: src/strings.php:424
 msgid "HTTP Proxy Hostname"
 msgstr ""
 
-#: src/strings.php:419
+#: src/strings.php:425
 msgid "HTTP Proxy Port num"
 msgstr ""
 
-#: src/strings.php:420
+#: src/strings.php:426
 msgid "HTTP Proxy Username"
 msgstr ""
 
-#: src/strings.php:421
+#: src/strings.php:427
 msgid "HTTP Proxy Password"
 msgstr ""
 
-#: src/strings.php:424
-#: src/strings.php:696
+#: src/strings.php:430
+#: src/strings.php:702
 msgid "API Service Communication"
 msgstr ""
 
-#: src/strings.php:425
+#: src/strings.php:431
 msgid "Once the API key is generate the plugin will communicate with a remote API service that will act as a safe data storage for the audit logs generated when the website triggers certain events that the plugin monitors. If the website is hacked the attacker will not have access to these logs and that way you can investigate what was modified <em>(for malware infaction)</em> and/or how the malicious person was able to gain access to the website."
 msgstr ""
 
-#: src/strings.php:429
+#: src/strings.php:435
 msgid "Disabling the API service communication will stop the event monitoring, consider to enable the <a href=\"%%SUCURI.URL.Settings%%#general\">Log Exporter</a> to keep the monitoring working while the HTTP requests are ignored, otherwise an attacker may execute an action that will not be registered in the security logs and you will not have a way to investigate the attack in the future."
 msgstr ""
 
-#: src/strings.php:433
+#: src/strings.php:439
 msgid "<strong>Are you a developer?</strong> You may be interested in our API. Feel free to use the URL shown below to access the latest 50 entries in your security log, change the value for the parameter <code>l=N</code> if you need more. Be aware that the API doesn’t provides an offset parameter, so if you have the intention to query specific sections of the log you will need to wrap the HTTP request around your own cache mechanism. We <strong>DO NOT</strong> take feature requests for the API, this is a semi-private service tailored for the specific needs of the plugin and not intended to be used by 3rd-party apps, we may change the behavior of each API endpoint without previous notice, use it at your own risk."
 msgstr ""
 
-#: src/strings.php:439
+#: src/strings.php:445
 msgid "Data Storage"
 msgstr ""
 
-#: src/strings.php:440
+#: src/strings.php:446
 msgid "This is the directory where the plugin will store the security logs, the list of files marked as fixed in the core integrity tool, the cache for the malware scanner and 3rd-party plugin metadata. The plugin requires write permissions in this directory as well as the files contained in it. If you prefer to keep these files in a non-public directory <em>(one level up the document root)</em> please define a constant in the <em>\"wp-config.php\"</em> file named <em>\"SUCURI_DATA_STORAGE\"</em> with the absolute path to the new directory."
 msgstr ""
 
-#: src/strings.php:452
+#: src/strings.php:458
 msgid "Import &amp; Export Settings"
 msgstr ""
 
-#: src/strings.php:453
+#: src/strings.php:459
 msgid "Copy the JSON-encoded data from the box below, go to your other websites and click the <em>\"Import\"</em> button in the settings page. The plugin will start using the same settings from this website. Notice that some options are omitted as they contain values specific to this website. To import the settings from another website into this one, replace the JSON-encoded data in the box below with the JSON-encoded data exported from the other website, then click the button <em>\"Import\"</em>. Notice that some options will not be imported to reduce the security risk of writing arbitrary data into the disk."
 msgstr ""
 
-#: src/strings.php:461
+#: src/strings.php:467
 msgid "IP Address Discoverer"
 msgstr ""
 
-#: src/strings.php:462
+#: src/strings.php:468
 msgid "IP address discoverer will use DNS lookups to automatically detect if the website is behind the <a href=\"https://sucuri.net/website-firewall/\" target=\"_blank\" rel=\"noopener\">Sucuri Firewall</a>, in which case it will modify the global server variable <em>Remote-Addr</em> to set the real IP of the website’s visitors. This check runs on every WordPress init action and that is why it may slow down your website as some hosting providers rely on slow DNS servers which makes the operation take more time than it should."
 msgstr ""
 
-#: src/strings.php:466
+#: src/strings.php:472
 msgid "HTTP Header:"
 msgstr ""
 
-#: src/strings.php:467
+#: src/strings.php:473
 msgid "Proceed"
 msgstr ""
 
-#: src/strings.php:468
+#: src/strings.php:474
 msgid "Sucuri Firewall"
 msgstr ""
 
-#: src/strings.php:470
+#: src/strings.php:476
 msgid "Top Level Domain:"
 msgstr ""
 
-#: src/strings.php:471
+#: src/strings.php:477
 msgid "Hostname:"
 msgstr ""
 
-#: src/strings.php:472
+#: src/strings.php:478
 msgid "IP Address (Hostname):"
 msgstr ""
 
-#: src/strings.php:473
+#: src/strings.php:479
 msgid "IP Address (Username):"
 msgstr ""
 
-#: src/strings.php:476
+#: src/strings.php:482
 msgid "Reset Security Logs, Hardening and Settings"
 msgstr ""
 
-#: src/strings.php:477
+#: src/strings.php:483
 msgid "This action will trigger the deactivation / uninstallation process of the plugin. All local security logs, hardening and settings will be deleted. Notice that the security logs stored in the API service will not be deleted, this is to prevent tampering from a malicious user. You can request a new API key if you want to start from scratch."
 msgstr ""
 
-#: src/strings.php:485
+#: src/strings.php:491
 msgid "Reverse Proxy"
 msgstr ""
 
-#: src/strings.php:486
+#: src/strings.php:492
 msgid "The event monitor uses the API address of the origin of the request to track the actions. The plugin uses two methods to retrieve this: the main method uses the global server variable <em>Remote-Addr</em> available in most modern web servers, and an alternative method uses custom HTTP headers <em>(which are unsafe by default)</em>. You should not worry about this option unless you know what a reverse proxy is. Services like the <a href=\"https://sucuri.net/website-firewall/\" target=\"_blank\" rel=\"noopener\">Sucuri Firewall</a> &mdash; once active &mdash; force the network traffic to pass through them to filter any security threat that may affect the original server. A side effect of this is that the real IP address is no longer available in the global server variable <em>Remote-Addr</em> but in a custom HTTP header with a name provided by the service."
 msgstr ""
 
-#: src/strings.php:492
+#: src/strings.php:498
 msgid "Log Exporter"
 msgstr ""
 
-#: src/strings.php:493
+#: src/strings.php:499
 msgid "This option allows you to export the WordPress audit logs to a local log file that can be read by a SIEM or any log analysis software <em>(we recommend OSSEC)</em>. That will give visibility from within WordPress to complement your log monitoring infrastructure. <b>NOTE:</b> Do not use a publicly accessible file, you must use a file at least one level up the document root to prevent leaks of information."
 msgstr ""
 
-#: src/strings.php:497
-#: src/strings.php:515
+#: src/strings.php:503
+#: src/strings.php:521
 msgid "File Path:"
 msgstr ""
 
-#: src/strings.php:501
+#: src/strings.php:507
 msgid "Timezone Override"
 msgstr ""
 
-#: src/strings.php:502
+#: src/strings.php:508
 msgid "This option defines the timezone that will be used through out the entire plugin to print the dates and times whenever is necessary. This option also affects the date and time of the logs visible in the audit logs panel which is data that comes from a remote server configured to use Eastern Daylight Time (EDT). WordPress offers an option in the general settings page to allow you to configure the timezone for the entire website, however, if you are experiencing problems with the time in the audit logs, this option will help you fix them."
 msgstr ""
 
-#: src/strings.php:506
+#: src/strings.php:512
 msgid "Timezone:"
 msgstr ""
 
-#: src/strings.php:510
+#: src/strings.php:516
 msgid "Allow Blocked PHP Files"
 msgstr ""
 
-#: src/strings.php:511
+#: src/strings.php:517
 msgid "After you apply the hardening in either the includes, content, and/or uploads directories, the plugin will add a rule in the access control file to deny access to any PHP file located in these folders. This is a good precaution in case an attacker is able to upload a shell script. With a few exceptions the <em>\"index.php\"</em> file is the only one that should be publicly accessible, however many theme/plugin developers decide to use these folders to process some operations. In this case applying the hardening <strong>may break</strong> their functionality."
 msgstr ""
 
-#: src/strings.php:519
+#: src/strings.php:525
 msgid "Directory"
 msgstr ""
 
-#: src/strings.php:520
+#: src/strings.php:526
 msgid "Pattern"
-msgstr ""
-
-#: src/strings.php:525
-#: src/strings.php:536
-msgid "WordPress has a big user base in the public Internet, which brings interest to attackers to find vulnerabilities in the code, 3rd-party extensions, and themes that other companies develop. You should keep every piece of code installed in your website updated to prevent attacks as soon as disclosed vulnerabilities are patched."
-msgstr ""
-
-#: src/strings.php:530
-#: src/strings.php:541
-#: src/strings.php:586
-msgid "Version"
 msgstr ""
 
 #: src/strings.php:531
 #: src/strings.php:542
-#: src/strings.php:775
+msgid "WordPress has a big user base in the public Internet, which brings interest to attackers to find vulnerabilities in the code, 3rd-party extensions, and themes that other companies develop. You should keep every piece of code installed in your website updated to prevent attacks as soon as disclosed vulnerabilities are patched."
+msgstr ""
+
+#: src/strings.php:536
+#: src/strings.php:547
+#: src/strings.php:592
+msgid "Version"
+msgstr ""
+
+#: src/strings.php:537
+#: src/strings.php:548
+#: src/strings.php:781
 msgid "Update"
 msgstr ""
 
-#: src/strings.php:532
-#: src/strings.php:543
+#: src/strings.php:538
+#: src/strings.php:549
 msgid "Tested With"
 msgstr ""
 
-#: src/strings.php:535
+#: src/strings.php:541
 msgid "Available Plugin and Theme Updates"
 msgstr ""
 
-#: src/strings.php:547
+#: src/strings.php:553
 msgid "Download"
 msgstr ""
 
-#: src/strings.php:550
+#: src/strings.php:556
 msgid "WordPress has invalidated the password for your account <b>%%SUCURI.ResetPassword.UserName%%</b> at <a target=\"_blank\" href=\"http://%%SUCURI.ResetPassword.Website%%\" rel=\"noopener\">%%SUCURI.ResetPassword.Website%%</a>. The change has been requested by one of the admins in this website for security reasons. You can set a new password at &mdash; <span style=\"font-family:Menlo, Monaco, monospace, serif;font-weight:700\"><a target=\"_blank\" href=\"%%%SUCURI.ResetPassword.ResetURL%%%\" rel=\"noopener\">%%%SUCURI.ResetPassword.ResetURL%%%</a></span> &mdash;."
 msgstr ""
 
-#: src/strings.php:556
+#: src/strings.php:562
 msgid "Reset User Password"
 msgstr ""
 
-#: src/strings.php:558
+#: src/strings.php:564
 msgid "Select users from the list in order to change their passwords, terminate their sessions and email them a password reset link. Please be aware that the plugin will change the passwords before sending the emails, meaning that if your web server is unable to send emails, your users will be locked out of the site."
 msgstr ""
 
-#: src/strings.php:566
+#: src/strings.php:572
 msgid "Roles"
 msgstr ""
 
-#: src/strings.php:570
+#: src/strings.php:576
 msgid "Reset Installed Plugins"
 msgstr ""
 
-#: src/strings.php:572
+#: src/strings.php:578
 msgid "In case you suspect having an infection in your site, or after you got rid of a malicious code, it’s recommended to reinstall all the plugins installed in your site, including the ones you are not using. Notice that premium plugins will not be automatically reinstalled to prevent backward compatibility issues and problems with licenses."
 msgstr ""
 
-#: src/strings.php:576
+#: src/strings.php:582
 msgid "The information shown here is cached for %%SUCURI.ResetPlugin.CacheLifeTime%% seconds. This is necessary to reduce the quantity of HTTP requests sent to the WordPress servers and the bandwidth of your site. Currently there is no option to recreate this cache."
 msgstr ""
 
-#: src/strings.php:580
+#: src/strings.php:586
 msgid "<b>WARNING!</b> This procedure can break your website. The reset will not affect the database nor the settings of each plugin, but depending on how they were written the reset action might break them. Be sure to create a backup of the plugins directory before the execution of this tool."
 msgstr ""
 
-#: src/strings.php:587
+#: src/strings.php:593
 msgid "Type"
 msgstr ""
 
-#: src/strings.php:592
+#: src/strings.php:598
 msgid "Update Secret Keys"
 msgstr ""
 
-#: src/strings.php:593
+#: src/strings.php:599
 msgid "The secret or security keys are a list of constants added to your site to ensure better encryption of information stored in the user’s cookies. A secret key makes your site harder to hack by adding random elements to the password. You do not have to remember the keys, just write a random, complicated, and long string in the <code>wp-config.php</code> file. You can change these keys at any point in time. Changing them will invalidate all existing cookies, forcing all logged in users to login again."
 msgstr ""
 
-#: src/strings.php:597
+#: src/strings.php:603
 msgid "Your current session will expire once the form is submitted."
 msgstr ""
 
-#: src/strings.php:602
+#: src/strings.php:608
 msgid "Generate New Security Keys"
 msgstr ""
 
-#: src/strings.php:603
+#: src/strings.php:609
 msgid "Automatic Secret Keys Updater"
 msgstr ""
 
-#: src/strings.php:604
+#: src/strings.php:610
 msgid "Changing the Secret Keys frequently will decrease the chances of misuse of sessions left open on unprotected devices."
 msgstr ""
 
-#: src/strings.php:608
+#: src/strings.php:614
 msgid "Frequency:"
 msgstr ""
 
-#: src/strings.php:612
+#: src/strings.php:618
 msgid "Scheduled Tasks"
 msgstr ""
 
-#: src/strings.php:613
+#: src/strings.php:619
 msgid "The plugin scans your entire website looking for changes which are later reported via the API in the audit logs page. By default the scanner runs daily but you can change the frequency to meet your requirements. Notice that scanning your project files too frequently may affect the performance of your website. Be sure to have enough server resources before changing this option. The memory limit and maximum execution time are two of the PHP options that your server will set to stop your website from consuming too much resources."
 msgstr ""
 
-#: src/strings.php:617
+#: src/strings.php:623
 msgid "The scanner uses the <a href=\"http://php.net/manual/en/class.splfileobject.php\" target=\"_blank\" rel=\"noopener\">PHP SPL library</a> and the <a target=\"_blank\" href=\"http://php.net/manual/en/class.filesystemiterator.php\" rel=\"noopener\">Filesystem Iterator</a> class to scan the directory tree where your website is located in the server. This library is only available on PHP 5 >= 5.3.0 &mdash; OR &mdash; PHP 7; if you have an older version of PHP the plugin will not work as expected. Please ask your hosting provider to advise you on this matter."
 msgstr ""
 
-#: src/strings.php:621
+#: src/strings.php:627
 msgid "Scheduled tasks are rules registered in your database by a plugin, theme, or the base system itself; they are used to automatically execute actions defined in the code every certain amount of time. A good use of these rules is to generate backup files of your site, execute a security scanner, or remove unused elements like drafts. <b>Note:</b> Scheduled tasks can be re-installed by any plugin/theme automatically."
 msgstr ""
 
-#: src/strings.php:627
+#: src/strings.php:633
 msgid "Schedule"
 msgstr ""
 
-#: src/strings.php:628
+#: src/strings.php:634
 msgid "Next Due"
 msgstr ""
 
-#: src/strings.php:629
+#: src/strings.php:635
 msgid "Arguments"
 msgstr ""
 
-#: src/strings.php:635
+#: src/strings.php:641
 msgid "Ignore Files And Folders During The Scans"
 msgstr ""
 
-#: src/strings.php:636
+#: src/strings.php:642
 msgid "Use this tool to select the files and/or folders that are too heavy for the scanner to process. These are usually folders with images, media files like videos and audios, backups and &mdash; in general &mdash; anything that is not code-related. Ignoring these files or folders will reduce the memory consumption of the PHP script."
 msgstr ""
 
-#: src/strings.php:640
+#: src/strings.php:646
 msgid "Ignore a file or directory:"
 msgstr ""
 
-#: src/strings.php:641
+#: src/strings.php:647
 msgid "e.g. /private/directory/"
 msgstr ""
 
-#: src/strings.php:646
+#: src/strings.php:652
 msgid "Unignore Selected Directories"
 msgstr ""
 
-#: src/strings.php:649
+#: src/strings.php:655
 msgid "WordPress Integrity (False Positives)"
 msgstr ""
 
-#: src/strings.php:650
+#: src/strings.php:656
 msgid "Since the scanner doesn’t read the files during the execution of the integrity check, it is possible to find false positives. Files listed here have been marked as false positives and will be ignored by the scanner in subsequent scans."
 msgstr ""
 
-#: src/strings.php:655
+#: src/strings.php:661
 msgid "Reason"
 msgstr ""
 
-#: src/strings.php:656
+#: src/strings.php:662
 msgid "Ignored At"
 msgstr ""
 
-#: src/strings.php:659
+#: src/strings.php:665
 msgid "Stop Ignoring the Selected Files"
 msgstr ""
 
-#: src/strings.php:663
+#: src/strings.php:669
 msgid "If your server allows the execution of system commands, you can configure the plugin to use the <a href=\"https://en.wikipedia.org/wiki/Diff_utility\" target=\"_blank\" rel=\"noopener\">Unix Diff Utility</a> to compare the actual content of the file installed in the website and the original file provided by WordPress. This will show the differences between both files and then you can act upon the information provided."
 msgstr ""
 
-#: src/strings.php:670
+#: src/strings.php:676
 msgid "Environment Variables"
 msgstr ""
 
-#: src/strings.php:673
+#: src/strings.php:679
 msgid "Access File Integrity"
 msgstr ""
 
-#: src/strings.php:674
+#: src/strings.php:680
 msgid "The <code>.htaccess</code> file is a distributed configuration file, and is how the Apache web server handles configuration changes on a per-directory basis. WordPress uses this file to manipulate how Apache serves files from its root directory and subdirectories thereof; most notably, it modifies this file to be able to handle pretty permalinks."
 msgstr ""
 
-#: src/strings.php:678
+#: src/strings.php:684
 msgid "Htaccess file found in"
 msgstr ""
 
-#: src/strings.php:679
+#: src/strings.php:685
 msgid "Your website has no <code>.htaccess</code> file or it was not found in the default location."
 msgstr ""
 
-#: src/strings.php:683
+#: src/strings.php:689
 msgid "Your web server does not support .htaccess files."
 msgstr ""
 
-#: src/strings.php:684
+#: src/strings.php:690
 msgid "The main <code>.htaccess</code> file in your site has the standard rules for a WordPress installation. You can customize it to improve the performance and change the behaviour of the redirections for pages and posts in your site. To get more information visit the official documentation at <a target=\"_blank\" rel=\"noopener\" href=\"https://codex.wordpress.org/Using_Permalinks#Creating_and_editing_.28.htaccess.29\"> Codex WordPress - Creating and editing (.htaccess)</a>"
 msgstr ""
 
-#: src/strings.php:688
+#: src/strings.php:694
 msgid "Codex WordPress HTAccess"
 msgstr ""
 
-#: src/strings.php:691
+#: src/strings.php:697
 msgid "General Settings"
 msgstr ""
 
-#: src/strings.php:692
+#: src/strings.php:698
 msgid "Scanner"
 msgstr ""
 
-#: src/strings.php:693
+#: src/strings.php:699
 msgid "Hardening"
 msgstr ""
 
-#: src/strings.php:694
+#: src/strings.php:700
 msgid "Post-Hack"
 msgstr ""
 
-#: src/strings.php:695
+#: src/strings.php:701
 msgid "Alerts"
 msgstr ""
 
-#: src/strings.php:697
+#: src/strings.php:703
 msgid "Website Info"
 msgstr ""
 
-#: src/strings.php:698
+#: src/strings.php:704
 msgid "Hardening Options"
 msgstr ""
 
-#: src/strings.php:701
+#: src/strings.php:707
 msgid "This information will be updated %%SUCURI.SiteCheck.Lifetime%%"
 msgstr ""
 
-#: src/strings.php:702
+#: src/strings.php:708
 msgid "Refresh Malware Scan"
 msgstr ""
 
-#: src/strings.php:705
+#: src/strings.php:711
 msgid "Request Malware Cleanup"
 msgstr ""
 
-#: src/strings.php:706
+#: src/strings.php:712
 msgid "No malicious JavaScript"
 msgstr ""
 
-#: src/strings.php:707
+#: src/strings.php:713
 msgid "No malicious iFrames"
 msgstr ""
 
-#: src/strings.php:708
+#: src/strings.php:714
 msgid "No suspicious redirections"
 msgstr ""
 
-#: src/strings.php:709
+#: src/strings.php:715
 msgid "No blackhat SEO spam"
 msgstr ""
 
-#: src/strings.php:710
+#: src/strings.php:716
 msgid "No anomaly detection"
 msgstr ""
 
-#: src/strings.php:711
+#: src/strings.php:717
 msgid "This is a free website security scanner. Some types of malware and security issues cannot be detected by this scanner. If no issues are detected but you suspect a problem still exists, <a href=\"https://sucuri.net/website-security-platform/signup/\" target=\"_blank\" rel=\"noopener\">sign up</a> for a complete and in depth website scan with malware cleanup."
 msgstr ""
 
-#: src/strings.php:715
+#: src/strings.php:721
 msgid "The Sucuri Security Plugin&apos;s automated scanner has detected malware in your WordPress environment."
 msgstr ""
 
-#: src/strings.php:719
+#: src/strings.php:725
 msgid "Log in to the <a href=\"https://dashboard.sucuri.net/login\" target=\"_blank\" rel=\"noopener\">Sucuri Platform</a> dashboard for a complete scan of your website files and guaranteed malware removal. You can <a href=\"https://sucuri.net/website-security-platform/signup/\" target=\"_blank\" rel=\"noopener\">sign up here</a> if you don&apos;t have an account yet."
 msgstr ""
 
-#: src/strings.php:725
+#: src/strings.php:731
 msgid "Hover to see the Payload"
 msgstr ""
 
-#: src/strings.php:728
+#: src/strings.php:734
 msgid "Recommendations"
 msgstr ""
 
-#: src/strings.php:731
-#: src/strings.php:736
+#: src/strings.php:737
+#: src/strings.php:742
 msgid "Malware Scan Target"
 msgstr ""
 
-#: src/strings.php:732
+#: src/strings.php:738
 msgid "The remote malware scanner provided by the plugin is powered by <a href=\"https://sitecheck.sucuri.net/\" target=\"_blank\" rel=\"noopener\">Sucuri SiteCheck</a>, a service that takes a publicly accessible URL and scans it for malicious code. If your website is not visible to the Internet, for example, if it is hosted in a local development environment or a restricted network, the scanner will not be able to work on it. Additionally, if the website was installed in a non-standard directory the scanner will report a \"404 Not Found\" error. You can use this option to change the URL that will be scanned."
 msgstr ""
 
-#: src/strings.php:737
+#: src/strings.php:743
 msgid "Malware Scan Target:"
 msgstr ""
 
-#: src/strings.php:741
+#: src/strings.php:747
 msgid "WordPress Security Recommendations"
 msgstr ""
 
-#: src/strings.php:744
+#: src/strings.php:750
 msgid "The max-age setting tells your browser how long, in seconds, it can keep a copy of a web page before it needs to check for a new version. This is the basic setting needed to make caching work on most devices."
 msgstr ""
 
-#: src/strings.php:748
+#: src/strings.php:754
 msgid "The s-maxage setting tells shared caches, like those used by multiple visitors or devices (such as CDNs or web accelerators), how long they can keep a copy of a web page. It allows you to control how often these shared caches update their content compared to private caches."
 msgstr ""
 
-#: src/strings.php:752
+#: src/strings.php:758
 msgid "The stale-if-error setting allows a cached page to be served even after it has expired if the original web server returns an error. This helps keep your website available by showing an older version of the page instead of an error message. You need to set a private or shared cache duration to use this option, and it can be set for hours or days."
 msgstr ""
 
-#: src/strings.php:756
+#: src/strings.php:762
 msgid "The stale-while-revalidate setting lets shared caches serve an old version of a web page while they update the cached copy in the background. This improves loading times because visitors don’t have to wait for the updated content. Like stale-if-error, it requires a private or shared cache duration, and can be used together with stale-if-error. This setting is useful for ensuring quick page loads while keeping content reasonably fresh."
 msgstr ""
 
-#: src/strings.php:760
+#: src/strings.php:766
 msgid "When this option is set, older pages will be cached for longer than newer pages (determined by page number). The configured pagination factor is added to the main maxage and s-maxage options. This allows less popular archives to be served as stale for longer."
 msgstr ""
 
-#: src/strings.php:764
+#: src/strings.php:770
 msgid "When this option is set, the max-age and s-maxage values will be multiplied by the number of years since the last edit or comment (the Last Modified time). This allows posts that were published a long time ago to be cached longer than newer posts."
 msgstr ""
 
-#: src/strings.php:768
+#: src/strings.php:774
 msgid "Here you can see all the cache options available."
 msgstr ""
 
-#: src/strings.php:769
+#: src/strings.php:775
 msgid "Option"
 msgstr ""
 
-#: src/strings.php:770
+#: src/strings.php:776
 msgid "No options available"
 msgstr ""
 
-#: src/strings.php:771
+#: src/strings.php:777
 msgid "Cache Control Header"
 msgstr ""
 
-#: src/strings.php:774
-#: src/strings.php:815
+#: src/strings.php:780
+#: src/strings.php:821
 msgid "Mode:"
 msgstr ""
 
-#: src/strings.php:777
+#: src/strings.php:783
 msgid "Please enable site caching on your WAF to use these settings. If you are a Sucuri client and require assistance, please <a href=\"https://docs.sucuri.net/billing/how-do-i-open-a-general-support-ticket/\" target=\"_blank\" rel=\"noopener\">{{create a ticket}}</a> and reach out to the firewall team for support."
 msgstr ""
 
-#: src/strings.php:786
+#: src/strings.php:792
 msgid "CORS Options"
 msgstr ""
 
-#: src/strings.php:787
-#: src/strings.php:795
+#: src/strings.php:793
+#: src/strings.php:801
 msgid "Cross-Origin Resource Sharing (CORS) is a security feature that allows web applications to control the resources that can be requested from another domain."
 msgstr ""
 
-#: src/strings.php:791
+#: src/strings.php:797
 msgid "Here you can see all the CORS options available."
 msgstr ""
 
-#: src/strings.php:792
+#: src/strings.php:798
 msgid "Header"
 msgstr ""
 
-#: src/strings.php:793
+#: src/strings.php:799
 msgid "Header Value"
 msgstr ""
 
-#: src/strings.php:794
+#: src/strings.php:800
 msgid "CORS"
 msgstr ""
 
-#: src/strings.php:802
+#: src/strings.php:808
 msgid "Content Security Policy (CSP) Options"
 msgstr ""
 
-#: src/strings.php:803
-#: src/strings.php:811
+#: src/strings.php:809
+#: src/strings.php:817
 msgid "Content Security Policy (CSP) is a security feature that helps prevent various types of attacks, such as Cross-Site Scripting (XSS) and data injection attacks."
 msgstr ""
 
-#: src/strings.php:807
+#: src/strings.php:813
 msgid "Here you can see all the CSP options available."
 msgstr ""
 
-#: src/strings.php:808
+#: src/strings.php:814
 msgid "Directive"
 msgstr ""
 
-#: src/strings.php:809
+#: src/strings.php:815
 msgid "Directive Value"
 msgstr ""
 
-#: src/strings.php:810
+#: src/strings.php:816
 msgid "Content Security Policy"
 msgstr ""
 
-#: src/strings.php:820
+#: src/strings.php:826
 msgid "Two-factor authentication is not activated."
 msgstr ""
 
-#: src/strings.php:821
+#: src/strings.php:827
 msgid "Please scan the QR, or input the key manually in your preferred 2FA app, and verify to activate it."
 msgstr ""
 
-#: src/strings.php:822
+#: src/strings.php:828
 msgid "Please keep in mind that activating this option for all users will block them from being able to log-in until they activate their two-factor authentication. Each user will be prompted to activate upon their next login attempt."
 msgstr ""
 
-#: src/strings.php:823
+#: src/strings.php:829
 msgid "Open your authenticator app on your phone."
 msgstr ""
 
-#: src/strings.php:824
+#: src/strings.php:830
 msgid "Scan the QR code on the screen (or enter the key manually)."
 msgstr ""
 
-#: src/strings.php:825
+#: src/strings.php:831
 msgid "Enter the 6-digit code generated by the app."
 msgstr ""
 
-#: src/strings.php:826
+#: src/strings.php:832
 msgid "Click \"Setup\" to activate."
 msgstr ""
 
-#: src/strings.php:827
+#: src/strings.php:833
 #: src/topt.lib.php:1330
 msgid "Two-Factor Authentication is enabled for your account."
 msgstr ""
 
-#: src/strings.php:828
+#: src/strings.php:834
 msgid "Enforce two-factor for all users"
 msgstr ""
 
-#: src/strings.php:829
+#: src/strings.php:835
 msgid "Setup"
 msgstr ""
 
-#: src/strings.php:832
+#: src/strings.php:838
 #: src/topt.lib.php:1290
 msgid "Two-Factor Authentication is already enabled for your account."
 msgstr ""

--- a/src/api.lib.php
+++ b/src/api.lib.php
@@ -1035,13 +1035,15 @@ class SucuriScanAPI extends SucuriScanOption
 
             $log_data = self::getLogsHotfix($log_data);
 
-            if (strpos($log_data['message'], ";\x20password:") !== false) {
-                $log_data['message'] = substr(
-                    $log_data['message'],
-                    0,
-                    strpos($log_data['message'], ";\x20password:")
-                );
-            }
+            /**
+             * Redacted again on the way out, not only on the way in: records
+             * written by plugin versions that predate the redaction are still
+             * sitting in the queue, and they are displayed and exported by this
+             * same method. Redacting before the filters run also keeps a
+             * credential from being searchable.
+             */
+            $log_data['message'] = SucuriScanEvent::redactSensitiveData($log_data['message']);
+            $log_data['file_list'] = SucuriScanEvent::redactSensitiveData($log_data['file_list']);
 
             // Based on filters, evaluate if should skip.
             if (self::filterAuditLog($log_data, $filters) === false) {

--- a/src/api.lib.php
+++ b/src/api.lib.php
@@ -274,8 +274,13 @@ class SucuriScanAPI extends SucuriScanOption
             return true;
         }
 
+        /**
+         * Every message below is built from a remote response and ends up in
+         * an admin notice that renders raw HTML, so it is escaped here rather
+         * than trusted to arrive clean.
+         */
         if (is_string($res) && !empty($res)) {
-            return SucuriScanInterface::error($res);
+            return SucuriScanInterface::error(esc_html($res));
         }
 
         if (!is_array($res)
@@ -306,7 +311,7 @@ class SucuriScanAPI extends SucuriScanOption
             SucuriScanOption::setRevProxy('disable', true);
             SucuriScanOption::setAddrHeader('REMOTE_ADDR', true);
 
-            return SucuriScanInterface::error($msg);
+            return SucuriScanInterface::error(esc_html($msg));
         }
 
         // Stop SSL peer verification on connection failures.
@@ -325,7 +330,7 @@ class SucuriScanAPI extends SucuriScanOption
             $msg = __('Invalid email format or the host is missing MX records.', 'sucuri-scanner');
         }
 
-        return SucuriScanInterface::error($msg);
+        return SucuriScanInterface::error(esc_html($msg));
     }
 
     /**

--- a/src/api.lib.php
+++ b/src/api.lib.php
@@ -754,7 +754,17 @@ class SucuriScanAPI extends SucuriScanOption
                 implode("\x20", (array) $log['file_list']),
             );
 
-            if (stripos(implode("\x20", $searchable), $frontend_filters['search']) === false) {
+            /**
+             * The haystack is decoded, not the needle. Hooks store names
+             * through SucuriScan::escape(), so a plugin called "R&D Tools" is
+             * on disk as "R&amp;D Tools"; the search term arrives decoded, and
+             * comparing the two raw would never match. Decoding here keeps the
+             * stored term escaped for the filter input and the pagination
+             * links, which escape it again on their way back out.
+             */
+            $haystack = html_entity_decode(implode("\x20", $searchable), ENT_QUOTES, 'UTF-8');
+
+            if (stripos($haystack, $frontend_filters['search']) === false) {
                 return false;
             }
         }

--- a/src/api.lib.php
+++ b/src/api.lib.php
@@ -484,6 +484,21 @@ class SucuriScanAPI extends SucuriScanOption
     }
 
     /**
+     * Apply audit-log filters to an existing API response.
+     *
+     * Keeping the raw response in the cache allows every filter and search to
+     * operate on the same set of logs instead of caching one filtered result.
+     *
+     * @param array $res     Parsed or raw API response containing output logs.
+     * @param array $filters Filters to apply to the logs.
+     * @return array|null Filtered audit-log response.
+     */
+    public static function filterAuditLogs($res, $filters = array())
+    {
+        return self::parseAuditLogs($res, $filters);
+    }
+
+    /**
      * Retrieves the available filters for the audit logs.
      *
      * @return array An associative array containing the filters for the auditlogs.
@@ -628,6 +643,36 @@ class SucuriScanAPI extends SucuriScanOption
                     'label' => __('Deactivated', 'sucuri-scanner'),
                     'value' => 'Plugin deactivated',
                 ),
+                'updated' => array(
+                    'label' => __('Updated', 'sucuri-scanner'),
+                    'value' => 'Plugin updated',
+                ),
+                'deleted' => array(
+                    'label' => __('Deleted', 'sucuri-scanner'),
+                    'value' => 'Plugin deleted',
+                ),
+            ),
+            'themes' => array(
+                'all themes' => array(
+                    'label' => __('All Themes', 'sucuri-scanner'),
+                    'value' => '',
+                ),
+                'installed' => array(
+                    'label' => __('Installed', 'sucuri-scanner'),
+                    'value' => 'Theme installed',
+                ),
+                'activated' => array(
+                    'label' => __('Activated', 'sucuri-scanner'),
+                    'value' => 'Theme activated',
+                ),
+                'updated' => array(
+                    'label' => __('Updated', 'sucuri-scanner'),
+                    'value' => 'Theme updated',
+                ),
+                'deleted' => array(
+                    'label' => __('Deleted', 'sucuri-scanner'),
+                    'value' => 'Theme deleted',
+                ),
             ),
             'files' => array(
                 'all files' => array(
@@ -637,6 +682,36 @@ class SucuriScanAPI extends SucuriScanOption
                 'added' => array(
                     'label' => __('Added', 'sucuri-scanner'),
                     'value' => 'Media file added',
+                ),
+            ),
+            'events' => array(
+                'all events' => array(
+                    'label' => __('All Severities', 'sucuri-scanner'),
+                    'value' => '',
+                ),
+                'critical' => array(
+                    'label' => __('Critical', 'sucuri-scanner'),
+                    'value' => 'critical',
+                ),
+                'error' => array(
+                    'label' => __('Error', 'sucuri-scanner'),
+                    'value' => 'error',
+                ),
+                'warning' => array(
+                    'label' => __('Warning', 'sucuri-scanner'),
+                    'value' => 'warning',
+                ),
+                'notice' => array(
+                    'label' => __('Notice', 'sucuri-scanner'),
+                    'value' => 'notice',
+                ),
+                'info' => array(
+                    'label' => __('Info', 'sucuri-scanner'),
+                    'value' => 'info',
+                ),
+                'debug' => array(
+                    'label' => __('Debug', 'sucuri-scanner'),
+                    'value' => 'debug',
                 ),
             ),
         );
@@ -663,31 +738,62 @@ class SucuriScanAPI extends SucuriScanOption
             }
         }
 
+        if (isset($frontend_filters['search']) && $frontend_filters['search'] !== '') {
+            $searchable = array(
+                $log['event'],
+                $log['datetime'],
+                $log['account'],
+                $log['username'],
+                $log['remote_addr'],
+                $log['message'],
+                implode("\x20", (array) $log['file_list']),
+            );
+
+            if (stripos(implode("\x20", $searchable), $frontend_filters['search']) === false) {
+                return false;
+            }
+        }
+
+        if (isset($frontend_filters['events'])) {
+            $event_filter = $frontend_filters['events'];
+
+            if (!isset($filters['events'][$event_filter])
+                || $log['event'] !== $filters['events'][$event_filter]['value']
+            ) {
+                return false;
+            }
+        }
+
         $other_filters = $frontend_filters;
-        unset($other_filters['time'], $other_filters['startDate'], $other_filters['endDate']);
+        unset(
+            $other_filters['time'],
+            $other_filters['startDate'],
+            $other_filters['endDate'],
+            $other_filters['search'],
+            $other_filters['events']
+        );
 
         if (empty($other_filters)) {
             return true;
         }
 
-        // Check if the log matches any of the other filters
+        // Activity categories use OR semantics so users can combine event types.
         foreach ($other_filters as $active_filter => $value_filter) {
             if (isset($filters[$active_filter][$value_filter])) {
                 $search_term = $filters[$active_filter][$value_filter]['value'];
 
-                $match = false;
-
                 if (is_array($search_term)) {
                     foreach ($search_term as $term) {
                         if (strpos($log['message'], $term) !== false) {
-                            $match = true;
+                            return true;
                         }
                     }
-
-                    return $match;
                 }
 
-                if (strpos($log['message'], $search_term) !== false) {
+                if (is_string($search_term)
+                    && $search_term !== ''
+                    && strpos($log['message'], $search_term) !== false
+                ) {
                     return true;
                 }
             }
@@ -913,6 +1019,14 @@ class SucuriScanAPI extends SucuriScanOption
             }
 
             $log_data = self::getLogsHotfix($log_data);
+
+            if (strpos($log_data['message'], ";\x20password:") !== false) {
+                $log_data['message'] = substr(
+                    $log_data['message'],
+                    0,
+                    strpos($log_data['message'], ";\x20password:")
+                );
+            }
 
             // Based on filters, evaluate if should skip.
             if (self::filterAuditLog($log_data, $filters) === false) {

--- a/src/auditlogs.lib.php
+++ b/src/auditlogs.lib.php
@@ -51,6 +51,11 @@ class SucuriScanAuditLogs
          * The export is a plain link, so the nonce travels in the href. The
          * template renders this through the escaped "%%...%%" tag, which turns
          * the query separators into "&amp;" as an HTML attribute requires.
+         *
+         * admin_url() on purpose, rather than the SucuriScan::adminURL() helper
+         * the rest of the plugin uses: that helper switches to
+         * network_admin_url() on multisite, and WordPress ships no
+         * wp-admin/network/admin-post.php for the link to point at.
          */
         $params['AuditLogs.DownloadURL'] = add_query_arg(
             array(
@@ -408,15 +413,24 @@ class SucuriScanAuditLogs
             );
         }
 
+        /**
+         * Built before a single header goes out. Reading the queue is the
+         * expensive part of the export, and a failure there once the download
+         * headers were already on the wire reached the browser as a complete
+         * but silently truncated CSV; now it surfaces as an ordinary error page
+         * and no file is saved.
+         */
+        $csv = self::getAuditLogsCsv();
         $filename = 'sucuri-audit-trails-' . SucuriScan::datetime(null, 'Y-m-d') . '.csv';
 
         nocache_headers();
         header('Content-Type: text/csv; charset=utf-8');
         header('Content-Disposition: attachment; filename="' . $filename . '"');
         header('X-Content-Type-Options: nosniff');
+        header('Content-Length: ' . strlen($csv));
 
         // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        echo self::getAuditLogsCsv();
+        echo $csv;
 
         exit(0);
     }
@@ -440,6 +454,13 @@ class SucuriScanAuditLogs
      * block is already discarded by SucuriScanCache while it parses the
      * datastore, so only real records reach the export.
      *
+     * The whole queue is held in memory while the CSV is assembled, which is
+     * what reusing the audit page's parser buys in simplicity. Peak usage runs
+     * to roughly twenty times the size of the queue file, so the practical
+     * ceiling is a queue of a few megabytes against the 256M that WordPress
+     * raises the admin memory limit to. Past that the export fails, visibly,
+     * before any download headers are sent.
+     *
      * @return string CSV content.
      */
     private static function getAuditLogsCsv()
@@ -448,6 +469,9 @@ class SucuriScanAuditLogs
         $logs = (is_array($auditlogs) && isset($auditlogs['output_data']))
             ? (array) $auditlogs['output_data']
             : array();
+
+        /* the raw log strings are a second full copy of the queue */
+        unset($auditlogs);
 
         usort($logs, array('SucuriScanAuditLogs', 'sortByDate'));
 

--- a/src/auditlogs.lib.php
+++ b/src/auditlogs.lib.php
@@ -467,7 +467,14 @@ class SucuriScanAuditLogs
      * to roughly twenty times the size of the queue file, so the practical
      * ceiling is a queue of a few megabytes against the 256M that WordPress
      * raises the admin memory limit to. Past that the export fails, visibly,
-     * before any download headers are sent.
+     * before any download headers are sent. Reading the queue costs about what
+     * one load of the audit trail page costs, since that page parses the same
+     * queue in full on every request.
+     *
+     * A record the parser rejects -- a line whose JSON does not decode, which
+     * an interrupted append can leave behind -- is skipped here exactly as it
+     * is skipped on the page. Deliberate: the export shows what the audit trail
+     * shows, rather than growing a second reader that disagrees with it.
      *
      * @return string CSV content.
      */

--- a/src/auditlogs.lib.php
+++ b/src/auditlogs.lib.php
@@ -72,8 +72,11 @@ class SucuriScanAuditLogs
 
             if ($filter === 'startDate' || $filter === 'endDate') {
                 $date = isset($frontend_filter[$filter]) ? $frontend_filter[$filter] : '';
+                $label = ($filter === 'startDate')
+                    ? __('Start Date', 'sucuri-scanner')
+                    : __('End Date', 'sucuri-scanner');
 
-                $filters_snippet .= '<input type="date" id="' . esc_attr($filter) . '" name="' . esc_attr($filter . 'Filter') . '" value="' . esc_attr($date) . '">';
+                $filters_snippet .= '<input type="date" id="' . esc_attr($filter) . '" name="' . esc_attr($filter . 'Filter') . '" value="' . esc_attr($date) . '" aria-label="' . esc_attr($label) . '" title="' . esc_attr($label) . '">';
                 continue;
             }
 
@@ -87,6 +90,7 @@ class SucuriScanAuditLogs
 
             $option_data = array(
                 'AuditLog.FilterName' => esc_attr($filter),
+                'AuditLog.FilterLabel' => esc_attr(ucwords($filter)),
                 'AuditLog.FilterOptions' => $filter_options,
             );
 
@@ -95,9 +99,131 @@ class SucuriScanAuditLogs
 
         $filters_data = array(
             'AuditLog.Filters' => $filters_snippet,
+            'AuditLog.Search' => isset($frontend_filter['search']) ? esc_attr($frontend_filter['search']) : '',
         );
 
         return SucuriScanTemplate::getSnippet('auditlogs-filters', $filters_data);
+    }
+
+    /**
+     * Get and validate filters supplied by the audit-log interface.
+     *
+     * @return array Valid audit-log filters.
+     */
+    private static function getRequestFilters()
+    {
+        $filters = array();
+        $available = SucuriScanAPI::getFilters();
+
+        foreach (array('time', 'posts', 'logins', 'users', 'plugins', 'themes', 'files', 'events') as $key) {
+            $value = SucuriScanRequest::get($key);
+
+            if ($value
+                && strpos($value, 'all ') !== 0
+                && isset($available[$key][$value])
+            ) {
+                $filters[$key] = $value;
+            }
+        }
+
+        if (isset($filters['time']) && $filters['time'] === 'custom') {
+            $start_date = SucuriScanRequest::get('startDate', '[0-9]{4}-[0-9]{2}-[0-9]{2}');
+            $end_date = SucuriScanRequest::get('endDate', '[0-9]{4}-[0-9]{2}-[0-9]{2}');
+
+            if ($start_date
+                && $end_date
+                && strtotime($start_date) !== false
+                && strtotime($end_date) !== false
+                && strtotime($start_date) <= strtotime($end_date)
+            ) {
+                $filters['startDate'] = $start_date;
+                $filters['endDate'] = $end_date;
+            } else {
+                unset($filters['time']);
+            }
+        }
+
+        $search = SucuriScanRequest::get('search');
+
+        if ($search) {
+            $search = trim(html_entity_decode($search, ENT_QUOTES, 'UTF-8'));
+
+            if ($search !== '') {
+                $filters['search'] = substr($search, 0, 200);
+            }
+        }
+
+        return $filters;
+    }
+
+    /**
+     * Retrieve the latest remote logs and local queue, then apply filters once.
+     *
+     * @param array $filters Filters to apply.
+     * @return array Audit-log result and request metadata.
+     */
+    private static function getAuditLogData($filters)
+    {
+        $result = array(
+            'auditlogs' => false,
+            'errors' => '',
+            'limited' => false,
+            'queueSize' => 0,
+            'status' => '',
+        );
+        $logs_limit = SUCURISCAN_AUDITLOGS_PER_PAGE * SUCURISCAN_MAX_PAGINATION_BUTTONS;
+        $cache = new SucuriScanCache('auditlogs');
+        $auditlogs = $cache->get('response_full', SUCURISCAN_AUDITLOGS_LIFETIME, 'array');
+
+        if (!$auditlogs) {
+            ob_start();
+            $start = microtime(true);
+            $auditlogs = SucuriScanAPI::getAuditLogs($logs_limit);
+            $result['errors'] = ob_get_contents();
+            $duration = microtime(true) - $start;
+            ob_end_clean();
+
+            if (!is_array($auditlogs)) {
+                $result['status'] = __('API is not available; using local queue', 'sucuri-scanner');
+            } else {
+                /* translators: %s: number of seconds */
+                $result['status'] = sprintf(__('API %s secs', 'sucuri-scanner'), round($duration, 4));
+            }
+
+            if ($auditlogs && empty($result['errors'])) {
+                $cache->add('response_full', $auditlogs);
+            }
+        }
+
+        if (is_array($auditlogs)
+            && isset($auditlogs['total_entries'], $auditlogs['output'])
+            && $auditlogs['total_entries'] > count((array) $auditlogs['output'])
+        ) {
+            $result['limited'] = true;
+        }
+
+        $queuelogs = SucuriScanAPI::getAuditLogsFromQueue();
+
+        if (is_array($queuelogs) && !empty($queuelogs['output'])) {
+            $result['queueSize'] = (int) $queuelogs['total_entries'];
+
+            if (!$auditlogs || empty($auditlogs['output'])) {
+                $auditlogs = $queuelogs;
+            } else {
+                $auditlogs['output'] = array_merge(
+                    $queuelogs['output'],
+                    (array) $auditlogs['output']
+                );
+            }
+        }
+
+        if (is_array($auditlogs)) {
+            $auditlogs = SucuriScanAPI::filterAuditLogs($auditlogs, $filters);
+        }
+
+        $result['auditlogs'] = $auditlogs;
+
+        return $result;
     }
 
     /**
@@ -106,8 +232,8 @@ class SucuriScanAuditLogs
      * To reduce the amount of queries to the API this method will cache the logs
      * for a short period of time enough to give the service a rest. Once the
      * cache expires the method will communicate with the API once again to get
-     * a fresh copy of the new logs. The cache is skipped when the user clicks
-     * around the pagination.
+     * a fresh copy of the new logs. Filters and pagination are applied to the
+     * same cached raw response.
      *
      * Additionally, if the API key has not been added but the website owner has
      * enabled the security log exporter, the method will retrieve the logs from
@@ -142,27 +268,7 @@ class SucuriScanAuditLogs
         /* initialize the values for the pagination */
         $maxPerPage = SUCURISCAN_AUDITLOGS_PER_PAGE;
         $pageNumber = SucuriScanTemplate::pageNumber();
-        $logsLimit = ($pageNumber * $maxPerPage);
-
-        /* Initialize filter values */
-        $filters = array();
-
-        if (SucuriScanRequest::get('time')) {
-            $filters['time'] = SucuriScanRequest::get('time');
-
-            if ($filters['time'] === 'custom') {
-                $filters['startDate'] = SucuriScanRequest::get('startDate');
-                $filters['endDate'] = SucuriScanRequest::get('endDate');
-            }
-        }
-
-        $filter_keys = array('posts', 'logins', 'users', 'plugins', 'files');
-
-        foreach ($filter_keys as $key) {
-            if (SucuriScanRequest::get($key)) {
-                $filters[$key] = SucuriScanRequest::get($key);
-            }
-        }
+        $filters = self::getRequestFilters();
 
         if (!empty($filters)) {
             $response['filtersStatus'] = 'active';
@@ -170,65 +276,12 @@ class SucuriScanAuditLogs
 
         $response['filters'] = self::getFiltersSnippet($filters);
 
-        /* Get data from the cache if possible. */
-        $errors = ''; /* no errors so far */
-        $cache = new SucuriScanCache('auditlogs');
-        $auditlogs = $cache->get('response', SUCURISCAN_AUDITLOGS_LIFETIME, 'array');
-        $cacheTheResponse = false; /* cache if the data comes from the API */
-
-        /* API call if cache is invalid. */
-        if (!$auditlogs || $pageNumber !== 1) {
-            ob_start();
-            $start = microtime(true);
-            $cacheTheResponse = true;
-            $auditlogs = SucuriScanAPI::getAuditLogs($logsLimit, $filters);
-            $errors = ob_get_contents(); /* capture errors */
-            $duration = microtime(true) - $start;
-            ob_end_clean();
-
-            /* report latency in the API calls */
-            if (!is_array($auditlogs)) {
-                $response['status'] = __('API is not available; using local queue', 'sucuri-scanner');
-            } else {
-                /* translators: %s: number of seconds */
-                $response['status'] = sprintf(__('API %s secs', 'sucuri-scanner'), round($duration, 4));
-            }
-        }
-
-        /* stop everything and report errors */
-        if (!empty($errors)) {
-            $response['content'] .= $errors;
-        }
-
-        /* Cache the data for some time. */
-        if ($cacheTheResponse && $auditlogs && empty($errors)) {
-            $cache->add('response', $auditlogs);
-        }
-
-        /* merge the logs from the queue system */
-        $queuelogs = SucuriScanAPI::getAuditLogsFromQueue($filters);
-
-        if (is_array($queuelogs) && !empty($queuelogs)) {
-            if (!$auditlogs || empty($auditlogs)) {
-                $auditlogs = $queuelogs;
-            } else {
-                $auditlogs['output'] = array_merge(
-                    $queuelogs['output'],
-                    @$auditlogs['output']
-                );
-
-                $auditlogs['output_data'] = array_merge(
-                    $queuelogs['output_data'],
-                    @$auditlogs['output_data']
-                );
-
-                if (isset($auditlogs['total_entries'])) {
-                    $auditlogs['total_entries'] = $auditlogs['total_entries'] + $queuelogs['total_entries'];
-                } else {
-                    $auditlogs['total_entries'] = $queuelogs['total_entries'];
-                }
-            }
-        }
+        $data = self::getAuditLogData($filters);
+        $auditlogs = $data['auditlogs'];
+        $response['content'] .= $data['errors'];
+        $response['limited'] = $data['limited'];
+        $response['queueSize'] = $data['queueSize'];
+        $response['status'] = $data['status'];
 
         if (!is_array($auditlogs)
             || !isset($auditlogs['output_data'])
@@ -252,7 +305,7 @@ class SucuriScanAuditLogs
         usort($outdata, array('SucuriScanAuditLogs', 'sortByDate'));
 
         for ($i = $iterator_start; $i < $total_items; $i++) {
-            if ($counter_i > $maxPerPage) {
+            if ($counter_i >= $maxPerPage) {
                 break;
             }
 
@@ -261,11 +314,6 @@ class SucuriScanAuditLogs
             }
 
             $audit_log = (array)$outdata[$i];
-
-            if (strpos($audit_log['message'], ";\x20password:")) {
-                $idx = strpos($audit_log['message'], ";\x20password:");
-                $audit_log['message'] = substr($audit_log['message'], 0, $idx);
-            }
 
             $snippet_data = array(
                 'AuditLog.Event' => $audit_log['event'],
@@ -319,8 +367,6 @@ class SucuriScanAuditLogs
                 );
             }
         }
-
-        $response['queueSize'] = $auditlogs['total_entries'];
 
         wp_send_json($response, 200);
     }

--- a/src/auditlogs.lib.php
+++ b/src/auditlogs.lib.php
@@ -47,6 +47,19 @@ class SucuriScanAuditLogs
 
         $params['AuditLogs.Lifetime'] = SUCURISCAN_AUDITLOGS_LIFETIME;
 
+        /**
+         * The export is a plain link, so the nonce travels in the href. The
+         * template renders this through the escaped "%%...%%" tag, which turns
+         * the query separators into "&amp;" as an HTML attribute requires.
+         */
+        $params['AuditLogs.DownloadURL'] = add_query_arg(
+            array(
+                'action' => 'sucuriscan_download_audit_logs',
+                'sucuriscan_page_nonce' => wp_create_nonce('sucuriscan_page_nonce'),
+            ),
+            admin_url('admin-post.php')
+        );
+
         return SucuriScanTemplate::getSection('auditlogs', $params);
     }
 
@@ -369,6 +382,139 @@ class SucuriScanAuditLogs
         }
 
         wp_send_json($response, 200);
+    }
+
+    /**
+     * Send every audit trail stored on this website to the browser as a CSV.
+     *
+     * The filters on the audit trail page deliberately do not apply here; the
+     * export is always the complete local history.
+     *
+     * @codeCoverageIgnore - The method ends the request with exit(), which a
+     * test runner cannot survive. Everything it decides is delegated to
+     * canDownloadAuditLogs() and getAuditLogsCsv(), both of which are covered.
+     *
+     * @return void
+     */
+    public static function downloadAuditLogs()
+    {
+        SucuriScanInterface::checkPageVisibility();
+
+        if (!self::canDownloadAuditLogs()) {
+            wp_die(
+                esc_html__('The audit trail download link is invalid or expired.', 'sucuri-scanner'),
+                esc_html__('Audit trail export', 'sucuri-scanner'),
+                array('response' => 403, 'back_link' => true)
+            );
+        }
+
+        $filename = 'sucuri-audit-trails-' . SucuriScan::datetime(null, 'Y-m-d') . '.csv';
+
+        nocache_headers();
+        header('Content-Type: text/csv; charset=utf-8');
+        header('Content-Disposition: attachment; filename="' . $filename . '"');
+        header('X-Content-Type-Options: nosniff');
+
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        echo self::getAuditLogsCsv();
+
+        exit(0);
+    }
+
+    /**
+     * Check the nonce that authorizes an audit trail export.
+     *
+     * @return bool Whether the request carries a valid download nonce.
+     */
+    private static function canDownloadAuditLogs()
+    {
+        $nonce = SucuriScanRequest::get('sucuriscan_page_nonce', '_nonce');
+
+        return (bool) ($nonce && wp_verify_nonce($nonce, 'sucuriscan_page_nonce'));
+    }
+
+    /**
+     * Build a CSV with every audit trail stored on this website.
+     *
+     * The logs are read from the local queue file, whose leading PHP guard
+     * block is already discarded by SucuriScanCache while it parses the
+     * datastore, so only real records reach the export.
+     *
+     * @return string CSV content.
+     */
+    private static function getAuditLogsCsv()
+    {
+        $auditlogs = SucuriScanAPI::getAuditLogsFromQueue();
+        $logs = (is_array($auditlogs) && isset($auditlogs['output_data']))
+            ? (array) $auditlogs['output_data']
+            : array();
+
+        usort($logs, array('SucuriScanAuditLogs', 'sortByDate'));
+
+        $csv = self::auditLogCsvRow(
+            array('Date', 'Time', 'Severity', 'Username', 'IP Address', 'Message', 'Details')
+        );
+
+        foreach ($logs as $log) {
+            $csv .= self::auditLogCsvRow(
+                array(
+                    isset($log['date']) ? $log['date'] : '',
+                    isset($log['time']) ? $log['time'] : '',
+                    isset($log['event']) ? $log['event'] : '',
+                    isset($log['username']) ? $log['username'] : '',
+                    isset($log['remote_addr']) ? $log['remote_addr'] : '',
+                    isset($log['message']) ? $log['message'] : '',
+                    isset($log['file_list']) ? implode(";\x20", (array) $log['file_list']) : '',
+                )
+            );
+        }
+
+        return $csv;
+    }
+
+    /**
+     * Write one RFC 4180 CSV row.
+     *
+     * Every field is quoted and every embedded quote is doubled, which is all
+     * the escaping the format needs; fputcsv() is avoided because its handling
+     * of the escape character changed between the PHP versions this plugin
+     * supports.
+     *
+     * @param array $fields CSV field values.
+     * @return string One CSV row, terminated with CRLF.
+     */
+    private static function auditLogCsvRow($fields)
+    {
+        $quoted = array();
+
+        foreach ((array) $fields as $value) {
+            $value = self::spreadsheetSafeValue($value);
+            $quoted[] = '"' . str_replace('"', '""', $value) . '"';
+        }
+
+        return implode(',', $quoted) . "\r\n";
+    }
+
+    /**
+     * Prevent spreadsheet applications from evaluating exported values.
+     *
+     * @param mixed $value CSV field value.
+     * @return string Safe CSV field value.
+     */
+    private static function spreadsheetSafeValue($value)
+    {
+        $value = (string) $value;
+
+        /**
+         * "|" and "%" open a DDE link in LibreOffice Calc and older versions of
+         * Excel, so they need the same treatment as the four characters that
+         * start a formula.
+         */
+        if (preg_match('/^[\x00-\x20]*[=+\-@|%]/', $value)) {
+            return "'" . $value;
+        }
+
+        return $value;
     }
 
     /**

--- a/src/auditlogs.lib.php
+++ b/src/auditlogs.lib.php
@@ -339,7 +339,7 @@ class SucuriScanAuditLogs
                 'AuditLog.Date' => SucuriScan::datetime($audit_log['timestamp'], 'M d, Y'),
                 'AuditLog.Username' => $audit_log['username'],
                 'AuditLog.Address' => $audit_log['remote_addr'],
-                'AuditLog.Message' => $audit_log['message'],
+                'AuditLog.Message' => self::plainText($audit_log['message']),
                 'AuditLog.Extra' => '',
             );
 
@@ -352,7 +352,8 @@ class SucuriScanAuditLogs
                 $snippet_data['AuditLog.Extra'] .= '<ul class="sucuriscan-list-as-table">';
 
                 foreach ($audit_log['file_list'] as $log_extra) {
-                    $snippet_data['AuditLog.Extra'] .= '<li>' . SucuriScan::escape($log_extra) . '</li>';
+                    $snippet_data['AuditLog.Extra'] .= '<li>'
+                        . SucuriScan::escape(self::plainText($log_extra)) . '</li>';
                 }
 
                 $snippet_data['AuditLog.Extra'] .= '</ul>';
@@ -427,7 +428,14 @@ class SucuriScanAuditLogs
         header('Content-Type: text/csv; charset=utf-8');
         header('Content-Disposition: attachment; filename="' . $filename . '"');
         header('X-Content-Type-Options: nosniff');
-        header('Content-Length: ' . strlen($csv));
+
+        /**
+         * No Content-Length on purpose. Anything that has already written to
+         * the response -- a stray notice, a plugin echoing on admin_init --
+         * makes the declared length disagree with the body, and the browser
+         * then saves a CSV cut short at that offset. Letting the connection
+         * close instead keeps a noisy download complete.
+         */
 
         // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         echo $csv;
@@ -480,15 +488,19 @@ class SucuriScanAuditLogs
         );
 
         foreach ($logs as $log) {
+            $details = isset($log['file_list'])
+                ? array_map(array('SucuriScanAuditLogs', 'plainText'), (array) $log['file_list'])
+                : array();
+
             $csv .= self::auditLogCsvRow(
                 array(
                     isset($log['date']) ? $log['date'] : '',
                     isset($log['time']) ? $log['time'] : '',
                     isset($log['event']) ? $log['event'] : '',
-                    isset($log['username']) ? $log['username'] : '',
+                    self::plainText(isset($log['username']) ? $log['username'] : ''),
                     isset($log['remote_addr']) ? $log['remote_addr'] : '',
-                    isset($log['message']) ? $log['message'] : '',
-                    isset($log['file_list']) ? implode(";\x20", (array) $log['file_list']) : '',
+                    self::plainText(isset($log['message']) ? $log['message'] : ''),
+                    implode(";\x20", $details),
                 )
             );
         }
@@ -584,6 +596,24 @@ class SucuriScanAuditLogs
     }
 
     /**
+     * Decode an audit trail value back to the text the event described.
+     *
+     * Hooks build their messages out of values passed through
+     * SucuriScan::escape(), so a plugin named "A<B" is stored as "A&lt;B".
+     * Every consumer escapes again on the way out -- the template through its
+     * "%%...%%" tag, the CSV writer by quoting -- which would show the reader
+     * the entity rather than the character. Decoding once here is what makes
+     * the two agree; callers must still escape for their own medium.
+     *
+     * @param mixed $value Stored audit trail value.
+     * @return string Decoded text.
+     */
+    private static function plainText($value)
+    {
+        return html_entity_decode((string) $value, ENT_QUOTES, 'UTF-8');
+    }
+
+    /**
      * Format the file list shown for a "status has been changed" audit entry.
      *
      * The result is assigned to AuditLog.Extra, which the audit-log template renders
@@ -595,9 +625,14 @@ class SucuriScanAuditLogs
      */
     private static function formatChangedStatusFiles($file_list)
     {
+        $entries = array_map(
+            array('SucuriScanAuditLogs', 'plainText'),
+            (array) $file_list
+        );
+
         return implode(
             ",\x20",
-            array_map(array('SucuriScan', 'escape'), (array) $file_list)
+            array_map(array('SucuriScan', 'escape'), $entries)
         );
     }
 

--- a/src/auditlogs.lib.php
+++ b/src/auditlogs.lib.php
@@ -398,7 +398,8 @@ class SucuriScanAuditLogs
      *
      * @codeCoverageIgnore - The method ends the request with exit(), which a
      * test runner cannot survive. Everything it decides is delegated to
-     * canDownloadAuditLogs() and getAuditLogsCsv(), both of which are covered.
+     * canDownloadAuditLogs() and writeAuditLogsCsv(), both of which are
+     * covered.
      *
      * @return void
      */
@@ -415,25 +416,26 @@ class SucuriScanAuditLogs
         }
 
         /**
-         * admin-post.php loads wp-admin/includes/admin.php, not
-         * wp-admin/admin.php, so unlike every admin screen it never raises the
-         * memory limit for itself and runs at WP_MEMORY_LIMIT -- 40M on a
-         * single site. Asking for the admin allowance here is what the API is
-         * for, and it is what the ceiling documented on getAuditLogsCsv()
-         * assumes.
+         * Assembled into a scratch stream, not a string, and completed before a
+         * single header goes out. Two things fall out of that: the response
+         * never holds the whole export in memory, and a failure while reading
+         * the queue surfaces as an ordinary error page instead of reaching the
+         * browser as a complete-looking but truncated CSV.
          */
-        if (function_exists('wp_raise_memory_limit')) {
-            wp_raise_memory_limit('admin');
+        $buffer = self::openCsvBuffer();
+
+        if (!is_resource($buffer) || !self::writeAuditLogsCsv($buffer)) {
+            if (is_resource($buffer)) {
+                fclose($buffer); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+            }
+
+            wp_die(
+                esc_html__('The audit trails could not be read. No CSV was downloaded.', 'sucuri-scanner'),
+                esc_html__('Audit trail export', 'sucuri-scanner'),
+                array('response' => 500, 'back_link' => true)
+            );
         }
 
-        /**
-         * Built before a single header goes out. Reading the queue is the
-         * expensive part of the export, and a failure there once the download
-         * headers were already on the wire reached the browser as a complete
-         * but silently truncated CSV; now it surfaces as an ordinary error page
-         * and no file is saved.
-         */
-        $csv = self::getAuditLogsCsv();
         $filename = 'sucuri-audit-trails-' . SucuriScan::datetime(null, 'Y-m-d') . '.csv';
 
         nocache_headers();
@@ -449,10 +451,26 @@ class SucuriScanAuditLogs
          * close instead keeps a noisy download complete.
          */
 
-        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        echo $csv;
+        rewind($buffer);
+        fpassthru($buffer);
+        fclose($buffer); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 
         exit(0);
+    }
+
+    /**
+     * Open the scratch stream the CSV is assembled into.
+     *
+     * php://temp keeps the first couple of megabytes in memory and spills the
+     * rest to a temporary file, so the size of the export stops mattering to
+     * the memory limit. It is cleaned up when the handle closes.
+     *
+     * @return resource|bool Writable stream, or false when it cannot be opened.
+     */
+    private static function openCsvBuffer()
+    {
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+        return @fopen('php://temp/maxmemory:' . (2 * 1024 * 1024), 'w+');
     }
 
     /**
@@ -468,63 +486,173 @@ class SucuriScanAuditLogs
     }
 
     /**
-     * Build a CSV with every audit trail stored on this website.
+     * Write every audit trail stored on this website to a stream as CSV.
      *
-     * The logs are read from the local queue file, whose leading PHP guard
-     * block is already discarded by SucuriScanCache while it parses the
-     * datastore, so only real records reach the export.
+     * The queue is read a line at a time and each record is converted and
+     * written before the next one is read, so peak memory is a function of the
+     * longest single entry rather than of the size of the queue. That matters
+     * because admin-post.php loads wp-admin/includes/admin.php rather than
+     * wp-admin/admin.php, and so never raises the memory limit the way an admin
+     * screen does: this runs at WP_MEMORY_LIMIT, 40M on a single site, and a
+     * site that has never had an API key configured accumulates the queue
+     * indefinitely because only sendLogsFromQueue() ever drains it.
      *
-     * The whole queue is held in memory while the CSV is assembled, which is
-     * what reusing the audit page's parser buys in simplicity. Peak usage runs
-     * to roughly twenty times the size of the queue file, so with the admin
-     * allowance downloadAuditLogs() asks for -- WP_MAX_MEMORY_LIMIT, 256M by
-     * default -- the practical ceiling is a queue around ten megabytes. Past
-     * that the export fails, visibly, before any download headers are sent.
-     * Reading the queue costs about what one load of the audit trail page
-     * costs, since that page parses the same queue in full on every request.
+     * Rows come out oldest first, in the order the events were recorded. The
+     * audit page sorts newest first, but sorting means holding every record at
+     * once, which is the cost this method exists to avoid; chronological order
+     * is the natural one for a log file anyway.
      *
      * A record the parser rejects -- a line whose JSON does not decode, which
      * an interrupted append can leave behind -- is skipped here exactly as it
      * is skipped on the page. Deliberate: the export shows what the audit trail
      * shows, rather than growing a second reader that disagrees with it.
      *
-     * @return string CSV content.
+     * @param resource $stream Writable stream to receive the CSV.
+     * @return bool Whether the whole queue was read and written.
      */
-    private static function getAuditLogsCsv()
+    private static function writeAuditLogsCsv($stream)
     {
-        $auditlogs = SucuriScanAPI::getAuditLogsFromQueue();
-        $logs = (is_array($auditlogs) && isset($auditlogs['output_data']))
-            ? (array) $auditlogs['output_data']
-            : array();
-
-        /* the raw log strings are a second full copy of the queue */
-        unset($auditlogs);
-
-        usort($logs, array('SucuriScanAuditLogs', 'sortByDate'));
-
-        $csv = self::auditLogCsvRow(
+        $written = self::writeCsvRow(
+            $stream,
             array('Date', 'Time', 'Severity', 'Username', 'IP Address', 'Message', 'Details')
         );
 
-        foreach ($logs as $log) {
-            $details = isset($log['file_list'])
-                ? array_map(array('SucuriScanAuditLogs', 'plainText'), (array) $log['file_list'])
-                : array();
-
-            $csv .= self::auditLogCsvRow(
-                array(
-                    isset($log['date']) ? $log['date'] : '',
-                    isset($log['time']) ? $log['time'] : '',
-                    isset($log['event']) ? $log['event'] : '',
-                    self::plainText(isset($log['username']) ? $log['username'] : ''),
-                    isset($log['remote_addr']) ? $log['remote_addr'] : '',
-                    self::plainText(isset($log['message']) ? $log['message'] : ''),
-                    implode(";\x20", $details),
-                )
-            );
+        if (!$written) {
+            return false;
         }
 
-        return $csv;
+        $cache = new SucuriScanCache('auditqueue');
+        $finfo = $cache->getDatastoreInfo();
+        $path = is_array($finfo) && isset($finfo['fpath']) ? $finfo['fpath'] : '';
+
+        if (!$path || !is_readable($path)) {
+            /* nothing has ever been logged; an empty export is still valid */
+            return true;
+        }
+
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+        $handle = @fopen($path, 'r');
+
+        if ($handle === false) {
+            return false;
+        }
+
+        $started = false;
+
+        while (($line = fgets($handle)) !== false) {
+            /**
+             * The datastore is a PHP file that stops its own execution when it
+             * is requested directly. Everything up to and including the line
+             * that closes that block is the guard, not data.
+             */
+            if (!$started) {
+                $started = strpos($line, '?>') !== false;
+                continue;
+            }
+
+            $log = self::parseQueueLine($line);
+
+            if ($log === null) {
+                continue;
+            }
+
+            if (!self::writeAuditLogRow($stream, $log)) {
+                $written = false;
+                break;
+            }
+        }
+
+        fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+
+        return $written;
+    }
+
+    /**
+     * Convert one raw datastore line into a parsed audit trail.
+     *
+     * The line is handed to the same parser the audit page uses, one record at
+     * a time, so the export cannot drift from what the page shows -- redaction
+     * included.
+     *
+     * @param string $line Raw datastore line.
+     * @return array|null Parsed audit trail, or null when the line is not one.
+     */
+    private static function parseQueueLine($line)
+    {
+        $line = trim($line);
+        $separator = strpos($line, ':');
+
+        if ($line === '' || $separator === false) {
+            return null;
+        }
+
+        $key = substr($line, 0, $separator);
+        $message = json_decode(substr($line, $separator + 1), true);
+
+        if (!is_string($message)) {
+            return null; /* incompatible JSON data */
+        }
+
+        $offset = strpos($key, '_');
+        $timestamp = $offset === false ? $key : substr($key, 0, $offset);
+
+        $parsed = SucuriScanAPI::filterAuditLogs(
+            array(
+                'output' => array(
+                    sprintf(
+                        '%s %s : %s',
+                        SucuriScan::datetime($timestamp, 'Y-m-d H:i:s'),
+                        SucuriScan::getSiteEmail(),
+                        $message
+                    ),
+                ),
+                'total_entries' => 1,
+                'from_queue' => '1',
+            )
+        );
+
+        return isset($parsed['output_data'][0]) ? $parsed['output_data'][0] : null;
+    }
+
+    /**
+     * Write one parsed audit trail as a CSV row.
+     *
+     * @param resource $stream Writable stream.
+     * @param array    $log    Parsed audit trail.
+     * @return bool Whether the complete row was written.
+     */
+    private static function writeAuditLogRow($stream, $log)
+    {
+        $details = isset($log['file_list'])
+            ? array_map(array('SucuriScanAuditLogs', 'plainText'), (array) $log['file_list'])
+            : array();
+
+        return self::writeCsvRow(
+            $stream,
+            array(
+                isset($log['date']) ? $log['date'] : '',
+                isset($log['time']) ? $log['time'] : '',
+                isset($log['event']) ? $log['event'] : '',
+                self::plainText(isset($log['username']) ? $log['username'] : ''),
+                isset($log['remote_addr']) ? $log['remote_addr'] : '',
+                self::plainText(isset($log['message']) ? $log['message'] : ''),
+                implode(";\x20", $details),
+            )
+        );
+    }
+
+    /**
+     * Write one RFC 4180 CSV row to a stream.
+     *
+     * @param resource $stream Writable stream.
+     * @param array    $fields CSV field values.
+     * @return bool Whether the complete row was written.
+     */
+    private static function writeCsvRow($stream, $fields)
+    {
+        $row = self::auditLogCsvRow($fields);
+
+        return fwrite($stream, $row) === strlen($row);
     }
 
     /**

--- a/src/auditlogs.lib.php
+++ b/src/auditlogs.lib.php
@@ -415,6 +415,18 @@ class SucuriScanAuditLogs
         }
 
         /**
+         * admin-post.php loads wp-admin/includes/admin.php, not
+         * wp-admin/admin.php, so unlike every admin screen it never raises the
+         * memory limit for itself and runs at WP_MEMORY_LIMIT -- 40M on a
+         * single site. Asking for the admin allowance here is what the API is
+         * for, and it is what the ceiling documented on getAuditLogsCsv()
+         * assumes.
+         */
+        if (function_exists('wp_raise_memory_limit')) {
+            wp_raise_memory_limit('admin');
+        }
+
+        /**
          * Built before a single header goes out. Reading the queue is the
          * expensive part of the export, and a failure there once the download
          * headers were already on the wire reached the browser as a complete
@@ -464,12 +476,12 @@ class SucuriScanAuditLogs
      *
      * The whole queue is held in memory while the CSV is assembled, which is
      * what reusing the audit page's parser buys in simplicity. Peak usage runs
-     * to roughly twenty times the size of the queue file, so the practical
-     * ceiling is a queue of a few megabytes against the 256M that WordPress
-     * raises the admin memory limit to. Past that the export fails, visibly,
-     * before any download headers are sent. Reading the queue costs about what
-     * one load of the audit trail page costs, since that page parses the same
-     * queue in full on every request.
+     * to roughly twenty times the size of the queue file, so with the admin
+     * allowance downloadAuditLogs() asks for -- WP_MAX_MEMORY_LIMIT, 256M by
+     * default -- the practical ceiling is a queue around ten megabytes. Past
+     * that the export fails, visibly, before any download headers are sent.
+     * Reading the queue costs about what one load of the audit trail page
+     * costs, since that page parses the same queue in full on every request.
      *
      * A record the parser rejects -- a line whose JSON does not decode, which
      * an interrupted append can leave behind -- is skipped here exactly as it

--- a/src/event.lib.php
+++ b/src/event.lib.php
@@ -86,21 +86,60 @@ class SucuriScanEvent extends SucuriScan
             return $value;
         }
 
+        $redacted = self::maskCredentialFields($value);
+
         /**
-         * Credentials reach this method in several encodings: raw, backslash
-         * escaped inside JSON, and HTML-escaped by the callers that run values
-         * through SucuriScan::escape() before building a message. Matching is
-         * therefore done against a decoded copy, but the decoded copy is only
-         * returned when it actually contained something to redact -- otherwise
-         * an innocuous "R&amp;D" would be rewritten to "R&D" and every message
-         * escaped upstream would be silently un-escaped on its way to storage.
+         * Credentials also arrive encoded: backslash escaped inside JSON, or
+         * HTML escaped by the callers that build messages out of values passed
+         * through SucuriScan::escape(). A second pass over a decoded copy
+         * catches those, but its result is only used when it actually found
+         * something the first pass missed -- otherwise every message would be
+         * silently un-escaped, and an innocuous "R&amp;D" rewritten to "R&D",
+         * on its way to storage.
          */
         $decoded = html_entity_decode(
             str_replace(array('\\"', "\\'"), array('"', "'"), $value),
             ENT_QUOTES,
             'UTF-8'
         );
+        $decoded_redacted = self::maskCredentialFields($decoded);
 
+        if (self::decodeForMatching($redacted) === $decoded_redacted) {
+            return $redacted;
+        }
+
+        /**
+         * The encoding was hiding a credential, so the decoded copy is the only
+         * safe thing to emit. Escape it on the way out: decoding can turn
+         * stored entities back into live markup, and this value is rendered on
+         * the audit trail page.
+         */
+        return esc_attr($decoded_redacted);
+    }
+
+    /**
+     * Decode the escapings a credential can hide behind.
+     *
+     * @param string $value Audit message or detail value.
+     * @return string Decoded copy, used only for matching.
+     */
+    private static function decodeForMatching($value)
+    {
+        return html_entity_decode(
+            str_replace(array('\\"', "\\'"), array('"', "'"), $value),
+            ENT_QUOTES,
+            'UTF-8'
+        );
+    }
+
+    /**
+     * Replace the value of every credential-looking field in a string.
+     *
+     * @param string $value Audit message or detail value.
+     * @return string Value with credential fields masked.
+     */
+    private static function maskCredentialFields($value)
+    {
         /**
          * The optional prefixes are length-bounded on purpose. Unbounded
          * "[a-z0-9_-]*" segments in front of an alternation backtrack
@@ -113,18 +152,29 @@ class SucuriScanEvent extends SucuriScan
             . '|access[_-]?key|private[_-]?key|client[_-]?secret|authorization'
             . '|cookie|salt';
         $field = '(?:[a-z0-9_-]{0,32}[_-])?(?:' . $keys . ')';
+
+        /**
+         * An unquoted value runs to the end of the field, but a message often
+         * packs many fields together -- hookOptionsChanges() joins every option
+         * changed in one save with a comma. Without the lookahead the mask
+         * would swallow each following field as if it were part of the
+         * credential, deleting the record of everything that changed after it.
+         * A comma inside the value itself is still covered, because only a
+         * comma that introduces another "name:" pair ends the match.
+         */
+        $boundary = '(?:(?!,\s*["\']?[a-z0-9_-]{1,64}["\']?\s*[:=])[^;&}\r\n])*';
         $quoted = '/((?:^|[,{;\s])["\']?' . $field . '["\']?\s*[:=]\s*)(["\'])(.*?)\2/i';
-        $plain = '/((?:^|[;,&?\s{])["\']?' . $field . '["\']?\s*[:=]\s*)(?!["\'])([^;&}\r\n]*)/i';
+        $plain = '/((?:^|[;,&?\s{])["\']?' . $field . '["\']?\s*[:=]\s*)(?!["\'])(' . $boundary . ')/i';
 
         /**
          * Each result is checked before it is reused as the next subject: PHP
          * coerces a null subject to an empty string, so chaining the calls
          * without a guard turns a single failed match into a wiped audit entry.
          */
-        $redacted = preg_replace($quoted, '$1$2[redacted]$2', $decoded);
+        $redacted = preg_replace($quoted, '$1$2[redacted]$2', $value);
 
         if ($redacted === null) {
-            /* nothing has been masked yet, so the original is still safe */
+            /* nothing has been masked yet, so the original is still intact */
             return $value;
         }
 
@@ -136,21 +186,7 @@ class SucuriScanEvent extends SucuriScan
          * pattern had already replaced back into the audit trail: the failure
          * mode of a redaction routine must never be "emit the secret".
          */
-        $redacted = ($plain_redacted === null) ? $redacted : $plain_redacted;
-
-        if ($redacted === $decoded) {
-            /* nothing sensitive matched; keep the value exactly as received */
-            return $value;
-        }
-
-        /**
-         * Matching runs against an entity-decoded copy, so returning it can
-         * turn markup the caller had escaped back into live tags. Stripping
-         * here rather than at each call site also covers parseAuditLogs(),
-         * which redacts again at display and export time -- including records
-         * written by plugin versions that predate this redaction.
-         */
-        return wp_strip_all_tags($redacted);
+        return ($plain_redacted === null) ? $redacted : $plain_redacted;
     }
 
     /**
@@ -612,11 +648,16 @@ class SucuriScanEvent extends SucuriScan
         }
 
         /**
-         * Stripping first stops markup from splitting a key name apart, which
-         * would hide it from the pattern ("<b>pass</b>word: secret").
-         * redactSensitiveData() strips again on its way out, because it matches
-         * against an entity-decoded copy.
+         * Stripping before redacting stops markup from splitting a key name
+         * apart, which would hide it from the pattern ("<b>pass</b>word:
+         * secret").
+         *
+         * A "<" with no ">" after it is text, not an unterminated tag, and is
+         * escaped rather than handed to the stripper: strip_tags() deletes from
+         * such a bracket to the end of the string, so a site title or option
+         * value containing one silently truncated the audit entry.
          */
+        $message = preg_replace('/<(?![^<]*>)/', '&lt;', (string) $message);
         $message = self::redactSensitiveData(wp_strip_all_tags($message));
         $message = str_replace("\r", '', $message);
         $message = str_replace("\n", '', $message);

--- a/src/event.lib.php
+++ b/src/event.lib.php
@@ -164,7 +164,15 @@ class SucuriScanEvent extends SucuriScan
          */
         $boundary = '(?:(?!,\s*["\']?[a-z0-9_-]{1,64}["\']?\s*[:=])[^;&}\r\n])*';
         $quoted = '/((?:^|[,{;\s])["\']?' . $field . '["\']?\s*[:=]\s*)(["\'])(.*?)\2/i';
-        $plain = '/((?:^|[;,&?\s{])["\']?' . $field . '["\']?\s*[:=]\s*)(?!["\'])(' . $boundary . ')/i';
+
+        /**
+         * Whitespace is excluded from the lookahead as well as the quotes it
+         * guards against. Without it the engine backtracks the preceding "\s*"
+         * to nothing, finds a space rather than a quote, and matches after all
+         * -- which re-masks a value the quoted pattern has already handled and
+         * strips the quotes off it on the way through.
+         */
+        $plain = '/((?:^|[;,&?\s{])["\']?' . $field . '["\']?\s*[:=]\s*)(?![\s"\'])(' . $boundary . ')/i';
 
         /**
          * Each result is checked before it is reused as the next subject: PHP

--- a/src/event.lib.php
+++ b/src/event.lib.php
@@ -466,21 +466,30 @@ class SucuriScanEvent extends SucuriScan
             $username = sprintf("\x20%s,", $user->user_login);
         }
 
+        /**
+         * The severity prefix is part of the stored record, not of the user
+         * interface. parseAuditLogs() reads it back and discards any entry
+         * whose level it does not recognise, so translating it here would make
+         * every trail written by a non-English site vanish from the audit page
+         * and from the CSV export. Nothing user facing is lost: the page uses
+         * the parsed level as a CSS class, and the severity names shown in the
+         * filter dropdown are translated by SucuriScanAPI::getFilters().
+         */
         $severity = intval($severity);
-        $severity_name = __('Info', 'sucuri-scanner');
+        $severity_name = 'Info';
         $severities = array(
             /* 0 */
-            __('Debug', 'sucuri-scanner'),
+            'Debug',
             /* 1 */
-            __('Notice', 'sucuri-scanner'),
+            'Notice',
             /* 2 */
-            __('Info', 'sucuri-scanner'),
+            'Info',
             /* 3 */
-            __('Warning', 'sucuri-scanner'),
+            'Warning',
             /* 4 */
-            __('Error', 'sucuri-scanner'),
+            'Error',
             /* 5 */
-            __('Critical', 'sucuri-scanner'),
+            'Critical',
         );
 
         if (isset($severities[$severity])) {

--- a/src/event.lib.php
+++ b/src/event.lib.php
@@ -46,6 +46,114 @@ if (!defined('SUCURISCAN_INIT') || SUCURISCAN_INIT !== true) {
 class SucuriScanEvent extends SucuriScan
 {
     /**
+     * Check whether a field name commonly contains credentials.
+     *
+     * @param mixed $key Field or option name.
+     * @return bool Whether values for this key must not be logged.
+     */
+    public static function isSensitiveKey($key)
+    {
+        return (bool) (
+            is_string($key)
+            && preg_match(
+                '/password|passwd|(?:^|[_-])pass(?:$|[_-])|pwd|(?:^|[_-])pw(?:$|[_-])'
+                . '|secret|token|api[_-]?key|access[_-]?key|private[_-]?key'
+                . '|client[_-]?secret|authorization|cookie|salt/i',
+                $key
+            )
+        );
+    }
+
+    /**
+     * Redact common credential fields from audit trail text.
+     *
+     * @param mixed $value Audit message or detail value.
+     * @return mixed Redacted value with the original shape.
+     */
+    public static function redactSensitiveData($value)
+    {
+        if (is_array($value)) {
+            foreach ($value as $key => $item) {
+                $value[$key] = self::isSensitiveKey($key)
+                    ? '[redacted]'
+                    : self::redactSensitiveData($item);
+            }
+
+            return $value;
+        }
+
+        if (!is_string($value)) {
+            return $value;
+        }
+
+        /**
+         * Credentials reach this method in several encodings: raw, backslash
+         * escaped inside JSON, and HTML-escaped by the callers that run values
+         * through SucuriScan::escape() before building a message. Matching is
+         * therefore done against a decoded copy, but the decoded copy is only
+         * returned when it actually contained something to redact -- otherwise
+         * an innocuous "R&amp;D" would be rewritten to "R&D" and every message
+         * escaped upstream would be silently un-escaped on its way to storage.
+         */
+        $decoded = html_entity_decode(
+            str_replace(array('\\"', "\\'"), array('"', "'"), $value),
+            ENT_QUOTES,
+            'UTF-8'
+        );
+
+        /**
+         * The optional prefixes are length-bounded on purpose. Unbounded
+         * "[a-z0-9_-]*" segments in front of an alternation backtrack
+         * catastrophically on long runs of those same characters (a file-change
+         * event listing many long paths is enough), and preg_replace then
+         * returns null with PREG_BACKTRACK_LIMIT_ERROR.
+         */
+        $keys = 'password|passwd|(?:[a-z0-9_-]{0,32}[_-])?pass|pwd'
+            . '|(?:[a-z0-9_-]{0,32}[_-])?pw|secret|token|api[_-]?key'
+            . '|access[_-]?key|private[_-]?key|client[_-]?secret|authorization'
+            . '|cookie|salt';
+        $field = '(?:[a-z0-9_-]{0,32}[_-])?(?:' . $keys . ')';
+        $quoted = '/((?:^|[,{;\s])["\']?' . $field . '["\']?\s*[:=]\s*)(["\'])(.*?)\2/i';
+        $plain = '/((?:^|[;,&?\s{])["\']?' . $field . '["\']?\s*[:=]\s*)(?!["\'])([^;&}\r\n]*)/i';
+
+        /**
+         * Each result is checked before it is reused as the next subject: PHP
+         * coerces a null subject to an empty string, so chaining the calls
+         * without a guard turns a single failed match into a wiped audit entry.
+         */
+        $redacted = preg_replace($quoted, '$1$2[redacted]$2', $decoded);
+
+        if ($redacted === null) {
+            /* nothing has been masked yet, so the original is still safe */
+            return $value;
+        }
+
+        $plain_redacted = preg_replace($plain, '$1[redacted]', $redacted);
+
+        /**
+         * A failed second pass must not throw away what the first one masked.
+         * Returning the original here would put a credential that the quoted
+         * pattern had already replaced back into the audit trail: the failure
+         * mode of a redaction routine must never be "emit the secret".
+         */
+        $redacted = ($plain_redacted === null) ? $redacted : $plain_redacted;
+
+        if ($redacted === $decoded) {
+            /* nothing sensitive matched; keep the value exactly as received */
+            return $value;
+        }
+
+        /**
+         * Matching runs against an entity-decoded copy, so returning it can
+         * turn markup the caller had escaped back into live tags. Stripping
+         * here rather than at each call site also covers parseAuditLogs(),
+         * which redacts again at display and export time -- including records
+         * written by plugin versions that predate this redaction.
+         */
+        return wp_strip_all_tags($redacted);
+    }
+
+    /**
      * Creates a cronjob to run the file system scanner.
      *
      * Right after a fresh installation of the plugin, it will create a cronjob
@@ -329,6 +437,13 @@ class SucuriScanEvent extends SucuriScan
      */
     public static function sendLogToQueue($message = '')
     {
+        /**
+         * Backstop, not a duplicate of the redaction reportEvent() already ran:
+         * stripping tags there can reveal a key name that was previously broken
+         * up by markup, and this is the last point before the value is written.
+         */
+        $message = self::redactSensitiveData($message);
+
         /* create storage directory if necessary */
         SucuriScanInterface::createStorageFolder();
 
@@ -496,8 +611,13 @@ class SucuriScanEvent extends SucuriScan
             $severity_name = $severities[$severity];
         }
 
-        /* remove unnecessary characters */
-        $message = wp_strip_all_tags($message);
+        /**
+         * Stripping first stops markup from splitting a key name apart, which
+         * would hide it from the pattern ("<b>pass</b>word: secret").
+         * redactSensitiveData() strips again on its way out, because it matches
+         * against an entity-decoded copy.
+         */
+        $message = self::redactSensitiveData(wp_strip_all_tags($message));
         $message = str_replace("\r", '', $message);
         $message = str_replace("\n", '', $message);
         $message = str_replace("\t", '', $message);

--- a/src/globals.php
+++ b/src/globals.php
@@ -152,6 +152,12 @@ if (defined('SUCURISCAN')) {
 
         /* Attach HTTP request handlers for the AJAX requests */
         add_action('wp_ajax_sucuriscan_ajax', 'sucuriscan_ajax');
+
+        /* The audit trail export is a file download, not an AJAX response */
+        add_action(
+            'admin_post_sucuriscan_download_audit_logs',
+            'SucuriScanAuditLogs::downloadAuditLogs'
+        );
     }
 
     /**

--- a/src/strings.php
+++ b/src/strings.php
@@ -30,6 +30,10 @@ __('Successfully sent to the API:', 'sucuri-scanner');
 __('Total request timeouts (failures):', 'sucuri-scanner');
 __('Total execution time:', 'sucuri-scanner');
 __('Send Logs', 'sucuri-scanner');
+__('Search audit trails', 'sucuri-scanner');
+__('Results are limited to the latest audit trails available.', 'sucuri-scanner');
+__('Filter', 'sucuri-scanner');
+__('Clear Filters', 'sucuri-scanner');
 
 // base.html.tpl
 __('Sucuri Security', 'sucuri-scanner');

--- a/src/strings.php
+++ b/src/strings.php
@@ -34,6 +34,8 @@ __('Search audit trails', 'sucuri-scanner');
 __('Results are limited to the latest audit trails available.', 'sucuri-scanner');
 __('Filter', 'sucuri-scanner');
 __('Clear Filters', 'sucuri-scanner');
+__('The CSV contains all audit trails currently stored on this website.', 'sucuri-scanner');
+__('Download CSV', 'sucuri-scanner');
 
 // base.html.tpl
 __('Sucuri Security', 'sucuri-scanner');

--- a/tests/ApiErrorEscapingTest.php
+++ b/tests/ApiErrorEscapingTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+if (!defined('SUCURISCAN_ADMIN_NOTICE_PREFIX')) {
+    define('SUCURISCAN_ADMIN_NOTICE_PREFIX', 'Sucuri');
+}
+
+final class ApiErrorEscapingTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when('__')->returnArg();
+        Functions\when('esc_html')->alias(function ($value) {
+            return htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        });
+        Functions\when('wp_rand')->justReturn(123);
+        Functions\when('get_site_url')->justReturn('https://example.com');
+        Functions\when('wp_cache_get')->justReturn(false);
+        Functions\when('wp_cache_set')->justReturn(true);
+        Functions\when('get_option')->justReturn(false);
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function testRemoteStringErrorIsEscapedBeforeAdminNoticeRendering()
+    {
+        ob_start();
+        SucuriScanAPI::handleResponse('<img src=x onerror=alert(1)>');
+        $output = ob_get_clean();
+
+        $this->assertStringNotContainsString('<img', $output);
+        $this->assertStringContainsString('&lt;img src=x onerror=alert(1)&gt;', $output);
+    }
+}

--- a/tests/AuditLogsCsvTest.php
+++ b/tests/AuditLogsCsvTest.php
@@ -223,6 +223,37 @@ final class AuditLogsCsvTest extends TestCase
         $this->assertSame($unfiltered, $this->rows($this->csv()));
     }
 
+    public function testExportsNamesAsTheTextTheEventDescribed()
+    {
+        /**
+         * Hooks build messages out of values passed through
+         * SucuriScan::escape(), so a plugin named "R&D <Tools>" reaches the
+         * queue entity-encoded. A CSV is data, not markup: the reader has to
+         * get the characters back, not the entities.
+         */
+        $this->storeAuditTrail(
+            'Warning: admin, 1.2.3.4; Plugin activated: R&amp;D &lt;Tools&gt; (v1.0; rd/rd.php)'
+        );
+
+        $csv = $this->csv();
+
+        $this->assertStringContainsString('Plugin activated: R&D <Tools>', $csv);
+        $this->assertStringNotContainsString('&amp;', $csv);
+        $this->assertStringNotContainsString('&lt;', $csv);
+    }
+
+    public function testExportsDetailColumnsAsPlainTextToo()
+    {
+        $this->storeAuditTrail(
+            'Notice: admin, 1.2.3.4; Post status has been changed; details: ID: 3,Title: Ben &amp; Jerry'
+        );
+
+        $csv = $this->csv();
+
+        $this->assertStringContainsString('Ben & Jerry', $csv);
+        $this->assertStringNotContainsString('&amp;', $csv);
+    }
+
     public function testNeverExportsStoredCredentials()
     {
         /**

--- a/tests/AuditLogsCsvTest.php
+++ b/tests/AuditLogsCsvTest.php
@@ -79,11 +79,26 @@ final class AuditLogsCsvTest extends TestCase
     /**
      * Build the CSV export from the audit queue fixture.
      *
+     * Driven through the same scratch stream downloadAuditLogs() writes into,
+     * so the export is exercised as it actually runs.
+     *
      * @return string Generated CSV.
      */
     private function csv(): string
     {
-        return (string) $this->invoke('getAuditLogsCsv');
+        $stream = $this->invoke('openCsvBuffer');
+
+        $this->assertIsResource($stream, 'the CSV scratch stream could not be opened');
+        $this->assertTrue(
+            (bool) $this->invoke('writeAuditLogsCsv', array($stream)),
+            'the audit queue could not be read'
+        );
+
+        rewind($stream);
+        $csv = (string) stream_get_contents($stream);
+        fclose($stream);
+
+        return $csv;
     }
 
     /**
@@ -110,7 +125,7 @@ final class AuditLogsCsvTest extends TestCase
      * an expectation taken from the same call the export makes could not
      * detect a fault in that call.
      *
-     * @return array Stored messages, keyed by datastore key.
+     * @return array Stored messages, one entry per record line.
      */
     private function storedAuditTrails(): array
     {
@@ -124,8 +139,15 @@ final class AuditLogsCsvTest extends TestCase
             $message = json_decode($parts[2], true);
 
             if (is_string($message)) {
-                /* duplicate keys collapse in the datastore, as they do on read */
-                $records[$parts[1]] = $message;
+                /**
+                 * A list, not a map: the export reads the queue line by line,
+                 * so two records sharing a datastore key are two rows. The
+                 * audit page collapses them, because the keyed reader it uses
+                 * builds a map -- but matching that would mean holding every
+                 * key in memory, which is the cost the streaming export exists
+                 * to avoid.
+                 */
+                $records[] = $parts[1] . ' ' . $message;
             }
         }
 
@@ -136,7 +158,11 @@ final class AuditLogsCsvTest extends TestCase
     {
         $csv = $this->csv();
 
-        foreach ($this->storedAuditTrails() as $key => $message) {
+        foreach ($this->storedAuditTrails() as $record) {
+            /* the key was prefixed for the failure message; drop it again */
+            $message = substr($record, strpos($record, ' ') + 1);
+            $key = strtok($record, ' ');
+
             /* "Severity: user, ip; " is split into its own columns */
             $body = substr($message, strpos($message, ';') + 2);
 
@@ -150,6 +176,35 @@ final class AuditLogsCsvTest extends TestCase
                 $probe,
                 $csv,
                 sprintf('audit trail %s is missing from the export', $key)
+            );
+        }
+    }
+
+    public function testExportsRowsInTheOrderTheyWereRecorded()
+    {
+        /**
+         * The audit page sorts newest first, but sorting means holding every
+         * record at once. The export streams instead, so rows come out in the
+         * order the queue holds them -- which on a real site, where every
+         * append carries the microtime of the event, is chronological.
+         */
+        $rows = $this->rows($this->csv());
+        array_shift($rows); /* drop the header */
+
+        $stored = $this->storedAuditTrails();
+
+        $this->assertGreaterThan(1, count($stored));
+        $this->assertCount(count($stored), $rows);
+
+        foreach ($stored as $index => $record) {
+            $message = substr($record, strpos($record, ' ') + 1);
+            $body = substr($message, strpos($message, ';') + 2);
+            $probe = strtok($body, ';');
+
+            $this->assertStringContainsString(
+                $probe,
+                $rows[$index][5],
+                sprintf('row %d does not hold the %dth stored audit trail', $index, $index)
             );
         }
     }

--- a/tests/AuditLogsCsvTest.php
+++ b/tests/AuditLogsCsvTest.php
@@ -1,0 +1,282 @@
+<?php declare(strict_types=1);
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+final class AuditLogsCsvTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        Functions\when('get_home_path')->justReturn(__DIR__);
+        Functions\when('__')->returnArg();
+        Functions\when('wp_cache_get')->justReturn(false);
+        Functions\when('wp_cache_set')->justReturn(true);
+        Functions\when('wp_cache_delete')->justReturn(true);
+        Functions\when('get_option')->justReturn(false);
+
+        $_GET = array();
+        $_SERVER['SERVER_SOFTWARE'] = 'apache';
+    }
+
+    protected function tearDown(): void
+    {
+        $_GET = array();
+
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    /**
+     * Invoke one of the private export helpers.
+     *
+     * @param string $name Method name.
+     * @param array  $args Method arguments.
+     * @return mixed Return value of the method.
+     */
+    private function invoke(string $name, array $args = array())
+    {
+        $method = (new ReflectionClass('SucuriScanAuditLogs'))->getMethod($name);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs(null, $args);
+    }
+
+    /**
+     * Build the CSV export from the audit queue fixture.
+     *
+     * @return string Generated CSV.
+     */
+    private function csv(): string
+    {
+        return (string) $this->invoke('getAuditLogsCsv');
+    }
+
+    /**
+     * Split a CSV into rows of fields.
+     *
+     * @param string $csv Generated CSV.
+     * @return array Parsed rows.
+     */
+    private function rows(string $csv): array
+    {
+        $rows = array();
+
+        foreach (preg_split('/\r\n/', trim($csv)) as $line) {
+            $rows[] = str_getcsv($line, ',', '"', '');
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Number of audit trails held in the local queue fixture.
+     *
+     * @return int Stored audit trail count.
+     */
+    private function storedAuditTrailCount(): int
+    {
+        $auditlogs = SucuriScanAPI::getAuditLogsFromQueue();
+
+        return count((array) $auditlogs['output_data']);
+    }
+
+    public function testExportsEveryStoredAuditTrail()
+    {
+        $rows = $this->rows($this->csv());
+
+        /* one header row plus every audit trail in the local queue */
+        $this->assertCount($this->storedAuditTrailCount() + 1, $rows);
+        $this->assertGreaterThan(1, count($rows));
+    }
+
+    public function testNeverLeaksTheDatastorePhpHeader()
+    {
+        $csv = $this->csv();
+
+        /**
+         * The queue is a PHP file that stops its own execution when requested
+         * directly. None of that preamble is data, so none of it belongs in
+         * the export.
+         */
+        $this->assertStringNotContainsString('<?php', $csv);
+        $this->assertStringNotContainsString('?>', $csv);
+        $this->assertStringNotContainsString('exit(0)', $csv);
+        $this->assertStringNotContainsString('datastore=', $csv);
+        $this->assertStringNotContainsString('created_on=', $csv);
+    }
+
+    public function testWritesTheExpectedHeaderRow()
+    {
+        $rows = $this->rows($this->csv());
+
+        $this->assertSame(
+            array('Date', 'Time', 'Severity', 'Username', 'IP Address', 'Message', 'Details'),
+            $rows[0]
+        );
+    }
+
+    public function testEveryRowHasTheSameColumnCountAsTheHeader()
+    {
+        $rows = $this->rows($this->csv());
+
+        foreach ($rows as $row) {
+            $this->assertCount(7, $row);
+        }
+    }
+
+    public function testExportsPopulatedFieldsForEveryTrail()
+    {
+        $rows = $this->rows($this->csv());
+        array_shift($rows); /* drop the header */
+
+        foreach ($rows as $row) {
+            $this->assertMatchesRegularExpression('/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/', $row[0]);
+            $this->assertMatchesRegularExpression('/^[0-9]{2}:[0-9]{2}:[0-9]{2}$/', $row[1]);
+            $this->assertNotSame('', $row[2]);
+            $this->assertNotSame('', $row[5]);
+        }
+    }
+
+    public function testIgnoresTheFiltersAppliedOnTheAuditTrailPage()
+    {
+        $unfiltered = $this->rows($this->csv());
+
+        /* the queue fixture holds logs from 2017, so this filter matches none */
+        $_GET['time'] = 'today';
+        $_GET['events'] = 'critical';
+        $_GET['search'] = 'no audit trail contains this';
+        $_GET['plugins'] = 'deleted';
+
+        $this->assertSame($unfiltered, $this->rows($this->csv()));
+    }
+
+    public function testExportsMessagesAndDetailsVerbatim()
+    {
+        $rows = $this->rows($this->invoke('auditLogCsvRow', array(
+            array(
+                '2026-07-15',
+                '10:30:00',
+                'warning',
+                'admin',
+                '192.0.2.1',
+                'Plugin updated: Example, version 2',
+                implode(";\x20", array('example.php', 'readme.txt')),
+            ),
+        )));
+
+        $this->assertSame(
+            array(
+                '2026-07-15',
+                '10:30:00',
+                'warning',
+                'admin',
+                '192.0.2.1',
+                'Plugin updated: Example, version 2',
+                'example.php; readme.txt',
+            ),
+            $rows[0]
+        );
+    }
+
+    public function testQuotesCommasQuotesAndNewlines()
+    {
+        $row = $this->invoke('auditLogCsvRow', array(
+            array('a,b', 'say "hi"', "line1\nline2", '', '', '', ''),
+        ));
+
+        $this->assertStringStartsWith('"a,b","say ""hi""","line1' . "\n" . 'line2"', $row);
+        $this->assertStringEndsWith("\r\n", $row);
+
+        $fields = str_getcsv(rtrim($row, "\r\n"), ',', '"', '');
+
+        $this->assertCount(7, $fields);
+        $this->assertSame('a,b', $fields[0]);
+        $this->assertSame('say "hi"', $fields[1]);
+        $this->assertSame("line1\nline2", $fields[2]);
+    }
+
+    public function testExportsTrailingBackslashesWithoutCorruptingColumns()
+    {
+        $row = $this->invoke('auditLogCsvRow', array(
+            array('2026-07-15', '10:30:00', 'notice', 'admin\\', '192.0.2.1', 'Windows path C:\\', ''),
+        ));
+        $fields = str_getcsv(rtrim($row, "\r\n"), ',', '"', '');
+
+        $this->assertCount(7, $fields);
+        $this->assertSame('admin\\', $fields[3]);
+        $this->assertSame('Windows path C:\\', $fields[5]);
+    }
+
+    public function testPreventsSpreadsheetFormulaInjection()
+    {
+        $row = $this->invoke('auditLogCsvRow', array(
+            array(
+                '=HYPERLINK("https://example.com")',
+                '+1',
+                "\t@SUM(1+1)",
+                '-dangerous.csv',
+                '|cmd',
+                '%payload',
+                'harmless',
+            ),
+        ));
+        $fields = str_getcsv(rtrim($row, "\r\n"), ',', '"', '');
+
+        $this->assertSame('\'=HYPERLINK("https://example.com")', $fields[0]);
+        $this->assertSame("'+1", $fields[1]);
+        $this->assertSame("'\t@SUM(1+1)", $fields[2]);
+        $this->assertSame("'-dangerous.csv", $fields[3]);
+        $this->assertSame("'|cmd", $fields[4]);
+        $this->assertSame("'%payload", $fields[5]);
+        $this->assertSame('harmless', $fields[6]);
+    }
+
+    public function testRendersTheDownloadLinkOnTheAuditTrailPage()
+    {
+        Functions\when('add_query_arg')->alias(function ($args, $url) {
+            return $url . '?' . http_build_query($args);
+        });
+        Functions\when('get_site_url')->justReturn('https://example.com');
+
+        $html = SucuriScanAuditLogs::pageAuditLogs();
+
+        $this->assertStringNotContainsString('%%SUCURI.AuditLogs.DownloadURL%%', $html);
+        $this->assertMatchesRegularExpression(
+            '/<a id="download-auditlogs-link" href="[^"]*admin-post\.php\?'
+            . 'action=sucuriscan_download_audit_logs&amp;sucuriscan_page_nonce=[a-z0-9]+"/',
+            $html
+        );
+    }
+
+    public function testRejectsARequestWithoutANonce()
+    {
+        Functions\when('wp_verify_nonce')->justReturn(true);
+
+        $this->assertFalse($this->invoke('canDownloadAuditLogs'));
+    }
+
+    public function testRejectsARequestWithAnInvalidNonce()
+    {
+        $_GET['sucuriscan_page_nonce'] = 'aaaaaaaaaa';
+
+        Functions\when('wp_verify_nonce')->justReturn(false);
+
+        $this->assertFalse($this->invoke('canDownloadAuditLogs'));
+    }
+
+    public function testAcceptsARequestWithAValidNonce()
+    {
+        $_GET['sucuriscan_page_nonce'] = 'aaaaaaaaaa';
+
+        Functions\when('wp_verify_nonce')->justReturn(true);
+
+        $this->assertTrue($this->invoke('canDownloadAuditLogs'));
+    }
+}

--- a/tests/AuditLogsCsvTest.php
+++ b/tests/AuditLogsCsvTest.php
@@ -104,24 +104,62 @@ final class AuditLogsCsvTest extends TestCase
     }
 
     /**
-     * Number of audit trails held in the local queue fixture.
+     * Audit trails held in the local queue fixture, read straight from disk.
      *
-     * @return int Stored audit trail count.
+     * Deliberately not routed through SucuriScanAPI::getAuditLogsFromQueue():
+     * an expectation taken from the same call the export makes could not
+     * detect a fault in that call.
+     *
+     * @return array Stored messages, keyed by datastore key.
      */
-    private function storedAuditTrailCount(): int
+    private function storedAuditTrails(): array
     {
-        $auditlogs = SucuriScanAPI::getAuditLogsFromQueue();
+        $records = array();
 
-        return count((array) $auditlogs['output_data']);
+        foreach (file($this->queuePath) as $line) {
+            if (!preg_match('/^([0-9]+_[0-9]+):(.*)$/', trim($line), $parts)) {
+                continue; /* header line, not a record */
+            }
+
+            $message = json_decode($parts[2], true);
+
+            if (is_string($message)) {
+                /* duplicate keys collapse in the datastore, as they do on read */
+                $records[$parts[1]] = $message;
+            }
+        }
+
+        return $records;
     }
 
     public function testExportsEveryStoredAuditTrail()
     {
+        $csv = $this->csv();
+
+        foreach ($this->storedAuditTrails() as $key => $message) {
+            /* "Severity: user, ip; " is split into its own columns */
+            $body = substr($message, strpos($message, ';') + 2);
+
+            /**
+             * A "... has been changed" entry is reshaped on read: the detail
+             * list moves into its own column, so compare on the part before it.
+             */
+            $probe = strtok($body, ';');
+
+            $this->assertStringContainsString(
+                $probe,
+                $csv,
+                sprintf('audit trail %s is missing from the export', $key)
+            );
+        }
+    }
+
+    public function testExportsOneRowPerStoredAuditTrail()
+    {
         $rows = $this->rows($this->csv());
 
-        /* one header row plus every audit trail in the local queue */
-        $this->assertCount($this->storedAuditTrailCount() + 1, $rows);
         $this->assertGreaterThan(1, count($rows));
+        $this->assertCount(count($this->storedAuditTrails()) + 1, $rows);
     }
 
     public function testNeverLeaksTheDatastorePhpHeader()

--- a/tests/AuditLogsCsvTest.php
+++ b/tests/AuditLogsCsvTest.php
@@ -9,12 +9,22 @@ final class AuditLogsCsvTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
+    /** @var string */
+    private $queuePath;
+
+    /** @var string */
+    private $queueBackup;
+
     protected function setUp(): void
     {
         parent::setUp();
         Monkey\setUp();
 
+        $this->queuePath = SUCURI_DATA_STORAGE . '/sucuri-auditqueue.php';
+        $this->queueBackup = (string) file_get_contents($this->queuePath);
+
         Functions\when('get_home_path')->justReturn(__DIR__);
+        Functions\when('wp_strip_all_tags')->alias('sucuriscan_test_strip_all_tags');
         Functions\when('__')->returnArg();
         Functions\when('wp_cache_get')->justReturn(false);
         Functions\when('wp_cache_set')->justReturn(true);
@@ -29,8 +39,26 @@ final class AuditLogsCsvTest extends TestCase
     {
         $_GET = array();
 
+        /* the queue is a shared fixture; every append has to be rolled back */
+        file_put_contents($this->queuePath, $this->queueBackup);
+
         Monkey\tearDown();
         parent::tearDown();
+    }
+
+    /**
+     * Append one raw record to the local audit queue.
+     *
+     * @param string $message Audit message to store.
+     * @return void
+     */
+    private function storeAuditTrail(string $message): void
+    {
+        file_put_contents(
+            $this->queuePath,
+            sprintf("9999999999_0000:%s\n", json_encode($message)),
+            FILE_APPEND
+        );
     }
 
     /**
@@ -155,6 +183,20 @@ final class AuditLogsCsvTest extends TestCase
         $_GET['plugins'] = 'deleted';
 
         $this->assertSame($unfiltered, $this->rows($this->csv()));
+    }
+
+    public function testNeverExportsStoredCredentials()
+    {
+        /**
+         * The export is the one path that takes audit trails off the site, so
+         * the redaction applied when logs are read back is asserted here too.
+         */
+        $this->storeAuditTrail('Warning: admin, 1.2.3.4; Mailer saved; smtp_password: hunter2');
+
+        $csv = $this->csv();
+
+        $this->assertStringNotContainsString('hunter2', $csv);
+        $this->assertStringContainsString('smtp_password: [redacted]', $csv);
     }
 
     public function testExportsMessagesAndDetailsVerbatim()

--- a/tests/AuditLogsDisplayTest.php
+++ b/tests/AuditLogsDisplayTest.php
@@ -1,0 +1,166 @@
+<?php declare(strict_types=1);
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises what the audit trail page renders for a stored entry.
+ *
+ * Hooks store their messages entity-encoded, so the page and the CSV export
+ * have to agree on decoding them exactly once.
+ */
+final class AuditLogsDisplayTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /** @var array|null */
+    public $sent;
+
+    /** @var string */
+    private $queuePath;
+
+    /** @var string */
+    private $queueBackup;
+
+    /** @var string */
+    private $settingsPath;
+
+    /** @var string */
+    private $settingsBackup;
+
+    /** @var array */
+    private $postBackup;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        $self = $this;
+        $this->sent = null;
+        $this->postBackup = $_POST;
+        /**
+         * Rendering the page reports events and caches its response, so both
+         * of these tracked fixtures are written to. Without a restore the suite
+         * leaves the working tree dirty and the drift gets committed by
+         * accident.
+         */
+        $this->queuePath = SUCURI_DATA_STORAGE . '/sucuri-auditqueue.php';
+        $this->queueBackup = (string) file_get_contents($this->queuePath);
+        $this->settingsPath = SUCURI_DATA_STORAGE . '/sucuri-settings.php';
+        $this->settingsBackup = (string) file_get_contents($this->settingsPath);
+
+        $_POST = array('form_action' => 'get_audit_logs');
+        $_GET = array();
+        $_SERVER['SERVER_SOFTWARE'] = 'apache';
+
+        Functions\when('__')->returnArg();
+        Functions\when('get_home_path')->justReturn(__DIR__);
+        Functions\when('wp_cache_get')->justReturn(false);
+        Functions\when('wp_cache_set')->justReturn(true);
+        Functions\when('wp_cache_delete')->justReturn(true);
+        Functions\when('get_option')->justReturn(false);
+        Functions\when('update_option')->justReturn(true);
+        Functions\when('delete_option')->justReturn(true);
+        Functions\when('sucuriscan_lastlogins_datastore_exists')->justReturn(true);
+        Functions\when('sanitize_text_field')->returnArg();
+        Functions\when('wp_unslash')->returnArg();
+        Functions\when('get_site_url')->justReturn('https://example.com');
+        Functions\when('wp_strip_all_tags')->alias('sucuriscan_test_strip_all_tags');
+        Functions\when('esc_html')->alias(function ($value) {
+            return htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        });
+
+        /* capture the payload instead of emitting it and calling die() */
+        Functions\when('wp_send_json')->alias(function ($data, $status = null) use ($self) {
+            $self->sent = array('data' => $data, 'status' => $status);
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        file_put_contents($this->queuePath, $this->queueBackup);
+        file_put_contents($this->settingsPath, $this->settingsBackup);
+
+        /* the response cache is created by the render, not part of the fixtures */
+        $cache = SUCURI_DATA_STORAGE . '/sucuri-auditlogs.php';
+
+        if (file_exists($cache)) {
+            unlink($cache);
+        }
+
+        $_POST = $this->postBackup;
+        $_GET = array();
+
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    /**
+     * Append one raw record to the local audit queue.
+     *
+     * @param string $message Audit message to store.
+     * @return void
+     */
+    private function storeAuditTrail(string $message): void
+    {
+        file_put_contents(
+            $this->queuePath,
+            sprintf("9999999999_0000:%s\n", json_encode($message)),
+            FILE_APPEND
+        );
+    }
+
+    public function testRendersStoredNamesAsTheTextTheEventDescribed()
+    {
+        /**
+         * "R&D <Tools>" is stored as "R&amp;D &lt;Tools&gt;" by the hook. The
+         * template escapes whatever it is handed, so passing the stored value
+         * straight through rendered the entities themselves back to the reader
+         * as "R&amp;amp;D".
+         */
+        $this->storeAuditTrail(
+            'Warning: admin, 1.2.3.4; Plugin activated: R&amp;D &lt;Tools&gt; (v1.0; rd/rd.php)'
+        );
+
+        SucuriScanAuditLogs::ajaxAuditLogs();
+        $content = $this->sent['data']['content'];
+
+        /* escaped exactly once: the browser shows "R&D <Tools>" */
+        $this->assertStringContainsString('R&amp;D &lt;Tools&gt;', $content);
+        $this->assertStringNotContainsString('&amp;amp;', $content);
+        $this->assertStringNotContainsString('&amp;lt;', $content);
+    }
+
+    public function testRendersDetailEntriesAsPlainTextToo()
+    {
+        $this->storeAuditTrail(
+            'Notice: admin, 1.2.3.4; Post status has been changed; details: ID: 3,Title: Ben &amp; Jerry'
+        );
+
+        SucuriScanAuditLogs::ajaxAuditLogs();
+        $content = $this->sent['data']['content'];
+
+        $this->assertStringContainsString('Ben &amp; Jerry', $content);
+        $this->assertStringNotContainsString('&amp;amp;', $content);
+    }
+
+    public function testStillEscapesMarkupThatWasNeverEncoded()
+    {
+        /**
+         * Decoding must not become a way to smuggle live markup onto the page:
+         * a record holding a raw tag still has to reach the browser escaped.
+         */
+        $this->storeAuditTrail(
+            'Warning: admin, 1.2.3.4; Plugin activated: <script>alert(1)</script> (v1.0; x/x.php)'
+        );
+
+        SucuriScanAuditLogs::ajaxAuditLogs();
+        $content = $this->sent['data']['content'];
+
+        $this->assertStringNotContainsString('<script>', $content);
+        $this->assertStringContainsString('&lt;script&gt;', $content);
+    }
+}

--- a/tests/AuditlogsTest.php
+++ b/tests/AuditlogsTest.php
@@ -168,6 +168,9 @@ final class AuditlogsTest extends TestCase
 
     public function testRedactsLegacyPasswordsBeforeFilteringOrExport()
     {
+        /* records predating the redaction are masked when they are read back */
+        Functions\when('wp_strip_all_tags')->alias('sucuriscan_test_strip_all_tags');
+
         $auditlogs = SucuriScanAPI::filterAuditLogs(array(
             'output' => array(
                 '2026-07-15 10:30:00 admin@example.com : Error: admin, 192.0.2.1; User authentication failed: admin; password: secret',
@@ -176,8 +179,9 @@ final class AuditlogsTest extends TestCase
         ));
 
         $this->assertCount(1, $auditlogs['output_data']);
+        $this->assertStringNotContainsString('secret', $auditlogs['output_data'][0]['message']);
         $this->assertSame(
-            'User authentication failed: admin',
+            'User authentication failed: admin; password: [redacted]',
             $auditlogs['output_data'][0]['message']
         );
     }

--- a/tests/AuditlogsTest.php
+++ b/tests/AuditlogsTest.php
@@ -86,4 +86,78 @@ final class AuditlogsTest extends TestCase
             $this->assertStringContainsString('User account deleted', $log['message']);
         }
     }
+
+    public function testSearchesAuditLogFieldsCaseInsensitively()
+    {
+        $auditlogs = SucuriScanAPI::getAuditLogsFromQueue(array(
+            'search' => 'activity log',
+        ));
+
+        $this->assertCount(1, $auditlogs['output_data']);
+        $this->assertStringContainsString('Activity Log', $auditlogs['output_data'][0]['message']);
+
+        $auditlogs = SucuriScanAPI::getAuditLogsFromQueue(array(
+            'search' => '1.2.3.4',
+        ));
+
+        $this->assertNotEmpty($auditlogs['output_data']);
+
+        foreach ($auditlogs['output_data'] as $log) {
+            $this->assertSame('1.2.3.4', $log['remote_addr']);
+        }
+    }
+
+    public function testSearchNarrowsCategoryFilters()
+    {
+        $auditlogs = SucuriScanAPI::getAuditLogsFromQueue(array(
+            'plugins' => 'activated',
+            'search' => 'activity log',
+        ));
+
+        $this->assertCount(1, $auditlogs['output_data']);
+        $this->assertStringContainsString('Plugin activated', $auditlogs['output_data'][0]['message']);
+    }
+
+    public function testMultipleActivityCategoriesUseOrSemantics()
+    {
+        $auditlogs = SucuriScanAPI::getAuditLogsFromQueue(array(
+            'posts' => 'deleted',
+            'plugins' => 'activated',
+        ));
+
+        $this->assertCount(3, $auditlogs['output_data']);
+
+        foreach ($auditlogs['output_data'] as $log) {
+            $this->assertStringContainsString('Plugin activated', $log['message']);
+        }
+    }
+
+    public function testFiltersBySeverity()
+    {
+        $auditlogs = SucuriScanAPI::getAuditLogsFromQueue(array(
+            'events' => 'warning',
+        ));
+
+        $this->assertNotEmpty($auditlogs['output_data']);
+
+        foreach ($auditlogs['output_data'] as $log) {
+            $this->assertSame('warning', $log['event']);
+        }
+    }
+
+    public function testRedactsLegacyPasswordsBeforeFilteringOrExport()
+    {
+        $auditlogs = SucuriScanAPI::filterAuditLogs(array(
+            'output' => array(
+                '2026-07-15 10:30:00 admin@example.com : Error: admin, 192.0.2.1; User authentication failed: admin; password: secret',
+            ),
+            'total_entries' => 1,
+        ));
+
+        $this->assertCount(1, $auditlogs['output_data']);
+        $this->assertSame(
+            'User authentication failed: admin',
+            $auditlogs['output_data'][0]['message']
+        );
+    }
 }

--- a/tests/AuditlogsTest.php
+++ b/tests/AuditlogsTest.php
@@ -107,6 +107,27 @@ final class AuditlogsTest extends TestCase
         }
     }
 
+    public function testSearchesNamesThatWereStoredHtmlEscaped()
+    {
+        /**
+         * Hooks record plugin and theme names through SucuriScan::escape(), so
+         * "R&D Tools" sits in the queue as "R&amp;D Tools". The search term
+         * arrives decoded, and comparing the two raw would never match.
+         */
+        $auditlogs = SucuriScanAPI::filterAuditLogs(
+            array(
+                'output' => array(
+                    '2026-07-15 10:30:00 admin@example.com : Warning: admin, 192.0.2.1;'
+                    . ' Plugin activated: R&amp;D Tools (v1.0; rd-tools/rd-tools.php)',
+                ),
+                'total_entries' => 1,
+            ),
+            array('search' => 'R&D Tools')
+        );
+
+        $this->assertCount(1, $auditlogs['output_data']);
+    }
+
     public function testSearchNarrowsCategoryFilters()
     {
         $auditlogs = SucuriScanAPI::getAuditLogsFromQueue(array(

--- a/tests/EventRedactionTest.php
+++ b/tests/EventRedactionTest.php
@@ -194,6 +194,21 @@ final class EventRedactionTest extends TestCase
         $this->assertStringContainsString('italic', $stored);
     }
 
+    public function testKeepsTheShapeOfAQuotedCredentialField()
+    {
+        /**
+         * The quoted pattern masks between the quotes and leaves them in place.
+         * The unquoted pattern used to re-match the result -- backtracking its
+         * leading "\s*" to nothing so a space satisfied the "not a quote"
+         * guard -- and strip both the quotes and the space back off.
+         */
+        $stored = $this->report('Config saved; "password": "s3cr3t"; other: keep');
+
+        $this->assertStringNotContainsString('s3cr3t', $stored);
+        $this->assertStringContainsString('"password": "[redacted]"', $stored);
+        $this->assertStringContainsString('other: keep', $stored);
+    }
+
     public function testMasksACredentialHiddenBehindItsEncoding()
     {
         /**

--- a/tests/EventRedactionTest.php
+++ b/tests/EventRedactionTest.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types=1);
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises what reportEvent() actually commits to the local audit trail.
+ *
+ * Everything the CSV export ships is read back out of this file, so the
+ * assertions below are on the stored bytes rather than on a return value.
+ */
+final class EventRedactionTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /** @var string */
+    private $queuePath;
+
+    /** @var string */
+    private $queueBackup;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        $this->queuePath = SUCURI_DATA_STORAGE . '/sucuri-auditqueue.php';
+        $this->queueBackup = (string) file_get_contents($this->queuePath);
+
+        Functions\when('__')->returnArg();
+        Functions\when('get_home_path')->justReturn(__DIR__);
+
+        /**
+         * createStorageFolder() calls this one unguarded. It has to be defined
+         * through Brain\Monkey rather than at file scope: PHPUnit loads every
+         * test file before Patchwork installs itself, and a plain declaration
+         * here makes the function un-redefinable for the rest of the suite.
+         */
+        Functions\when('sucuriscan_lastlogins_datastore_exists')->justReturn(true);
+        Functions\when('wp_cache_get')->justReturn(false);
+        Functions\when('wp_cache_set')->justReturn(true);
+        Functions\when('wp_cache_delete')->justReturn(true);
+        Functions\when('get_option')->justReturn(false);
+        Functions\when('update_option')->justReturn(true);
+        Functions\when('delete_option')->justReturn(true);
+        Functions\when('get_site_url')->justReturn('https://example.com');
+
+        /* faithful copy of the core helper; it is not part of the test stubs */
+        Functions\when('wp_strip_all_tags')->alias('sucuriscan_test_strip_all_tags');
+    }
+
+    protected function tearDown(): void
+    {
+        /* the queue is a shared fixture; every append has to be rolled back */
+        file_put_contents($this->queuePath, $this->queueBackup);
+
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    /**
+     * @param string $message Message handed to the reporting API.
+     * @return string The audit entry as it was written to the queue file.
+     */
+    private function report(string $message): string
+    {
+        $before = filesize($this->queuePath);
+
+        $this->assertTrue(SucuriScanEvent::reportWarningEvent($message));
+
+        clearstatcache(true, $this->queuePath);
+        $handle = fopen($this->queuePath, 'r');
+        fseek($handle, (int) $before);
+        $appended = trim((string) stream_get_contents($handle));
+        fclose($handle);
+
+        $this->assertNotSame('', $appended, 'nothing was appended to the audit queue');
+
+        return (string) json_decode(substr($appended, strpos($appended, ':') + 1), true);
+    }
+
+    public function testCredentialsHiddenBehindMarkupAreStillRedacted()
+    {
+        /**
+         * Markup can split a key name so the pattern never sees "password".
+         * Two layers stop it reaching storage, and this asserts the outcome
+         * rather than either layer: reportEvent() strips tags before it
+         * redacts, and sendLogToQueue() redacts once more after. Removing
+         * either one alone still passes -- the assertion is the invariant, not
+         * a pin on the ordering.
+         */
+        $stored = $this->report('Settings saved; <b>pass</b>word: hunter2');
+
+        $this->assertStringNotContainsString('hunter2', $stored);
+        $this->assertStringContainsString('password: [redacted]', $stored);
+    }
+
+    public function testMarkupRevealedByRedactionIsNotStored()
+    {
+        /**
+         * This is the case that pins the second strip in reportEvent().
+         * Redaction matches against an entity-decoded copy and returns that
+         * copy on a hit, so an escaped payload turns back into live markup on
+         * its way to storage; stripping only before the redaction leaves
+         * "<script>alert(1)</script>" in the trail and in every CSV export of
+         * it.
+         */
+        $escaped = htmlspecialchars('<script>alert(1)</script>', ENT_QUOTES, 'UTF-8');
+        $stored = $this->report($escaped . '; password: hunter2');
+
+        $this->assertStringNotContainsString('hunter2', $stored);
+        $this->assertStringNotContainsString('<script', $stored);
+        $this->assertStringContainsString('password: [redacted]', $stored);
+    }
+
+    public function testMessagesWithoutCredentialsKeepTheirEscaping()
+    {
+        /**
+         * Nothing matched, so the value must be stored exactly as the caller
+         * escaped it rather than as the decoded copy used for matching.
+         */
+        $escaped = htmlspecialchars('<script>alert(1)</script>', ENT_QUOTES, 'UTF-8');
+        $stored = $this->report($escaped . '; ID: 1');
+
+        $this->assertStringContainsString($escaped, $stored);
+        $this->assertStringNotContainsString('<script', $stored);
+    }
+}

--- a/tests/EventRedactionTest.php
+++ b/tests/EventRedactionTest.php
@@ -127,4 +127,102 @@ final class EventRedactionTest extends TestCase
         $this->assertStringContainsString($escaped, $stored);
         $this->assertStringNotContainsString('<script', $stored);
     }
+
+    public function testKeepsEveryOtherFieldChangedInTheSameSave()
+    {
+        /**
+         * hookOptionsChanges() joins every option changed in one settings save
+         * with a comma, and WordPress' own Writing page carries mailserver_pass.
+         * The mask has to stop at the field boundary: swallowing to the end of
+         * the value deleted the record of everything that changed after the
+         * credential, which is audit history that cannot be recovered.
+         */
+        $stored = $this->report(
+            "Writing settings changed: (multiple entries): "
+            . "mailserver_url: from 'mail.a.com' to 'smtp.a.com',"
+            . "mailserver_pass: from 'oldsecret' to 'newsecret',"
+            . "default_post_format: from '0' to 'aside'"
+        );
+
+        $this->assertStringNotContainsString('oldsecret', $stored);
+        $this->assertStringNotContainsString('newsecret', $stored);
+        $this->assertStringContainsString('mailserver_pass: [redacted]', $stored);
+        $this->assertStringContainsString("mailserver_url: from 'mail.a.com' to 'smtp.a.com'", $stored);
+        $this->assertStringContainsString("default_post_format: from '0' to 'aside'", $stored);
+    }
+
+    public function testKeepsValuesContainingAnAngleBracket()
+    {
+        /**
+         * strip_tags() deletes from "<" to the end of the string when nothing
+         * closes the tag, so masking used to truncate the entry at the bracket
+         * and take the credential mask that followed with it -- the record no
+         * longer showed that a password had changed at all.
+         */
+        $stored = $this->report(
+            "Global settings changed: (multiple entries): "
+            . "blogdescription: from 'a' to 'x<y',"
+            . "mailserver_pass: from 'p' to 'q'"
+        );
+
+        $this->assertStringNotContainsString("'p'", $stored);
+        $this->assertStringContainsString('mailserver_pass: [redacted]', $stored);
+
+        /* the bracket survives as text; it is escaped, never deleted */
+        $this->assertStringContainsString('x&lt;y', $stored);
+    }
+
+    public function testKeepsAValueContainingAnAngleBracketWithoutAnyCredential()
+    {
+        /**
+         * The same truncation, on the path where nothing is redacted at all.
+         * This one predates the redaction: reportEvent() has always run the
+         * message through strip_tags().
+         */
+        $stored = $this->report("Post was updated; ID: 1; name: Tips <3 for you");
+
+        $this->assertStringContainsString('Tips &lt;3 for you', $stored);
+    }
+
+    public function testStillStripsRealMarkup()
+    {
+        $stored = $this->report('Settings saved; <b>bold</b> and <i>italic</i>');
+
+        $this->assertStringNotContainsString('<b>', $stored);
+        $this->assertStringNotContainsString('<i>', $stored);
+        $this->assertStringContainsString('bold', $stored);
+        $this->assertStringContainsString('italic', $stored);
+    }
+
+    public function testMasksACredentialHiddenBehindItsEncoding()
+    {
+        /**
+         * Called directly rather than through reportEvent(), because this is
+         * the one branch where the decoded copy is the only thing that saw the
+         * credential: backslash escaping inside a JSON payload hides the quotes
+         * the pattern keys on. The result is escaped on the way out, since
+         * decoding can turn stored entities back into live markup.
+         */
+        $redacted = SucuriScanEvent::redactSensitiveData(
+            '{"user":"admin","password\\": \\"s3cr3t\\""}'
+        );
+
+        $this->assertStringNotContainsString('s3cr3t', $redacted);
+        $this->assertStringContainsString('[redacted]', $redacted);
+        $this->assertStringNotContainsString('"', $redacted);
+    }
+
+    public function testMasksAValueThatItselfContainsAComma()
+    {
+        /**
+         * Only a comma that introduces another "name:" pair ends the match, so
+         * a credential containing a comma is still masked in full.
+         */
+        $stored = $this->report('Connector saved; api_key: abc,def,ghi');
+
+        $this->assertStringNotContainsString('abc', $stored);
+        $this->assertStringNotContainsString('def', $stored);
+        $this->assertStringNotContainsString('ghi', $stored);
+        $this->assertStringContainsString('api_key: [redacted]', $stored);
+    }
 }

--- a/tests/EventSeverityTest.php
+++ b/tests/EventSeverityTest.php
@@ -1,0 +1,126 @@
+<?php declare(strict_types=1);
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises the severity prefix that reportEvent() commits to the audit trail.
+ *
+ * The stored line is a machine readable record: parseAuditLogs() reads the
+ * prefix back and drops any entry whose level it does not recognise, so the
+ * assertions below are on the stored bytes rather than on a return value.
+ */
+final class EventSeverityTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /** @var string */
+    private $queuePath;
+
+    /** @var string */
+    private $queueBackup;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        $this->queuePath = SUCURI_DATA_STORAGE . '/sucuri-auditqueue.php';
+        $this->queueBackup = (string) file_get_contents($this->queuePath);
+
+        /* every severity name is translated as if the site ran in Spanish */
+        Functions\when('__')->alias(function ($text) {
+            $catalog = array(
+                'Debug' => 'Depuracion',
+                'Notice' => 'Aviso',
+                'Info' => 'Informacion',
+                'Warning' => 'Advertencia',
+                'Error' => 'Fallo',
+                'Critical' => 'Critico',
+            );
+
+            return isset($catalog[$text]) ? $catalog[$text] : $text;
+        });
+
+        Functions\when('get_home_path')->justReturn(__DIR__);
+
+        /**
+         * createStorageFolder() calls this one unguarded. It has to be defined
+         * through Brain\Monkey rather than at file scope: PHPUnit loads every
+         * test file before Patchwork installs itself, and a plain declaration
+         * here makes the function un-redefinable for the rest of the suite.
+         */
+        Functions\when('sucuriscan_lastlogins_datastore_exists')->justReturn(true);
+        Functions\when('wp_cache_get')->justReturn(false);
+        Functions\when('wp_cache_set')->justReturn(true);
+        Functions\when('wp_cache_delete')->justReturn(true);
+        Functions\when('get_option')->justReturn(false);
+        Functions\when('update_option')->justReturn(true);
+        Functions\when('delete_option')->justReturn(true);
+        Functions\when('get_site_url')->justReturn('https://example.com');
+        Functions\when('wp_strip_all_tags')->alias('sucuriscan_test_strip_all_tags');
+    }
+
+    protected function tearDown(): void
+    {
+        /* the queue is a shared fixture; every append has to be rolled back */
+        file_put_contents($this->queuePath, $this->queueBackup);
+
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    /**
+     * Report an event and return the entry as it was written to the queue.
+     *
+     * @param string $message Message handed to the reporting API.
+     * @return string Stored audit entry.
+     */
+    private function report(string $message): string
+    {
+        $before = filesize($this->queuePath);
+
+        $this->assertTrue(SucuriScanEvent::reportWarningEvent($message));
+
+        clearstatcache(true, $this->queuePath);
+        $handle = fopen($this->queuePath, 'r');
+        fseek($handle, (int) $before);
+        $appended = trim((string) stream_get_contents($handle));
+        fclose($handle);
+
+        $this->assertNotSame('', $appended, 'nothing was appended to the audit queue');
+
+        return (string) json_decode(substr($appended, strpos($appended, ':') + 1), true);
+    }
+
+    public function testStoresTheSeverityUntranslated()
+    {
+        $stored = $this->report('Plugin activated: Example');
+
+        $this->assertStringStartsWith('Warning:', $stored);
+        $this->assertStringNotContainsString('Advertencia', $stored);
+    }
+
+    public function testStoredSeverityIsReadBackByTheLogParser()
+    {
+        /**
+         * A translated prefix makes parseAuditLogs() discard the entry as an
+         * unknown event type, so the trail written by a non-English site would
+         * be invisible on the audit page and absent from the CSV export.
+         */
+        $stored = $this->report('Plugin activated: Example');
+        $auditlogs = SucuriScanAPI::filterAuditLogs(
+            array(
+                'output' => array(
+                    '2026-07-15 10:30:00 admin@example.com : ' . $stored,
+                ),
+                'total_entries' => 1,
+            )
+        );
+
+        $this->assertCount(1, $auditlogs['output_data']);
+        $this->assertSame('warning', $auditlogs['output_data'][0]['event']);
+    }
+}

--- a/tests/IntegrityTest.php
+++ b/tests/IntegrityTest.php
@@ -6,10 +6,24 @@ use PHPUnit\Framework\TestCase;
 
 final class IntegrityTest extends TestCase
 {
+    /** @var string */
+    private $settingsPath;
+
+    /** @var string */
+    private $settingsBackup;
+
     protected function setUp(): void
     {
         parent::setUp();
         Monkey\setUp();
+
+        /**
+         * Reporting an event bumps the e-mail throttle counters in this
+         * tracked fixture; without a restore, running the suite leaves the
+         * working tree dirty and the drift gets committed by accident.
+         */
+        $this->settingsPath = SUCURI_DATA_STORAGE . '/sucuri-settings.php';
+        $this->settingsBackup = (string) file_get_contents($this->settingsPath);
 
         // Simple in-memory cache for wp_cache_* mocks
         $GLOBALS['__wp_cache'] = [];
@@ -69,6 +83,8 @@ final class IntegrityTest extends TestCase
 
     protected function tearDown(): void
     {
+        file_put_contents($this->settingsPath, $this->settingsBackup);
+
         Monkey\tearDown();
         unset($GLOBALS['__wp_cache']);
         unset($GLOBALS['__sucuri_test_mails']);

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -38,6 +38,34 @@ if (!function_exists('wp_kses_post')) {
     }
 }
 
+/**
+ * Mirror of wp_strip_all_tags() for the tests that need its real behaviour.
+ *
+ * Deliberately not named wp_strip_all_tags: anything declared in this bootstrap
+ * is loaded before Patchwork and can no longer be redefined, and some tests do
+ * stub that function. Those that want the real behaviour alias it to this with
+ * Functions\when('wp_strip_all_tags')->alias('sucuriscan_test_strip_all_tags').
+ *
+ * @param mixed $text          Value to strip.
+ * @param bool  $remove_breaks Collapse whitespace runs into a single space.
+ * @return string Stripped value.
+ */
+function sucuriscan_test_strip_all_tags($text, $remove_breaks = false)
+{
+    if (!is_scalar($text)) {
+        return '';
+    }
+
+    $text = preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', (string) $text);
+    $text = strip_tags((string) $text);
+
+    if ($remove_breaks) {
+        $text = preg_replace('/[\r\n\t ]+/', ' ', $text);
+    }
+
+    return trim($text);
+}
+
 if (file_exists(BASE_DIR . '/vendor/autoload.php')) {
     require BASE_DIR . '/vendor/autoload.php';
 }

--- a/tests/constants.php
+++ b/tests/constants.php
@@ -11,6 +11,11 @@ define('BASE_DIR', __DIR__ . '/..');
 define('SUCURISCAN_URL', 'https://example.com/wp-content/plugins/sucuri-scanner');
 define('SUCURISCAN_PLUGIN_PATH', BASE_DIR);
 
+// Mirrors the audit log values defined by sucuri.php at bootstrap.
+define('SUCURISCAN_AUDITLOGS_LIFETIME', 600);
+define('SUCURISCAN_AUDITLOGS_PER_PAGE', 25);
+define('SUCURISCAN_MAX_PAGINATION_BUTTONS', 16);
+
 // TODO: Copy fixtures to a temporary location in the future,
 // so they can be mutated when needed.
 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound


### PR DESCRIPTION
**Search and filters.** A search box for finding an event by name, plus filters for severity and themes, and update/delete filtering for plugin events. Filters and pagination now work off one set of logs, so moving between pages is instant instead of round-tripping to the API.

**Download CSV.** One click gets you every audit trail stored on this site as a spreadsheet, ready for a compliance review, an incident timeline, or an archive before logs age out. The download is the full history, not the filtered view. Large sites export fine — a 200,000-event history takes about six seconds and won't run the site out of memory.

## What's fixed

- **Sites not in English had no audit trail at all.** Every event was written and then silently discarded on the way back out, so the page looked empty no matter what happened on the site. This one had been there a while.

- **Records were being cut short or lost.** Saving WordPress' Writing settings wiped the record of every other option changed in that same save, and a stray `<` in a site title or option value truncated the entry from that point on. Both are fixed, and entries no longer stop mid-sentence.

- **Names now read the way you wrote them.** A plugin called `R&D Tools` showed up as `R&amp;D Tools` on the page and in the export, and searching for the name you actually see found nothing.

- **Passwords weren't the only secrets in there.** API keys, tokens and salts were being stored in plain text. They're now masked as events are written and as older records are read back, so nothing already in the queue stays exposed — and they can't be surfaced by search.

**Fixed a way markup from the Sucuri API could reach the dashboard unescaped.**

## Tests

Five new unit suites plus additions to two existing ones, and Cypress coverage for the filters and the download.